### PR TITLE
feat(aidd-orchestrator): branch enforcement, comment passthrough, skip routing

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+# Summary
+
+<!-- One or two sentences describing the change and why it matters. -->
+
+## Changes
+
+<!-- Bullet list of the concrete edits. Group by plugin or area when relevant. -->
+
+- 
+
+## Test plan
+
+<!-- How you verified this change. Commands, screenshots, manual steps. -->
+
+- [ ] 
+
+## Related issues
+
+<!-- "Closes #N" auto-links and closes the issue on merge. Use "Refs #N" for related-but-not-closing links. -->
+
+Closes #
+
+## Checklist
+
+- [ ] Commit messages follow the conventional format and use a scope listed in `commitlint.config.cjs`.
+- [ ] Documentation updated when behaviour or contracts changed (plugin README, skill README, references).
+- [ ] No cross-plugin references introduced in plugin docs.
+- [ ] No em-dash characters in newly added prose.
+- [ ] Pre-commit hooks pass locally (`lefthook run pre-commit`).

--- a/.github/workflows/aidd-async.yml
+++ b/.github/workflows/aidd-async.yml
@@ -29,6 +29,9 @@ jobs:
       mode: ${{ steps.route.outputs.mode }}
       ref: ${{ steps.route.outputs.ref }}
       issue_number: ${{ steps.route.outputs.issue_number }}
+      source_issue_number: ${{ steps.route.outputs.source_issue_number }}
+      trigger_kind: ${{ steps.route.outputs.trigger_kind }}
+      trigger_comment_url: ${{ steps.route.outputs.trigger_comment_url }}
       account_secret: ${{ steps.route_account.outputs.account_secret }}
       account_owner: ${{ steps.route_account.outputs.account_owner }}
     steps:
@@ -60,36 +63,82 @@ jobs:
             echo "account_owner=$OWNER"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Route to run vs review based on linked PR
+      - name: Route to run or review and capture trigger context
         id: route
         run: |
           NUM="${{ github.event.issue.number }}"
           IS_PR="${{ github.event.issue.pull_request != null }}"
+          EVENT_NAME="${{ github.event_name }}"
+          LABEL_NAME='${{ github.event.label.name }}'
+          COMMENT_BODY='${{ github.event.comment.body }}'
+          COMMENT_URL='${{ github.event.comment.html_url }}'
+          # Trigger kind: `comment` when fired by issue_comment, else `label`.
+          if [ "$EVENT_NAME" = "issue_comment" ]; then
+            TRIGGER_KIND="comment"
+          else
+            TRIGGER_KIND="label"
+          fi
+          # Detect human intent (implement vs review).
+          IMPLEMENT_INTENT="false"
+          REVIEW_INTENT="false"
+          case "$LABEL_NAME" in
+            to-implement) IMPLEMENT_INTENT="true" ;;
+            to-review)    REVIEW_INTENT="true" ;;
+          esac
+          case "$COMMENT_BODY" in
+            *"@claude /implement"*) IMPLEMENT_INTENT="true" ;;
+            *"@claude /review"*)    REVIEW_INTENT="true" ;;
+          esac
+
+          post_skip () {
+            local body="$1"
+            gh issue comment "$NUM" --repo "$GITHUB_REPOSITORY" --body "$body" >/dev/null || true
+          }
+
           if [ "$IS_PR" = "true" ]; then
-            # Event was posted on a PR directly; review that PR.
+            # Event posted on a PR -> review that PR directly.
             REF=$(gh pr view "$NUM" --repo "$GITHUB_REPOSITORY" --json headRefName --jq .headRefName)
             {
               echo "mode=review"
               echo "ref=$REF"
               echo "issue_number=$NUM"
+              echo "trigger_kind=$TRIGGER_KIND"
+              echo "trigger_comment_url=$COMMENT_URL"
             } >> "$GITHUB_OUTPUT"
           else
-            # Event was posted on an issue; check if any open PR closes that issue.
+            # Event posted on an issue; look for an open PR closing it.
             PR_NUM=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --json number,body \
               --jq "[.[] | select(.body | test(\"(?i)\\\\b(Closes|Fixes|Resolves)\\\\s+#${NUM}\\\\b\"))][0].number" || echo "")
             if [ -n "$PR_NUM" ] && [ "$PR_NUM" != "null" ]; then
