### PR TITLE
chore(framework): unify version management across marketplace and plugins via release-please

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,11 @@ jobs:
       github.event_name == 'push' &&
       (needs.commitlint.result == 'success' || needs.commitlint.result == 'skipped')
     outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
-      version: ${{ steps.release.outputs.version }}
+      releases_created: ${{ steps.release.outputs.releases_created }}
+      paths_released: ${{ steps.release.outputs.paths_released }}
+      root_released: ${{ steps.release.outputs.release_created }}
+      root_tag_name: ${{ steps.release.outputs.tag_name }}
+      root_version: ${{ steps.release.outputs.version }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
@@ -50,10 +52,10 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-  build-and-attach:
-    name: Build and attach
+  build-framework:
+    name: Build framework release artifacts
     needs: [release-please]
-    if: needs.release-please.outputs.release_created == 'true'
+    if: needs.release-please.outputs.root_released == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -81,16 +83,15 @@ jobs:
 
       - name: Build source tarball
         run: |
-          VERSION="${{ needs.release-please.outputs.version }}"
+          VERSION="${{ needs.release-please.outputs.root_version }}"
           tar czf "/tmp/aidd-framework-${VERSION}.tar.gz" \
             plugins/ \
             .claude-plugin/ \
-            aidd_docs/ \
-            version.txt
+            aidd_docs/
 
       - name: Build per-tool tarballs
         run: |
-          VERSION="${{ needs.release-please.outputs.version }}"
+          VERSION="${{ needs.release-please.outputs.root_version }}"
           for tool in claude cursor copilot codex; do
             tar czf "/tmp/aidd-${tool}-${VERSION}.tar.gz" \
               -C dist/${tool}-local \
@@ -106,8 +107,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          VERSION="${{ needs.release-please.outputs.version }}"
-          TAG="${{ needs.release-please.outputs.tag_name }}"
+          VERSION="${{ needs.release-please.outputs.root_version }}"
+          TAG="${{ needs.release-please.outputs.root_tag_name }}"
           gh release upload "${TAG}" \
             "/tmp/aidd-framework-${VERSION}.tar.gz" \
             "/tmp/aidd-claude-${VERSION}.tar.gz" \
@@ -119,3 +120,35 @@ jobs:
             "/tmp/aidd-codex-${VERSION}.tar.gz" \
             "/tmp/aidd-codex-remote-${VERSION}.tar.gz" \
             --clobber
+
+  build-plugins:
+    name: Build plugin release artifacts
+    needs: [release-please]
+    if: |
+      needs.release-please.outputs.releases_created == 'true' &&
+      contains(needs.release-please.outputs.paths_released, 'plugins/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build and attach per-plugin tarballs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PATHS_RELEASED: ${{ needs.release-please.outputs.paths_released }}
+        run: |
+          set -euo pipefail
+          for path in $(echo "${PATHS_RELEASED}" | jq -r '.[]'); do
+            case "${path}" in
+              plugins/*)
+                name="${path#plugins/}"
+                version="$(jq -r '.version' "${path}/.claude-plugin/plugin.json")"
+                tag="${name}-v${version}"
+                tarball="/tmp/${name}-v${version}.tar.gz"
+                tar czf "${tarball}" \
+                  -C plugins \
+                  --exclude='.aidd/cache' \
+                  "${name}"
+                gh release upload "${tag}" "${tarball}" --clobber
+                ;;
+            esac
+          done

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,7 +1,9 @@
 {
-  ".": "3.9.1",
+  ".": "4.0.0",
   "plugins/aidd-context": "1.0.0",
   "plugins/aidd-dev": "1.0.0",
   "plugins/aidd-vcs": "1.0.0",
-  "plugins/aidd-pm": "1.0.0-rc.1"
+  "plugins/aidd-pm": "1.0.0-rc.1",
+  "plugins/aidd-orchestrator": "1.0.0",
+  "plugins/aidd-refine": "1.0.0"
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,21 +33,33 @@ This repository follows [Semantic Versioning](https://semver.org/) with automate
 **How it works:**
 
 1. Every push to `main` with conventional commits triggers a **Release PR** (changelog + version bump)
-2. When the Release PR is merged → GitHub Release + tag + downloadable tarball
+2. When the Release PR is merged → GitHub Release(s) + tag(s) + downloadable tarball(s)
 
-The tarball contains only the framework content: `agents/`, `commands/`, `config/`, `rules/`, `skills/`, `templates/`, `aidd_docs/`, `version.txt`.
+Each plugin versions independently with its own tag (`aidd-<plugin>-v<X.Y.Z>`) and changelog. The framework root (`marketplace.json`) is the single public face of the catalog and is bumped by commits scoped to `framework` or `marketplace` (root tag stays `v<X.Y.Z>`).
+
+**Release artifacts:**
+
+| Trigger                 | Tag                          | Tarballs attached                                                         |
+| ----------------------- | ---------------------------- | ------------------------------------------------------------------------- |
+| Root release            | `v<X.Y.Z>`                   | `aidd-framework-v<X.Y.Z>.tar.gz` + per-tool bundles (`claude`, `cursor`, `copilot`, `codex`, local + remote) |
+| Per-plugin release      | `aidd-<plugin>-v<X.Y.Z>`     | `aidd-<plugin>-v<X.Y.Z>.tar.gz` (contents of `plugins/aidd-<plugin>/`)    |
+
+The framework tarball contains `plugins/`, `.claude-plugin/`, and `aidd_docs/`.
 
 ## Commit scope discipline
 
-Every commit must use one of the five allowed scopes:
+Every commit must use one of the allowed scopes. The scope decides which package release-please will bump.
 
-| Scope          | Use for                                                           |
-| -------------- | ----------------------------------------------------------------- |
-| `aidd-context` | Changes inside `plugins/aidd-context/`                            |
-| `aidd-dev`     | Changes inside `plugins/aidd-dev/`                                |
-| `aidd-vcs`     | Changes inside `plugins/aidd-vcs/`                                |
-| `aidd-pm`      | Changes inside `plugins/aidd-pm/`                                 |
-| `framework`    | Root-level changes: build scripts, CI, config, docs, `aidd_docs/` |
+| Scope               | Use for                                                                  | Bumps                              |
+| ------------------- | ------------------------------------------------------------------------ | ---------------------------------- |
+| `aidd-context`      | Changes inside `plugins/aidd-context/`                                   | `plugins/aidd-context/plugin.json` |
+| `aidd-dev`          | Changes inside `plugins/aidd-dev/`                                       | `plugins/aidd-dev/plugin.json`     |
+| `aidd-vcs`          | Changes inside `plugins/aidd-vcs/`                                       | `plugins/aidd-vcs/plugin.json`     |
+| `aidd-pm`           | Changes inside `plugins/aidd-pm/`                                        | `plugins/aidd-pm/plugin.json`      |
+| `aidd-orchestrator` | Changes inside `plugins/aidd-orchestrator/`                              | `plugins/aidd-orchestrator/plugin.json` |
+| `aidd-refine`       | Changes inside `plugins/aidd-refine/`                                    | `plugins/aidd-refine/plugin.json`  |
+| `framework`         | Root-level changes: build scripts, CI, config, docs, `aidd_docs/`        | `.claude-plugin/marketplace.json`  |
+| `marketplace`       | Catalog edits to `.claude-plugin/marketplace.json` (alias for root bump) | `.claude-plugin/marketplace.json`  |
 
 Examples:
 
@@ -56,6 +68,7 @@ git commit -m "feat(aidd-dev): add for-sure skill"
 git commit -m "fix(aidd-vcs): correct commit template"
 git commit -m "docs(framework): update README for plugin model"
 git commit -m "build(framework): regenerate catalogs"
+git commit -m "feat(marketplace): register new plugin in catalog"
 ```
 
 Cross-plugin changes must be split into separate commits, one per scope.

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -12,6 +12,7 @@ module.exports = {
         "aidd-refine",
         "aidd-orchestrator",
         "framework",
+        "marketplace",
       ],
     ],
     "body-max-line-length": [0, "always"],

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -63,6 +63,26 @@
           "jsonpath": "$.version"
         }
       ]
+    },
+    "plugins/aidd-orchestrator": {
+      "package-name": "aidd-orchestrator",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": ".claude-plugin/plugin.json",
+          "jsonpath": "$.version"
+        }
+      ]
+    },
+    "plugins/aidd-refine": {
+      "package-name": "aidd-refine",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": ".claude-plugin/plugin.json",
+          "jsonpath": "$.version"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary

Reconciles release-please config, manifest, commitlint scopes, and CI tarball logic so each plugin versions independently while the framework root (`marketplace.json`) stays the single public face of the catalog.

## Changes

- **`release-please-config.json`** — registered `plugins/aidd-orchestrator` and `plugins/aidd-refine` as full packages (mirror of existing plugin entries; bumps their `plugin.json` on release).
- **`.release-please-manifest.json`** — synced root `.` from `3.9.1` → `4.0.0` (match `marketplace.json`); added `aidd-orchestrator` + `aidd-refine` at `1.0.0`. Full set: root + 6 plugins.
- **`commitlint.config.cjs`** — added `marketplace` to scope-enum (alias for root bump). `aidd-orchestrator`/`aidd-refine` were already present.
- **`.github/workflows/ci.yml`** — removed deleted `version.txt` from the source tarball step; split `build-and-attach` into:
  - `build-framework` — fires only on root release (`outputs.release_created`); builds + attaches `aidd-framework-v<X.Y.Z>.tar.gz` and per-tool bundles (existing behavior).
  - `build-plugins` — fires when `paths_released` contains any `plugins/*`; iterates the JSON array, builds `aidd-<plugin>-v<X.Y.Z>.tar.gz`, uploads to the matching plugin tag.
- **`CONTRIBUTING.md`** — refreshed the Releases section (independent per-plugin tags, new artifact table, no more `version.txt`); rewrote the scope-discipline table to cover all 6 plugins plus `framework` / `marketplace` and what each scope bumps.

## Notes for reviewers

- **`paths_released` is a JSON-encoded string** (e.g. `["plugins/aidd-context"]`). `build-plugins` gates on `contains(paths_released, 'plugins/')` (substring on the raw JSON string) and the shell step uses `jq -r '.[]'` to iterate. Brittle but functional with release-please-action v4.
- **Root component outputs are unprefixed** (`release_created`/`tag_name`/`version`) — confirmed against `googleapis/release-please-action` v4 README. Plugin component outputs are prefixed (`plugins/aidd-X--release_created` etc.) but we iterate `paths_released` instead, deriving the version from the freshly-bumped `plugin.json` on the merge commit — simpler than enumerating six prefixed outputs.
- **Issue QA bullet 2** says `chore(framework): test bump` should trigger a root bump. **release-please does not bump on `chore:`** by default — only `feat` / `fix` / `feat!`. To smoke-test the wiring after merge, use `feat(marketplace): foo` or `feat(framework): foo`.
- Tarball name convention = tag name: `aidd-<plugin>-v<X.Y.Z>.tar.gz` (no double `aidd-` prefix).
- Pre-existing pre-commit hook failure in the parent repo (`check-framework-references` flags 345 stale command references in `courses/`) is unrelated to this PR; commit was created with `--no-verify` after the user confirmed bypass.

## Test plan

- [ ] CI succeeds on this PR (no release attempted on a feature branch).
- [ ] After merge, release-please opens a Release PR with bumps for any plugin/root touched by the merged commits.
- [ ] Smoke test post-merge: a commit `feat(aidd-refine): noop` produces a Release PR that bumps only `plugins/aidd-refine/.claude-plugin/plugin.json` and tags `aidd-refine-v1.1.0`.
- [ ] Smoke test post-merge: a commit `feat(marketplace): noop` (or `feat(framework): ...`) bumps only `marketplace.json` and tags `v4.1.0`.
- [ ] Plugin release attaches only `aidd-<plugin>-v<X.Y.Z>.tar.gz`.
- [ ] Root release attaches framework + per-tool bundles (existing behavior preserved).
- [ ] `commitlint` accepts `feat(aidd-orchestrator): …`, `feat(aidd-refine): …`, `feat(marketplace): …` and rejects unknown scopes (verified locally).

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)