### PR TITLE
fix(commands): align review_functional with behavioral review intent

### DIFF
--- a/aidd_docs/CATALOG.md
+++ b/aidd_docs/CATALOG.md
@@ -75,6 +75,7 @@ No files found.
 | `dev` | [code_review.md](templates/dev/code_review.md) | `Code review checklist and scoring template` | - |
 | `dev` | [decision.md](templates/dev/decision.md) | `Individual decision record template` | `<title>` |
 | `dev` | [review_code.md](templates/dev/review_code.md) | `Code review checklist and scoring template` | - |
+| `dev` | [review_functional.md](templates/dev/review_functional.md) | `Functional review report template` | - |
 | `dev` | [tech_choice.md](templates/dev/tech_choice.md) | `Technology selection and comparison template` | - |
 | `pm` | [prd.md](templates/pm/prd.md) | `Product Requirements Document template (15 sections)` | - |
 | `pm` | [user_story.md](templates/pm/user_story.md) | `Template for defining user stories with estimation and acceptance criteria` | - |
@@ -139,7 +140,7 @@ No files found.
 | File | Description | Argument Hint |
 |------|---|---|
 | [review_code.md](../commands/05_review/review_code.md) | `Ensure code quality and rules compliance` | - |
-| [review_functional.md](../commands/05_review/review_functional.md) | `Use this agent when you need to browse current project web application, getting browser console, screenshot, navigating across the app...` | `The technical plan to base the review on` |
+| [review_functional.md](../commands/05_review/review_functional.md) | `Review feature behavior against plan specification and current diff` | `Plan path to validate against` |
 
 #### `commands/06_tests`
 

--- a/aidd_docs/templates/dev/review_functional.md
+++ b/aidd_docs/templates/dev/review_functional.md
@@ -1,0 +1,60 @@
+---
+name: review_functional
+description: Functional review report template
+argument-hint: N/A
+---
+
+# Functional Review for {feature}
+
+- **Plan**: `{plan_path}`
+- **Diff scope**: `{base}...{head}`
+- **Date**: {yyyy-mm-dd}
+
+## Verdict
+
+{PASS | PARTIAL | FAIL} — {one-line rationale}
+
+## Scoring Matrix
+
+| Criterion | Files | Status | Severity | Notes |
+| --------- | ----- | ------ | -------- | ----- |
+|           |       | Met / Partial / Unmet | Blocker / Major / Minor |       |
+
+### Status values
+
+- `Met`: criterion fully implemented in diff
+- `Partial`: criterion implemented but gaps detected
+- `Unmet`: criterion absent from diff
+
+### Severity values
+
+Applies to `Partial` and `Unmet` rows only.
+
+- `Blocker`: feature cannot ship
+- `Major`: shipping degrades user experience
+- `Minor`: cosmetic or non-blocking gap
+
+## Missing Behaviors
+
+Acceptance criteria with no trace in the diff.
+
+- [ ] {criterion not found in diff}
+
+## Unplanned Behaviors
+
+Changes present in the diff but not traced to any acceptance criterion.
+
+- [ ] {unplanned change — confirm scope with author}
+
+## Flow / Edge-case Gaps
+
+Gaps surfaced while walking each criterion against the diff.
+
+- [ ] {flow or edge-case gap}
+
+## Summary
+
+- **Criteria covered**: {x/y}
+- **Blockers**: {count}
+- **Follow-up actions**: {actions}
+- **Additional notes**: {notes}

--- a/commands/05_review/review_functional.md
+++ b/commands/05_review/review_functional.md
@@ -1,41 +1,42 @@
 ---
 name: review_functional
-description: Use this agent when you need to browse current project web application, getting browser console, screenshot, navigating across the app...
-argument-hint: The technical plan to base the review on
+description: Review feature behavior against plan specification and current diff
+argument-hint: Plan path to validate against
 model: opus
 ---
 
-# Goal
+# Functional Review Prompt
 
-You are about to review the coded implementation done by a senior developer.
+## Goal
+
+Verify the implemented feature matches the plan's acceptance criteria, flows, and edge cases. Static review of current diff against plan intent. No app execution, no browser, no code quality checks.
 
 ## Rules
 
-You need to make sure:
+- Plan path via `$ARGUMENTS`
+- Default diff source: `git diff main`
+- Focus on _what_ the feature does, not _how_ it is coded
+- Behavioral verification only
+- No runtime testing
+- One row per acceptance criterion
+- Report-only output
 
-- Plan has been followed correctly
-- All tasks in all phases are perfectly implemented
+### Review template
 
-### Score Calculation
+```markdown
+@{{DOCS}}/templates/dev/review_functional.md
+```
 
-For each item you discover, create a table score
+## Process steps
 
-| Title | Files | Confidence Score |
-| ----- | ----- | ---------------- |
-|       |       |                  |
-
-0: No fix needed
-1: Minor improvements suggested
-2: Major issues found
-3: Critical problems detected
-
-## Steps
-
-1. Read the following plan: $ARGUMENTS
-2. Look for code duplication and inconsistencies.
-3. Affect confidence score regarding the implementation.
-4. List all issues found in a scored table.
-5. Challenge your assumptions, remember less is more, only fix what really need to be fixed.
-6. **Wait for user approval**
-7. Spawn 1 `dev` sub-agent per issue and wait for all to be completed.
-8. Restart all the steps and iterate until no more score issues are found.
+1. Read plan from `$ARGUMENTS` if provided, else ask user to give functional review criteria directly
+2. Extract acceptance criteria from plan
+   - If criteria present: ask user to validate them before proceeding
+   - If criteria missing: ask user to provide them
+3. Fetch current diff: `git diff main` (or argument-provided scope)
+4. Map diff behavior to each criterion, fill scoring matrix
+5. List missing behaviors (criteria with no trace in diff)
+6. List unplanned behaviors (diff changes not traced to any criterion)
+7. List flow / edge-case gaps surfaced by criteria walkthrough
+8. Format using template
+9. Output to `{{DOCS}}/tasks/<yyyy_mm>/<yyyy_mm_dd>-<task_name>.review_functional.md`


### PR DESCRIPTION
## Summary

- Rewrite `review_functional` command so name/description/prompt match intent: behavioral review of feature vs plan acceptance criteria (static, no app execution, no browser)
- Replace 0-3 confidence score with Status (Met/Partial/Unmet) + Severity (Blocker/Major/Minor) scoring matrix
- Remove sub-agent fix loop (steps 7-8) — command is report-only
- Add dedicated report template `aidd_docs/templates/dev/review_functional.md` (Verdict, Scoring Matrix, Missing / Unplanned behaviors, Flow gaps)
- Regenerate CATALOG.md

## Context

Per issue #72: previous command mixed a functional-sounding name (browse app, screenshots) with a code-review prompt that scored confidence and spawned dev sub-agents. Users could not tell whether the command ran functional tests on the app or reviewed code.

New split:
- `review_code` → **how** (code quality + rules compliance) — unchanged
- `review_functional` → **what** (behavior against plan spec + diff) — rewritten here

## Test plan

- [ ] Run `/aidd:05:review_functional <plan_path>` against a plan with acceptance criteria — command validates criteria with user then produces report
- [ ] Run same command against a plan missing criteria — command asks user to provide them
- [ ] Verify report output file at `aidd_docs/tasks/<yyyy_mm>/<yyyy_mm_dd>-<task_name>.review_functional.md`
- [ ] Verify no sub-agent spawned, no code changes proposed

Fixes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)