-              REF=$(gh pr view "$PR_NUM" --repo "$GITHUB_REPOSITORY" --json headRefName --jq .headRefName)
-              {
-                echo "mode=review"
-                echo "ref=$REF"
-                echo "issue_number=$PR_NUM"
-              } >> "$GITHUB_OUTPUT"
+              if [ "$IMPLEMENT_INTENT" = "true" ]; then
+                # Issue already has an open PR; refuse to re-run implementation.
+                post_skip "Skipping: this issue already has an open PR (#$PR_NUM). Comment on that PR (or apply \`to-review\` on this issue) to request changes; do not re-trigger \`to-implement\`."
+                echo "mode=skip" >> "$GITHUB_OUTPUT"
+              else
+                REF=$(gh pr view "$PR_NUM" --repo "$GITHUB_REPOSITORY" --json headRefName --jq .headRefName)
+                {
+                  echo "mode=review"
+                  echo "ref=$REF"
+                  echo "issue_number=$PR_NUM"
+                  echo "source_issue_number=$NUM"
+                  echo "trigger_kind=$TRIGGER_KIND"
+                  echo "trigger_comment_url=$COMMENT_URL"
+                } >> "$GITHUB_OUTPUT"
+              fi
             else
-              {
-                echo "mode=run"
-                echo "ref=main"
-                echo "issue_number=$NUM"
-              } >> "$GITHUB_OUTPUT"
+              if [ "$REVIEW_INTENT" = "true" ] && [ "$IMPLEMENT_INTENT" != "true" ]; then
+                # Review intent on an issue with no open PR -> nothing to review.
+                post_skip "Skipping: cannot review issue #$NUM because no open PR closes it. Apply \`to-implement\` (or comment \`@claude /implement\`) to start the implementation flow."
+                echo "mode=skip" >> "$GITHUB_OUTPUT"
+              else
+                {
+                  echo "mode=run"
+                  echo "ref=main"
+                  echo "issue_number=$NUM"
+                  echo "trigger_kind=$TRIGGER_KIND"
+                  echo "trigger_comment_url=$COMMENT_URL"
+                } >> "$GITHUB_OUTPUT"
+              fi
             fi
           fi
         env:
@@ -108,7 +157,7 @@ jobs:
       - name: Run aidd-orchestrator pipeline
         uses: anthropics/claude-code-action@v1
         with:
-          prompt: "Use skill aidd-orchestrator:02:run-async-dev on issue #${{ needs.dispatch.outputs.issue_number }}"
+          prompt: "Use skill aidd-orchestrator:02:run-async-dev on issue #${{ needs.dispatch.outputs.issue_number }} (trigger_kind=${{ needs.dispatch.outputs.trigger_kind }}, trigger_comment_url=${{ needs.dispatch.outputs.trigger_comment_url }}). Fetch every comment newer than the last bot activity on the issue and feed them to the SDLC delegation as additional user direction."
           claude_code_oauth_token: ${{ secrets[needs.dispatch.outputs.account_secret] }}
           github_token: ${{ secrets.AIDD_BOT_TOKEN }}
           plugins: |
@@ -132,7 +181,7 @@ jobs:
       - name: Run aidd-orchestrator review loop
         uses: anthropics/claude-code-action@v1
         with:
