### PR TITLE
fix(init): add missing @ prefix to agents_coordination.md reference

### DIFF
--- a/commands/01_onboard/init.md
+++ b/commands/01_onboard/init.md
@@ -17,7 +17,7 @@ Every file has its own template to follow.
 ### Hard copy into memory bank (always generated)
 
 ```text
-{{DOCS}}/templates/aidd/agents_coordination.md
+@{{DOCS}}/templates/aidd/agents_coordination.md
 ```
 
 ### Memory templates


### PR DESCRIPTION
## Summary

- Adds missing `@` include prefix to `agents_coordination.md` reference in `commands/01_onboard/init.md`
- Without it, the AI never loads the template when running `/init`, silently skipping the hard-copy step
- Consistent with all other file references in the same file (lines 38, 44, 63)

Closes #57

## Test plan

- [ ] Run `/init` on a project and verify `agents_coordination.md` is properly copied to the memory bank

🤖 Generated with [Claude Code](https://claude.com/claude-code)