### PR TITLE
fix(template): complete truncated task placeholder in plan.md

### DIFF
--- a/aidd_docs/templates/aidd/plan.md
+++ b/aidd_docs/templates/aidd/plan.md
@@ -47,8 +47,8 @@ flowchart TD
 > {straight to point goal}
 
 1. {ultra concise task1, with logical ordering}
-2. {ultra concise task2, with logical ordering}
-3. {ultra concise task3, with logical ordering}
+2. {...}
+3. {...}
 
 ## Validation flow
 

--- a/aidd_docs/templates/aidd/plan.md
+++ b/aidd_docs/templates/aidd/plan.md
@@ -46,9 +46,9 @@ flowchart TD
 
 > {straight to point goal}
 
-1. {ultra concise task1, with logical
-2. {...}
-3. {...}
+1. {ultra concise task1, with logical ordering}
+2. {ultra concise task2, with logical ordering}
+3. {ultra concise task3, with logical ordering}
 
 ## Validation flow
 


### PR DESCRIPTION
## Summary

- Completes the truncated placeholder `{ultra concise task1, with logical` → `{ultra concise task1, with logical ordering}`
- Aligns task2 and task3 placeholders to the same format for consistency

Closes #61