-          prompt: "Use skill aidd-orchestrator:03:review-async-dev on PR #${{ needs.dispatch.outputs.issue_number }}"
+          prompt: "Use skill aidd-orchestrator:03:review-async-dev on PR #${{ needs.dispatch.outputs.issue_number }} (trigger_kind=${{ needs.dispatch.outputs.trigger_kind }}, trigger_comment_url=${{ needs.dispatch.outputs.trigger_comment_url }}, source_issue_number=${{ needs.dispatch.outputs.source_issue_number }}). Collect comments from both the PR and its linked issue newer than the last iteration before deciding stop vs continue."
           claude_code_oauth_token: ${{ secrets[needs.dispatch.outputs.account_secret] }}
           github_token: ${{ secrets.AIDD_BOT_TOKEN }}
           plugins: |

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,27 @@
+# Code of Conduct
+
+This project adopts the [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) as its Code of Conduct.
+
+By participating in this project (issues, pull requests, discussions, or any community channel tied to it), you agree to abide by its terms.
+
+## Scope
+
+The Code of Conduct applies to all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing the community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Reporting
+
+Instances of conduct that violate the Covenant may be reported to the project maintainers via [GitHub Security Advisories](https://github.com/ai-driven-dev/aidd-framework/security/advisories/new) (private channel) or by opening a confidential discussion with the maintainers.
+
+All reports will be reviewed and investigated promptly and fairly. The maintainers are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement
+
+Project maintainers are responsible for clarifying and enforcing the standards in the Covenant. They will take appropriate and fair corrective action in response to any behaviour that they deem inappropriate, threatening, offensive, or harmful, following the enforcement guidelines published with Contributor Covenant v2.1.
+
+## Attribution
+
+The full text of the Contributor Covenant v2.1 is available at:
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct/>
+
+For answers to common questions about this Code of Conduct, see the FAQ at:
+<https://www.contributor-covenant.org/faq/>

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 AI-Driven Dev contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,37 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+If you discover a security vulnerability in the AI-Driven Dev framework or any of its plugins, please report it privately via [GitHub Security Advisories](https://github.com/ai-driven-dev/aidd-framework/security/advisories/new).
+
+Do not file public issues for security problems. Public disclosure before a fix is available gives attackers time to exploit the issue.
+
+## What to include
+
+- A short description of the issue and its impact.
+- Steps to reproduce, or proof-of-concept code when possible.
+- Affected plugin(s) and version(s).
+- Any suggested fix or mitigation, if known.
+
+## What to expect
+
+- We acknowledge receipt within 5 business days.
+- We work with you privately to confirm the issue and prepare a fix.
+- Once a fix is ready, we publish a coordinated security advisory and credit you in the release notes (unless you prefer to remain anonymous).
+- We aim to ship a patch release within 30 days of a confirmed report.
+
+## Supported versions
+
+| Version       | Supported              |
+| ------------- | ---------------------- |
+| Latest stable | Yes                    |
+| Previous major| Critical fixes only    |
+| Older majors  | No                     |
+
+## Out of scope
+
+- Self-XSS, social engineering attacks against contributors, or denial-of-service via legitimate features.
+- Vulnerabilities in third-party plugins not maintained in this repository.
+- Vulnerabilities requiring physical access to a developer's machine.
+
+Thank you for helping keep the AI-Driven Dev community safe.

--- a/plugins/aidd-dev/skills/00-sdlc/SKILL.md
+++ b/plugins/aidd-dev/skills/00-sdlc/SKILL.md
@@ -70,6 +70,7 @@ Materialize the flow as a task list at skill entry; a task closes only when its 
 - Skip allowed: `01-spec` only (when the source already carries objective + acceptance criteria). Never: plan, implement, review, ship.
 - Choose the best decision based on the facts.
 - Open a pull request once implementation is reviewed and complete.
+- **Branch discipline (caller responsibility).** SDLC runs on whatever branch is checked out when invoked; it never auto-branches. The caller (manual user or upstream orchestrator) is responsible for putting HEAD on a non-default branch before invoking SDLC when the run is meant to ship through a PR. `05-ship` enforces the final guarantee: if HEAD is on the default branch at ship time, it aborts with `contract_violation: on_default_branch` and refuses to commit or push.
 
 ## References
 

--- a/plugins/aidd-dev/skills/00-sdlc/SKILL.md
+++ b/plugins/aidd-dev/skills/00-sdlc/SKILL.md
@@ -70,7 +70,7 @@ Materialize the flow as a task list at skill entry; a task closes only when its 
 - Skip allowed: `01-spec` only (when the source already carries objective + acceptance criteria). Never: plan, implement, review, ship.
 - Choose the best decision based on the facts.
 - Open a pull request once implementation is reviewed and complete.
-- **Branch discipline (caller responsibility).** SDLC runs on whatever branch is checked out when invoked; it never auto-branches. The caller (manual user or upstream orchestrator) is responsible for putting HEAD on a non-default branch before invoking SDLC when the run is meant to ship through a PR. `05-ship` enforces the final guarantee: if HEAD is on the default branch at ship time, it aborts with `contract_violation: on_default_branch` and refuses to commit or push.
+- **Branch discipline (caller responsibility).** SDLC runs on whatever branch is checked out when invoked; it never auto-branches. The caller (manual user or upstream orchestrator) is responsible for putting HEAD on a non-default branch before invoking SDLC when the run is meant to ship through a PR.
 
 ## References
 

--- a/plugins/aidd-orchestrator/skills/01-setup-async-dev/assets/workflow-template.yml
+++ b/plugins/aidd-orchestrator/skills/01-setup-async-dev/assets/workflow-template.yml
@@ -29,6 +29,9 @@ jobs:
       mode: ${{ steps.route.outputs.mode }}
       ref: ${{ steps.route.outputs.ref }}
       issue_number: ${{ steps.route.outputs.issue_number }}
+      source_issue_number: ${{ steps.route.outputs.source_issue_number }}
+      trigger_kind: ${{ steps.route.outputs.trigger_kind }}
+      trigger_comment_url: ${{ steps.route.outputs.trigger_comment_url }}
       account_secret: ${{ steps.route_account.outputs.account_secret }}
       account_owner: ${{ steps.route_account.outputs.account_owner }}
     steps:
@@ -60,36 +63,82 @@ jobs:
             echo "account_owner=$OWNER"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Route to run vs review based on linked PR
+      - name: Route to run or review and capture trigger context
         id: route
         run: |
           NUM="${{ github.event.issue.number }}"
           IS_PR="${{ github.event.issue.pull_request != null }}"
+          EVENT_NAME="${{ github.event_name }}"
+          LABEL_NAME='${{ github.event.label.name }}'
+          COMMENT_BODY='${{ github.event.comment.body }}'
+          COMMENT_URL='${{ github.event.comment.html_url }}'
+          # Trigger kind: `comment` when fired by issue_comment, else `label`.
+          if [ "$EVENT_NAME" = "issue_comment" ]; then
+            TRIGGER_KIND="comment"
+          else
+            TRIGGER_KIND="label"
+          fi
+          # Detect human intent (implement vs review).
+          IMPLEMENT_INTENT="false"
+          REVIEW_INTENT="false"
+          case "$LABEL_NAME" in
+            __TO_IMPLEMENT_LABEL__) IMPLEMENT_INTENT="true" ;;
+            __TO_REVIEW_LABEL__)    REVIEW_INTENT="true" ;;
+          esac
+          case "$COMMENT_BODY" in
+            *__MENTION_IMPLEMENT__*) IMPLEMENT_INTENT="true" ;;
+            *__MENTION_REVIEW__*)    REVIEW_INTENT="true" ;;
+          esac
+
+          post_skip () {
+            local body="$1"
+            gh issue comment "$NUM" --repo "$GITHUB_REPOSITORY" --body "$body" >/dev/null || true
+          }
+
           if [ "$IS_PR" = "true" ]; then
