### PR TITLE
fix(commands): make VCS/ticketing references provider-agnostic

### DIFF
--- a/aidd_docs/templates/aidd/memory/vcs.md
+++ b/aidd_docs/templates/aidd/memory/vcs.md
@@ -9,8 +9,8 @@ scope: all
 
 - Main Branch: `<main, master, trunk>`
 - Platform: `<gitlab, github, bitbucket>`
-- CLI: `<gh, glab, bb-cli...>` (preferred)
-- MCP: `<mcp-server-name>` (fallback if no CLI available)
+- CLI: `<gh, glab, bb-cli...>`
+- MCP: `<mcp-server-name>`
 - Ticketing Tool: `<linear, confluence, jira>`
 
 ## Branch Naming Convention

--- a/aidd_docs/templates/aidd/memory/vcs.md
+++ b/aidd_docs/templates/aidd/memory/vcs.md
@@ -9,7 +9,8 @@ scope: all
 
 - Main Branch: `<main, master, trunk>`
 - Platform: `<gitlab, github, bitbucket>`
-- CLI or MCP: `<gh, glab, bb-cli, mcp...>`
+- CLI: `<gh, glab, bb-cli...>` (preferred)
+- MCP: `<mcp-server-name>` (fallback if no CLI available)
 - Ticketing Tool: `<linear, confluence, jira>`
 
 ## Branch Naming Convention

--- a/commands/03_plan/plan.md
+++ b/commands/03_plan/plan.md
@@ -1,7 +1,7 @@
 ---
 name: plan
 description: Generate technical implementation plans from requirements
-argument-hint: requirements (GitHub issue URL or raw text)
+argument-hint: requirements (VCS issue URL or raw text)
 model: opus
 ---
 
@@ -40,9 +40,9 @@ $ARGUMENTS
 
 ### Step 1: Parse Input
 
-1. Detect input type (GitHub URL vs raw text)
+1. Detect input type (VCS issue URL vs raw text)
 2. Extract requirements from input:
-   - For GitHub issue: fetch and parse issue content
+   - For VCS issue: fetch and parse issue content
    - For raw text: clean and structure the requirements
 3. Normalize text (handle vocal dictation issues)
 4. Print user journey simplified in ASCII diagram for better understanding and validation

--- a/commands/03_plan/plan.md
+++ b/commands/03_plan/plan.md
@@ -1,7 +1,7 @@
 ---
 name: plan
 description: Generate technical implementation plans from requirements
-argument-hint: requirements (VCS issue URL or raw text)
+argument-hint: requirements (ticket URL or raw text)
 model: opus
 ---
 
@@ -40,9 +40,9 @@ $ARGUMENTS
 
 ### Step 1: Parse Input
 
-1. Detect input type (VCS issue URL vs raw text)
+1. Detect input type (ticket URL vs raw text)
 2. Extract requirements from input:
-   - For VCS issue: fetch and parse issue content
+   - For ticket URL: fetch and parse ticket content
    - For raw text: clean and structure the requirements
 3. Normalize text (handle vocal dictation issues)
 4. Print user journey simplified in ASCII diagram for better understanding and validation

--- a/commands/10_maintenance/new_issue.md
+++ b/commands/10_maintenance/new_issue.md
@@ -27,8 +27,7 @@ Create a ticket based on the problem: `$ARGUMENTS`
 
 ## Rules
 
-- From project memory identify the ticketing tool (Jira, Linear, GitHub Issues, etc.) and CLI or MCP to use.
-- Use CLI first, MCP as fallback.
+- From project memory identify the ticketing tool and use it.
 - Be thorough and concise in the issue description, focus on clarity, small sentences.
 - Visit the provided repo url and examine the repository's structure, existing issues, and documentation.
 - Look for any `CONTRIBUTING.md` that may contain guidelines for creating issues.

--- a/commands/10_maintenance/new_issue.md
+++ b/commands/10_maintenance/new_issue.md
@@ -1,6 +1,6 @@
 ---
 name: new_issue
