### PR TITLE
feat: replace sync-dist.js with aidd-cli for dist generation

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  packages: read
 
 jobs:
   release-please:
@@ -34,8 +35,14 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Install CLI
+        run: |
+          npm config set @ai-driven-dev:registry https://npm.pkg.github.com
+          npm config set //npm.pkg.github.com/:_authToken ${{ github.token }}
+          npm install -g @ai-driven-dev/aidd-cli
+
       - name: Build distributions
-        run: node scripts/sync-dist.js
+        run: bash scripts/build-dist.sh
 
       - name: Build source tarball
         run: |
@@ -54,7 +61,9 @@ jobs:
           VERSION="${{ needs.release-please.outputs.version }}"
           for tool in claude cursor copilot; do
             tar czf "/tmp/aidd-${tool}-${VERSION}.tar.gz" \
-              -C dist/${tool} .
+              -C dist/${tool} \
+              --exclude='.aidd' \
+              .
           done
 
       - name: Attach tarballs to release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "scripts": {
+    "build": "bash scripts/build-dist.sh",
     "prepare": "lefthook install || true"
   },
   "devDependencies": {

--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -e
+
+FRAMEWORK_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+if command -v aidd &>/dev/null; then
+  CLI="aidd"
+else
+  echo "Error: aidd CLI not found. Install it with: npm install -g @ai-driven-dev/aidd-cli" >&2
+  exit 1
+fi
+
+which aidd && aidd --version
+
+for tool in claude cursor copilot; do
+  TARGET="$FRAMEWORK_ROOT/dist/$tool"
+  rm -rf "$TARGET"
+  mkdir -p "$TARGET"
+  cd "$TARGET"
+  "$CLI" --framework "$FRAMEWORK_ROOT" install "$tool" --force
+  cd "$FRAMEWORK_ROOT"
+done


### PR DESCRIPTION
## Summary

- Replaces the custom `sync-dist.js` script with the `aidd-cli` to generate per-tool distributions (`dist/claude`, `dist/cursor`, `dist/copilot`)
- Adds `scripts/build-dist.sh` as the new build entry point
- Adds `pnpm build` script to `package.json`
- Updates CI workflow to install the CLI from GitHub Packages before generating distributions
- Excludes `.aidd/manifest.json` from per-tool tarballs

## Test plan

- [ ] Verify `pnpm build` generates correct `dist/` locally
- [ ] Verify CI workflow installs CLI and generates distributions on release
- [ ] Verify per-tool tarballs do not contain `.aidd/` directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)