-            # Event was posted on a PR directly; review that PR.
+            # Event posted on a PR -> review that PR directly.
             REF=$(gh pr view "$NUM" --repo "$GITHUB_REPOSITORY" --json headRefName --jq .headRefName)
             {
               echo "mode=review"
               echo "ref=$REF"
               echo "issue_number=$NUM"
+              echo "trigger_kind=$TRIGGER_KIND"
+              echo "trigger_comment_url=$COMMENT_URL"
             } >> "$GITHUB_OUTPUT"
           else
-            # Event was posted on an issue; check if any open PR closes that issue.
+            # Event posted on an issue; look for an open PR closing it.
             PR_NUM=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --json number,body \
               --jq "[.[] | select(.body | test(\"(?i)\\\\b(Closes|Fixes|Resolves)\\\\s+#${NUM}\\\\b\"))][0].number" || echo "")
             if [ -n "$PR_NUM" ] && [ "$PR_NUM" != "null" ]; then
-              REF=$(gh pr view "$PR_NUM" --repo "$GITHUB_REPOSITORY" --json headRefName --jq .headRefName)
-              {
-                echo "mode=review"
-                echo "ref=$REF"
-                echo "issue_number=$PR_NUM"
-              } >> "$GITHUB_OUTPUT"
+              if [ "$IMPLEMENT_INTENT" = "true" ]; then
+                # Issue already has an open PR; refuse to re-run implementation.
+                post_skip "Skipping: this issue already has an open PR (#$PR_NUM). Comment on that PR (or apply \`__TO_REVIEW_LABEL__\` on this issue) to request changes; do not re-trigger \`__TO_IMPLEMENT_LABEL__\`."
+                echo "mode=skip" >> "$GITHUB_OUTPUT"
+              else
+                REF=$(gh pr view "$PR_NUM" --repo "$GITHUB_REPOSITORY" --json headRefName --jq .headRefName)
+                {
+                  echo "mode=review"
+                  echo "ref=$REF"
+                  echo "issue_number=$PR_NUM"
+                  echo "source_issue_number=$NUM"
+                  echo "trigger_kind=$TRIGGER_KIND"
+                  echo "trigger_comment_url=$COMMENT_URL"
+                } >> "$GITHUB_OUTPUT"
+              fi
             else