-description: Create issues in the configured VCS/ticketing tool
+description: Create issues in the configured ticketing tool
 argument-hint: "Describe the problem you want to create an issue for"
 model: sonnet
 ---
@@ -9,7 +9,7 @@ model: sonnet
 
 ## Goal
 
-Create an issue based on the problem: `$ARGUMENTS`
+Create a ticket based on the problem: `$ARGUMENTS`
 
 ## Context
 
@@ -27,7 +27,7 @@ Create an issue based on the problem: `$ARGUMENTS`
 
 ## Rules
 
-- From project memory identify the VCS/ticketing tool (GitHub, GitLab, Jira, etc.) and CLI or MCP to use.
+- From project memory identify the ticketing tool (Jira, Linear, GitHub Issues, etc.) and CLI or MCP to use.
 - Use CLI first, MCP as fallback.
 - Be thorough and concise in the issue description, focus on clarity, small sentences.
 - Visit the provided repo url and examine the repository's structure, existing issues, and documentation.

--- a/commands/10_maintenance/new_issue.md
+++ b/commands/10_maintenance/new_issue.md
@@ -1,9 +1,7 @@
 ---
 name: new_issue
-description: Create GitHub issues with interactive template filling
+description: Create issues in the configured VCS/ticketing tool
 argument-hint: "Describe the problem you want to create an issue for"
-allowed-tools: Bash(date), gh
-docs: https://github.com/steipete/agent-rules/blob/main/global-rules/github-issue-creation.mdc
 model: sonnet
 ---
 
@@ -11,7 +9,7 @@ model: sonnet
 
 ## Goal
 
-Create GitHub issue based on the problem: `$ARGUMENTS`
+Create an issue based on the problem: `$ARGUMENTS`
 
 ## Context
 
@@ -29,7 +27,8 @@ Create GitHub issue based on the problem: `$ARGUMENTS`
 
 ## Rules
 
-- Use `gh` commands if GitHub related, including `--label`, `--project`, `--milestone` if applicable.
+- From project memory identify the VCS/ticketing tool (GitHub, GitLab, Jira, etc.) and CLI or MCP to use.
+- Use CLI first, MCP as fallback.
 - Be thorough and concise in the issue description, focus on clarity, small sentences.
 - Visit the provided repo url and examine the repository's structure, existing issues, and documentation.
 - Look for any `CONTRIBUTING.md` that may contain guidelines for creating issues.

--- a/commands/10_maintenance/reproduce.md
+++ b/commands/10_maintenance/reproduce.md
@@ -21,7 +21,7 @@ Fix bug systematically using test-driven approach, from issue creation to pull r
 
 ## Steps
 
-1. Create GitHub issue with short descriptive title
+1. Create issue in configured VCS/ticketing tool with short descriptive title
 2. Create fix branch
 3. Reproduce issue and understand root cause
 4. Write failing test demonstrating bug

--- a/commands/10_maintenance/reproduce.md
+++ b/commands/10_maintenance/reproduce.md
@@ -21,7 +21,7 @@ Fix bug systematically using test-driven approach, from issue creation to pull r
 
 ## Steps
 
-1. Create issue in configured VCS/ticketing tool with short descriptive title
+1. Create ticket in configured ticketing tool with short descriptive title
 2. Create fix branch
 3. Reproduce issue and understand root cause
 4. Write failing test demonstrating bug


### PR DESCRIPTION
## Summary

- Remove hardcoded `gh` CLI and GitHub-specific references from commands
- Commands now read platform and CLI/MCP tool from `vcs.md` memory at runtime
- CLI first, MCP as fallback
- Supports GitHub, GitLab, Jira, and any provider declared in memory

## Files changed

- `commands/10_maintenance/new_issue.md` — remove `allowed-tools: gh`, `docs:` link, GitHub-specific rules
- `commands/10_maintenance/reproduce.md` — "Create GitHub issue" → "Create issue in configured VCS/ticketing tool"
- `commands/03_plan/plan.md` — "GitHub issue URL" → "VCS issue URL"

Closes ai-driven-dev/aidd-cli#133