### PR TITLE
feat(onboard): add /onboard wizard command for new users

### DIFF
--- a/aidd_docs/README.md
+++ b/aidd_docs/README.md
@@ -133,6 +133,8 @@ Start at **Initialization**, then follow the path step by step. Each box shows t
 
 > **New commands:** `/init`
 
+> **Skip this phase** if `{{DOCS}}/memory/` already contains files — your project is already initialized. Go directly to [Phase 2](#️-phase-2--configure-your-project).
+
 ### Step by Step
 
 1. Install the AI-Driven Development framework using the [CLI](https://github.com/ai-driven-dev/aidd-cli) or by copying the dist files to your project root.

--- a/commands/01_onboard/onboard.md
+++ b/commands/01_onboard/onboard.md
@@ -1,0 +1,56 @@
+---
+name: onboard
+description: Detect project state and tell the user exactly what to run next
+model: opus
+---
+
+# Onboard
+
+## Goal
+
+Detect where the user stands, share a brief analysis, then guide them to one concrete next action.
+
+## Context
+
+### Framework guide
+
+```markdown
+@{{DOCS}}/README.md
+```
+
+## Rules
+
+- Always follow the framework guide to detect project state
+- Always complete the full loop
+- Never stop after detection or analysis
+- One next action only, no list, no overview
+- ALWAYS offer the choice
+- Never assume the user will run the command in this conversation
+- Always ask for feedback after the command is run
+- Number given by the user must be used to identify the choice, never the text
+
+## Steps
+
+1. Detect project state based on documentation
+2. Share a one-line analysis of what was found
+3. Present numbered choices to identify the user's situation based on documentation advice or to explain documentation sections
+4. **WAIT FOR USER RESPONSE**
+   1. If user select a choice to get more info
+      1. Explain it clearly and concisely
+      2. Propose to deep dive into specific knowledge based on given explanation
+      3. Always offer the choice to go back to step 3
+   2. If user selects a choice to run a command, proceed to step 5
+5. Explain the user about the next step and what it will do
+6. Give the user numbered choices : to run it now in this conversation, start a new session to run it themselves or go back to step 3 to select another option
+7. **WAIT FOR USER RESPONSE**
+8. If run now
+   1. Launch the command in subprocess
+   2. Wait for it to complete
+   3. Share the output to the user and ask to confirm it looks right
+   4. **WAIT FOR USER RESPONSE**
+   5. Then return to step 1 and loop
+9. If new session,
+   1. Tell the user which command to run and stop
+   2. Ask the user to give feedback on the results
+   3. **WAIT FOR USER RESPONSE**
+   4. Then return to step 1 and loop


### PR DESCRIPTION
## Summary

- Adds `/onboard` command (`commands/01_onboard/onboard.md`) that auto-detects project state and guides users to the right AIDD workflow
- Fixes `aidd_docs/README.md` Phase 1 to explicitly indicate the phase can be skipped when memory files already exist
- Updates `aidd_docs/CATALOG.md` with the new command entry

## How it works

1. Detects presence of `aidd_docs/memory/` files to determine setup state
2. If not initialized → recommends running `init`
3. If initialized → asks one qualifying question (3 choices) to identify the user's situation
4. Recommends the matching next command and offers to run it now or in a new session
5. After execution, loops back to re-detect state and continue guiding

## Test plan

- [ ] Test `case-a-fresh` — no memory, no code → should recommend `init`
- [ ] Test `case-b-init-done` — memory present, greenfield → should NOT recommend init, ask qualifying question
- [ ] Test `case-c-brownfield` — memory present, existing code → should NOT recommend init, ask qualifying question
- [ ] Verify loop returns to onboard after running a command

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)