-              {
-                echo "mode=run"
-                echo "ref=__DEFAULT_BRANCH__"
-                echo "issue_number=$NUM"
-              } >> "$GITHUB_OUTPUT"
+              if [ "$REVIEW_INTENT" = "true" ] && [ "$IMPLEMENT_INTENT" != "true" ]; then
+                # Review intent on an issue with no open PR -> nothing to review.
+                post_skip "Skipping: cannot review issue #$NUM because no open PR closes it. Apply \`__TO_IMPLEMENT_LABEL__\` (or comment \`__MENTION_IMPLEMENT__\`) to start the implementation flow."
+                echo "mode=skip" >> "$GITHUB_OUTPUT"
+              else
+                {
+                  echo "mode=run"
+                  echo "ref=__DEFAULT_BRANCH__"
+                  echo "issue_number=$NUM"
+                  echo "trigger_kind=$TRIGGER_KIND"
+                  echo "trigger_comment_url=$COMMENT_URL"
+                } >> "$GITHUB_OUTPUT"
+              fi
             fi
           fi
         env:
@@ -108,7 +157,7 @@ jobs:
       - name: Run aidd-orchestrator pipeline
         uses: anthropics/claude-code-action@v1
         with:
-          prompt: "Use skill aidd-orchestrator:02:run-async-dev on issue #${{ needs.dispatch.outputs.issue_number }}"
+          prompt: "Use skill aidd-orchestrator:02:run-async-dev on issue #${{ needs.dispatch.outputs.issue_number }} (trigger_kind=${{ needs.dispatch.outputs.trigger_kind }}, trigger_comment_url=${{ needs.dispatch.outputs.trigger_comment_url }}). Fetch every comment newer than the last bot activity on the issue and feed them to the SDLC delegation as additional user direction."
           __CLAUDE_AUTH_LINE__
           __GITHUB_WRITE_TOKEN_LINE__
           plugins: |
@@ -132,7 +181,7 @@ jobs:
       - name: Run aidd-orchestrator review loop
         uses: anthropics/claude-code-action@v1
         with:
-          prompt: "Use skill aidd-orchestrator:03:review-async-dev on PR #${{ needs.dispatch.outputs.issue_number }}"
+          prompt: "Use skill aidd-orchestrator:03:review-async-dev on PR #${{ needs.dispatch.outputs.issue_number }} (trigger_kind=${{ needs.dispatch.outputs.trigger_kind }}, trigger_comment_url=${{ needs.dispatch.outputs.trigger_comment_url }}, source_issue_number=${{ needs.dispatch.outputs.source_issue_number }}). Collect comments from both the PR and its linked issue newer than the last iteration before deciding stop vs continue."
           __CLAUDE_AUTH_LINE__
           __GITHUB_WRITE_TOKEN_LINE__
           plugins: |

--- a/plugins/aidd-orchestrator/skills/02-run-async-dev/actions/05-delegate-sdlc.md
+++ b/plugins/aidd-orchestrator/skills/02-run-async-dev/actions/05-delegate-sdlc.md
@@ -8,6 +8,8 @@ Hands the implementation off to the SDLC capability. The orchestrator picks the 
 - `run_id` (required) -- run identifier from `03-acquire-lock`
 - `discovered_skill` (required) -- skill name returned by `04-check-sdlc`
 - `config` (required) -- parsed `.claude/aidd-orchestrator.json`
+- `trigger_kind` (optional) -- `label` or `comment`; forwarded from dispatch
+- `trigger_comment_url` (optional) -- when `trigger_kind=comment`, the URL of the triggering comment
 
 ## Outputs
 
@@ -30,19 +32,21 @@ Hands the implementation off to the SDLC capability. The orchestrator picks the 
 
 ## Process
 
-**CRITICAL — DO NOT BYPASS.** This action's sole purpose is to invoke the SDLC capability. You MUST NOT write code, edit files, run tests, push branches, or open PRs yourself. Those tasks belong to the SDLC skill. Your only job is: build the delegation prompt, call the Skill tool, then verify the contract. Any direct Edit/Write/Bash usage to implement the feature is a contract violation and must be aborted.
+**CRITICAL — DO NOT BYPASS.** This action's sole purpose is to set up the feature branch and invoke the SDLC capability. You MUST NOT write feature code, edit feature files, run tests, or open PRs yourself — those tasks belong to the SDLC. The only mutations you are allowed are: (a) the up-front `git checkout -B` of the feature branch from `origin/<default>`, and (b) the contract recovery in step 7. Any other Edit/Write/Bash mutation is a contract violation and must be aborted.
 
 1. Record the default-branch SHA: `git fetch origin && BEFORE=$(git rev-parse origin/<default>)`. Contract baseline.
 2. Compute the feature branch name: `feat/issue-<issue.number>-<kebab-slug-of-title>` (truncate slug to 40 chars). Must not equal the default branch.
