### PR TITLE
feat(memory): add update_memory script and sync aidd_project_memory block

### DIFF
--- a/aidd_docs/templates/AGENTS.md
+++ b/aidd_docs/templates/AGENTS.md
@@ -8,7 +8,6 @@ description: AI agent configuration and guidelines
 > IMPORTANT: On first conversation message:
 >
 > - say "AI-Driven Development ON - Date: {current_date}, TZ: {current_timezone}." to User.
-> - load all memory files in [{{DOCS}}/memory]({{DOCS}}/memory) directory.
 
 ## Behavior Guidelines
 
@@ -28,18 +27,10 @@ All instructions and information above are willing to be up to date, but always 
 
 ## Memory Management
 
-This section contains your memory, because you might lack context.
+### Project memory
 
-### Load the memory on launch
+<aidd_project_memory>
+</aidd_project_memory>
 
-List all files:
-
-```shell
-! ls -1tr {{DOCS}}/memory/
-```
-
-Then:
-
-- READ every files in `{{DOCS}}/memory/*` on load
 - If needed: load files from `{{DOCS}}/memory/external/*` when user request it
 - If needed: load files from `{{DOCS}}/memory/internal/*`, you have to think about it

--- a/commands/01_onboard/init.md
+++ b/commands/01_onboard/init.md
@@ -63,6 +63,12 @@ All templates are in:
 @{{TOOLS}}/rules/01-standards/1-mermaid.md
 ```
 
+### IDE syntax reference
+
+```md
+@{{TOOLS}}/rules/04-tooling/ide-mapping.md
+```
+
 ## Steps
 
 1. Check if memory bank already exists in `{{DOCS}}/memory/` folder:
@@ -73,3 +79,4 @@ All templates are in:
 4. Spawn parallel task sub-agents for each template files
 5. Write generated files to `{{DOCS}}/memory/`
 6. Launch an agent to review all files for consistency and accuracy
+7. Execute `.aidd/scripts/update_memory.mjs` to sync memory references in context files

--- a/commands/01_onboard/init.md
+++ b/commands/01_onboard/init.md
@@ -63,12 +63,6 @@ All templates are in:
 @{{TOOLS}}/rules/01-standards/1-mermaid.md
 ```
 
-### IDE syntax reference
-
-```md
-@{{TOOLS}}/rules/04-tooling/ide-mapping.md
-```
-
 ## Steps
 
 1. Check if memory bank already exists in `{{DOCS}}/memory/` folder:

--- a/commands/07_documentation/learn.md
+++ b/commands/07_documentation/learn.md
@@ -12,6 +12,12 @@ Capture and store new learnings from recently implemented feature in memory bank
 
 ## Resources
 
+### IDE syntax reference
+
+```md
+@{{TOOLS}}/rules/04-tooling/ide-mapping.md
+```
+
 ### Doc content
 
 ```shell
@@ -97,3 +103,7 @@ Propose where to save each learning.
 1. Create file in `{{DOCS}}/internal/decisions/XXX-<title>.md` using decision template
 2. Update ADR table in `ADR.md`
 3. Create/update files in their categories as needed
+
+### Phase 4: Sync memory references
+
+Execute `.aidd/scripts/update_memory.mjs` to sync memory references in context files

--- a/commands/07_documentation/learn.md
+++ b/commands/07_documentation/learn.md
@@ -12,12 +12,6 @@ Capture and store new learnings from recently implemented feature in memory bank
 
 ## Resources
 
-### IDE syntax reference
-
-```md
-@{{TOOLS}}/rules/04-tooling/ide-mapping.md
-```
-
 ### Doc content
 
 ```shell