-3. Compose the delegation prompt with these explicit, non-negotiable constraints (state at the top AND repeat at the bottom):
+3. **Create the feature branch up-front.** SDLC is branch-agnostic by design (a manual user may invoke it on any branch); the orchestrator owns branch setup for the async flow. Run `git checkout -B feat/issue-<n>-<slug> origin/<default>`. Assert `git rev-parse --abbrev-ref HEAD` returns the new branch. Spec, plan, implement, and ship will all run on this branch — so their file writes (spec_path, plan_path) land on the feature branch, never on default.
+4. **Collect issue comments as additional direction.** Fetch `gh api repos/{owner}/{repo}/issues/<issue.number>/comments --jq '[.[] | select(.user.type != "Bot")]'`. Keep all human comments authored after the previous bot activity on the issue (use `gh api repos/{owner}/{repo}/issues/<issue.number>/timeline` to find the last bot commit/event; fall back to "all comments" on first run). These are the user's directions added since the last attempt and MUST be surfaced to the SDLC. If `trigger_kind=comment`, ensure the comment at `trigger_comment_url` is the first entry in the list.
+5. Compose the delegation prompt. Tell the SDLC that HEAD is already on the feature branch and must stay there, embed the human comments verbatim, repeat the non-negotiable constraints at top and bottom:
 
    ```
    You are implementing GitHub issue #<n>: "<title>".
 
+   HEAD is already on `feat/issue-<n>-<slug>` (checked out from `origin/<default>` by the caller). Stay on it for the entire run; every file you write — spec, plan, code — must land on this branch.
+
    Constraints:
-   - Work on a new branch named exactly: feat/issue-<n>-<slug>.
-     Create it from origin/<default>: git checkout -B feat/issue-<n>-<slug> origin/<default>.
-   - Do NOT make commits on <default>. Do NOT --force on <default>. Do NOT merge anything.
+   - Do NOT check out `<default>`. Do NOT make commits on <default>. Do NOT --force on <default>. Do NOT merge anything.
    - Run the project's test command before opening the PR; tests must pass.
    - Push the branch: git push -u origin feat/issue-<n>-<slug>.
    - Open a Pull Request:
@@ -56,11 +60,14 @@ Hands the implementation off to the SDLC capability. The orchestrator picks the 
    Issue body and labels follow.
    <issue body>
    <issue labels>
+
+   Human direction posted on the issue since the last bot activity (treat as authoritative additions/corrections to the request; reconcile with the issue body, surface conflicts in the plan rather than silently ignoring):
+   <comments collected in step 4, each rendered as `@<author> <created_at>: <body>` separated by `---`>
    ```
 
-4. **MANDATORY — invoke the SDLC skill via the `Skill` tool.** Use the skill name returned in `discovered_skill` (never hardcode). The orchestrator MUST issue exactly one `Skill` tool call with that name and the prompt from step 3 as `args`. Do not call Edit, Write, Bash-with-mutations, or `gh pr create` yourself; the SDLC owns those. If `discovered_skill` is empty, abort with a `claude/blocked` outcome and a comment listing the issue. The `Skill` tool call is the only way this action can succeed.
-5. Capture the SDLC result. If the SDLC did not return a `pr_number`, query the API: `gh pr list --repo <owner>/<repo> --head feat/issue-<n>-<slug> --state open --json number,url --jq '.[0]'`.
-6. **Verify the contract** (the SDLC could have ignored instructions):
+6. **MANDATORY — invoke the SDLC skill via the `Skill` tool.** Use the skill name returned in `discovered_skill` (never hardcode). The orchestrator MUST issue exactly one `Skill` tool call with that name and the prompt from step 5 as `args`. Do not call Edit, Write, Bash-with-mutations beyond the branch checkout in step 3 and the contract recovery in step 8, or `gh pr create` yourself; the SDLC owns those. If `discovered_skill` is empty, abort with a `claude/blocked` outcome and a comment listing the issue. The `Skill` tool call is the only way this action can succeed.
+7. Capture the SDLC result. If the SDLC did not return a `pr_number`, query the API: `gh pr list --repo <owner>/<repo> --head feat/issue-<n>-<slug> --state open --json number,url --jq '.[0]'`.
+8. **Verify the contract** (the SDLC could have ignored instructions):
    - `AFTER=$(git fetch origin && git rev-parse origin/<default>)`.
    - **No commits on default**: if `AFTER != BEFORE`, the SDLC pushed to `<default>`. Recover:
      - Cherry-pick `$BEFORE..$AFTER` onto `feat/issue-<n>-<slug>`, push.
@@ -68,7 +75,7 @@ Hands the implementation off to the SDLC capability. The orchestrator picks the 
      - Set `default_branch_advanced = true`. The audit comment names the offending SHAs.
    - **PR exists**: if no PR was returned and none can be found via the API, mark the run failed and route to `06-write-audit` as a contract violation.
    - **PR shape**: assert `headRefName == feat/issue-<n>-<slug>`, `baseRefName == <default>`, body contains `Closes #<n>`. If any field is wrong, post a comment on the PR with the contract violation and let the human fix it; the run still succeeds (PR exists; the lifecycle continues).
-7. Forward the structured result to `06-write-audit`. Do not transition labels here; that happens in `06`.
+9. Forward the structured result to `06-write-audit`. Do not transition labels here; that happens in `06`.
 
 ## Test
 

--- a/plugins/aidd-orchestrator/skills/03-review-async-dev/SKILL.md
+++ b/plugins/aidd-orchestrator/skills/03-review-async-dev/SKILL.md
@@ -11,7 +11,7 @@ Closes the loop after a PR is opened by this plugin's run skill. Detects when to
 
 | #   | Action              | Role                                                                                | Input        |
 | --- | ------------------- | ----------------------------------------------------------------------------------- | ------------ |
-| 01  | `collect-comments`  | Add `eyes` reaction, transition issue to `claude/working`, fetch comments           | PR number    |
+| 01  | `collect-comments`  | Add `eyes` reaction, transition issue to `claude/working`, fetch PR + issue comments | PR number    |
 | 02  | `detect-stop`       | Decide stop vs continue (max-N, blocked label, human reviewer)                      | comments + state |
 | 03  | `fix-iteration`     | Delegate fixes, push commit, reply per comment, resolve threads                     | comments     |
 | 04  | `finalize`          | Post structured summary, set final reaction, transition issue to awaiting-review or blocked | iteration log |

--- a/plugins/aidd-orchestrator/skills/03-review-async-dev/actions/01-collect-comments.md
+++ b/plugins/aidd-orchestrator/skills/03-review-async-dev/actions/01-collect-comments.md
@@ -6,6 +6,8 @@ Pulls new review comments since the last iteration and acknowledges the loop has
 
 - `pr_number` (required) -- integer, target PR
 - `trigger_comment_id` (optional) -- id of the comment that triggered the loop; receives an `eyes` reaction
+- `trigger_comment_url` (optional) -- full URL of the triggering comment; lets the loop reply in the thread that fired the trigger
+- `source_issue_number` (optional) -- issue number when the trigger was a comment on the linked issue (not the PR itself); enables fetching that thread alongside PR comments
 - `since` (optional) -- ISO 8601 timestamp; defaults to the timestamp of the last iteration recorded in the audit record
 
 ## Outputs