--- a/config/scripts/update_memory.mjs
+++ b/config/scripts/update_memory.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+/**
+ * update_memory.mjs — Syncs <aidd_project_memory> block in AI context files.
+ *
+ * Scans {docsDir}/memory/ for .md files and updates the <aidd_project_memory>
+ * block in each context file (CLAUDE.md, AGENTS.md, .github/copilot-instructions.md)
+ * with tool-appropriate references.
+ *
+ * Syntax:
+ *   CLAUDE.md / AGENTS.md        → @{docsDir}/memory/file.md
+ *   .github/copilot-instructions → [{docsDir}/memory/file.md](../{docsDir}/memory/file.md)
+ *
+ * Usage: node .aidd/scripts/update_memory.mjs [docsDir]
+ */
+
+import { readFileSync, writeFileSync, readdirSync, existsSync } from 'fs';
+import { join } from 'path';
+import { execSync } from 'child_process';
+
+// ── Constants ─────────────────────────────────────────────────────
+
+const MANIFEST_PATH = '.aidd/manifest.json';
+const MEMORY_SUBDIR = 'memory';
+const BLOCK_OPEN = '<aidd_project_memory>';
+const BLOCK_CLOSE = '</aidd_project_memory>';
+const EXCLUDED_FILES = new Set(['.gitkeep']);
+
+const TARGET_FILES = [
+  { path: 'CLAUDE.md', syntax: 'at' },
+  { path: 'AGENTS.md', syntax: 'at' },
+  { path: '.github/copilot-instructions.md', syntax: 'link' },
+];
+
+// ── Helpers ───────────────────────────────────────────────────────
+
+function readDocsDir() {
+  const argDocsDir = process.argv[2];
+  if (argDocsDir) return argDocsDir;
+  if (!existsSync(MANIFEST_PATH)) return null;
+  try {
+    const manifest = JSON.parse(readFileSync(MANIFEST_PATH, 'utf8'));
+    return manifest.docsDir ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function scanMemoryFiles(docsDir) {
+  const memoryDir = join(docsDir, MEMORY_SUBDIR);
+  if (!existsSync(memoryDir)) return [];
+  return readdirSync(memoryDir)
+    .filter((f) => f.endsWith('.md') && !EXCLUDED_FILES.has(f))
+    .sort()
+    .map((f) => join(docsDir, MEMORY_SUBDIR, f));
+}
+
+function buildReference(syntax, docsDir, filePath) {
+  const relativePath = filePath.replace(/\\/g, '/');
+  if (syntax === 'link') {
+    return `[${relativePath}](../${relativePath})`;
+  }
+  return `@${relativePath}`;
+}
+
+function buildBlockContent(memoryFiles, syntax, docsDir) {
+  if (memoryFiles.length === 0) return '';
+  const refs = memoryFiles.map((f) => buildReference(syntax, docsDir, f));
+  return '\n' + refs.join('\n') + '\n';
+}
+
+function updateBlock(content, innerContent) {
+  const openIdx = content.indexOf(BLOCK_OPEN);
+  const closeIdx = content.indexOf(BLOCK_CLOSE);
+  if (openIdx === -1 || closeIdx === -1 || closeIdx < openIdx) return null;
+  return (
+    content.slice(0, openIdx + BLOCK_OPEN.length) +
+    innerContent +
+    content.slice(closeIdx)
+  );
+}
+
+function gitAdd(files) {
+  try {
+    execSync(`git add ${files.map((f) => `"${f}"`).join(' ')}`, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  } catch {
+    // silent — no git or not a repo
+  }
+}
+
+// ── Main ──────────────────────────────────────────────────────────
+
+const docsDir = readDocsDir();
+if (!docsDir) process.exit(0);
+
+const memoryFiles = scanMemoryFiles(docsDir);
+const changed = [];
+
+for (const target of TARGET_FILES) {
+  if (!existsSync(target.path)) continue;
+
+  const original = readFileSync(target.path, 'utf8');
+  const innerContent = buildBlockContent(memoryFiles, target.syntax, docsDir);
+  const updated = updateBlock(original, innerContent);
+
+  if (updated === null || updated === original) continue;
+
+  writeFileSync(target.path, updated, 'utf8');
+  changed.push(target.path);
+}
+
+if (changed.length > 0) gitAdd(changed);


### PR DESCRIPTION
## Summary

- Add `config/scripts/update_memory.mjs` — scans `{docsDir}/memory/` and updates `<aidd_project_memory>` blocks in CLAUDE.md, AGENTS.md (`@path` syntax) and `.github/copilot-instructions.md` (`[path](../path)` syntax)
- Update `aidd_docs/templates/AGENTS.md` to use `<aidd_project_memory>` block instead of manual shell-based memory load section
- Add script execution step to `init` and `learn` commands

## Test plan

- [ ] Run `node config/scripts/update_memory.mjs` in a project with memory files — verify blocks updated in all 3 target files
- [ ] Verify CLAUDE.md/AGENTS.md get `@path` references, copilot-instructions.md gets `[path](../path)` references
- [ ] Empty memory dir → block content stays empty

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)