@@ -15,17 +17,24 @@ Pulls new review comments since the last iteration and acknowledges the loop has
   "pr_number": 117,
   "iteration": 2,
   "comments": [
-    { "id": 998, "author": "alice", "is_bot": false, "body": "...", "path": "src/foo.ts", "line": 12, "diff_hunk": "@@...", "created_at": "..." }
+    { "id": 998, "source": "pr_review", "author": "alice", "is_bot": false, "body": "...", "path": "src/foo.ts", "line": 12, "diff_hunk": "@@...", "created_at": "..." },
+    { "id": 1001, "source": "issue", "author": "alice", "is_bot": false, "body": "please also handle the null case", "created_at": "..." }
   ]
 }
 ```
+
+Each entry carries a `source` of `pr_review` (inline review thread), `pr_conversation` (top-level PR comment), or `issue` (comment on the linked issue). Issue comments have no `path`/`line` — Claude treats them as plain user direction.
 
 ## Process
 
 1. If `trigger_comment_id` is set, add an `eyes` reaction so the reviewer sees the loop started: `gh api -X POST repos/{owner}/{repo}/issues/comments/{id}/reactions -f content=eyes`. Ignore failures (already reacted, permission).
 2. Identify the linked issue from the PR (`gh pr view <pr> --json closingIssuesReferences --jq '.closingIssuesReferences[0].number'`). Transition labels on that issue: remove `config.labels.to_review` and `config.labels.awaiting_review`, add `config.labels.working`.
 3. Locate the audit record that owns `pr_number` by scanning `aidd_docs/async-runs/*/*.json` for `pr_number` match. Read its iteration counter; if absent, treat current iteration as 1.
-3. Fetch review comments: `gh api repos/{owner}/{repo}/pulls/<pr>/comments` plus issue comments `gh api repos/{owner}/{repo}/issues/<pr>/comments` (PRs share the issue endpoint). Capture `id`, `path`, `line`, `body`, `created_at`, `user.login`, `user.type`, and `pull_request_review_id`.
+3. Fetch comments from three streams and tag each with its `source`:
+   - PR inline review threads: `gh api repos/{owner}/{repo}/pulls/<pr>/comments` -> `source=pr_review`.
+   - PR top-level comments: `gh api repos/{owner}/{repo}/issues/<pr>/comments` -> `source=pr_conversation`.
+   - Linked issue comments: if `source_issue_number` is set, `gh api repos/{owner}/{repo}/issues/<source_issue_number>/comments`; otherwise resolve it from `closingIssuesReferences` and fetch that issue's comments -> `source=issue`.
+   Capture `id`, `body`, `created_at`, `user.login`, `user.type`, plus `path`/`line`/`pull_request_review_id` for `pr_review` only.
 4. Filter comments newer than `since`. Detect bots: `user.type == "Bot"`, login ends with `[bot]`, or login matches the trigger mention author.
 5. Skip comments already addressed in a previous iteration: read each prior iteration entry from the audit log and exclude those `comment_id`s.
 6. Emit the structured list with iteration number.


### PR DESCRIPTION
## Summary

Fixes three issues observed during async-dev run of #81:

1. **Bot pushed directly to main** instead of opening a PR. Branch creation is now the orchestrator's responsibility (it runs \`git checkout -B feat/issue-N-slug origin/<default>\` BEFORE invoking SDLC). SDLC stays branch-agnostic so manual users keep their existing workflow.
2. **\`to-review\` triggered \`run\` again** when no PR existed. Dispatch now routes that case to \`mode=skip\` with an explanatory comment.
3. **User comments on the issue were ignored.** The run skill now fetches all human issue comments newer than the last bot activity and embeds them verbatim in the SDLC prompt. The review skill collects from three streams: PR inline review, PR conversation, and linked-issue comments.

Also: \`to-implement\` on an issue with an existing open PR now skips with a comment.

## Files

- \`plugins/aidd-dev/skills/00-sdlc/SKILL.md\` — branch discipline = caller responsibility.
- \`plugins/aidd-orchestrator/skills/01-setup-async-dev/assets/workflow-template.yml\` — \`mode=skip\` cases, trigger-context outputs.
- \`plugins/aidd-orchestrator/skills/02-run-async-dev/actions/05-delegate-sdlc.md\` — orchestrator creates branch (step 3), collects comments (step 4), embeds in SDLC prompt (step 5).
- \`plugins/aidd-orchestrator/skills/03-review-async-dev/SKILL.md\` — three-stream comment collection.
- \`plugins/aidd-orchestrator/skills/03-review-async-dev/actions/01-collect-comments.md\` — fetches PR inline + PR conversation + linked-issue comments tagged by \`source\`.
- \`.github/workflows/aidd-async.yml\` — regenerated installed workflow with new dispatch logic.

## Test plan

- [ ] Create a fresh test issue. Label \`to-implement\`. Workflow fires \`mode=run\`. Orchestrator creates \`feat/issue-N-...\`, SDLC runs on it, PR opens with \`Closes #N\`. No commits land on \`main\`.
- [ ] On the new PR, post \`@claude /review\`. Workflow fires \`mode=review\`. Review skill picks up PR comments.
- [ ] On the test issue, post \`@claude /review\`. Workflow fires \`mode=review\` on the linked PR; review skill also pulls the issue comment.
- [ ] On a different issue (no PR linked), label \`to-review\`. Workflow fires \`mode=skip\` and posts the "no PR" comment.
- [ ] On an issue that already has an open PR, label \`to-implement\`. Workflow fires \`mode=skip\` and posts the "PR already open" comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)