### PR TITLE
fix(aidd-orchestrator): self-verifying audit + finalize

### DIFF
--- a/plugins/aidd-orchestrator/skills/02-run-async-dev/actions/06-write-audit.md
+++ b/plugins/aidd-orchestrator/skills/02-run-async-dev/actions/06-write-audit.md
@@ -1,18 +1,21 @@
 # 06 -- Write Audit
 
-Persists the run record, creates the GitHub Check Run, and transitions the lifecycle labels to `claude/awaiting-review` (or `claude/blocked` on failure).
+Persist the run record on the PR branch, finalize the Check Run, transition the issue labels, post the completion marker.
 
 ## Inputs
 
-- `run_record` (required) -- merged data from `03-acquire-lock` and `05-delegate-sdlc`
-- `config` (required) -- parsed `.claude/aidd-orchestrator.json`
+- `run_record` -- merged data from `03-acquire-lock` and `05-delegate-sdlc`
+- `config` -- parsed `.claude/aidd-orchestrator.json`
 
 ## Outputs
 
 ```json
 {
   "audit_path": "aidd_docs/async-runs/2026_05/2026-05-07T10-12-31Z-i42.json",
-  "check_run_id": 9876543210
+  "audit_commit_url": "https://github.com/org/repo/commit/<sha>",
+  "check_run_id": 9876543210,
+  "labels_after": ["claude/awaiting-review"],
+  "completion_marker_url": "https://github.com/org/repo/pull/<pr>#issuecomment-..."
 }
 ```
 
@@ -22,25 +25,43 @@ Persists the run record, creates the GitHub Check Run, and transitions the lifec
 
 ## Process
 
-**MANDATORY — this action must run and must persist its artifacts.** Skipping any step (especially the audit write or its commit + push to the PR branch) is a contract violation. The audit JSON is the single source of truth for the run; without it on the PR branch, the run is unverifiable.
-
-1. Compute `audit_dir = config.audit.log_dir + "/" + YYYY_MM` (UTC). Create it if missing.
-2. Write `<audit_dir>/<run_id>.json` with the full run record: trigger, issue, dependency check, lock timestamps, SDLC outcome (including `delegated_via_skill` boolean and the skill name actually called), errors if any, plugin version. The `delegated_via_skill` field MUST be `true` when action 05 invoked the SDLC skill via the `Skill` tool; `false` means the orchestrator bypassed delegation and the run is flagged as a contract violation.
-3. **Commit and push the audit file to the PR branch** (the SDLC pushed the feature branch in action 05). Run from the runner's working tree:
+1. Compose `audit_path = config.audit.log_dir + "/" + YYYY_MM + "/" + run_id + ".json"`. Build the run record JSON: trigger, issue, lock timestamps, SDLC outcome, `delegated_via_skill`, errors, plugin version.
+2. Push the audit file to the PR branch via the Contents API (no `git checkout`):
+   ```bash
+   SHA=$(gh api "repos/$GITHUB_REPOSITORY/contents/$audit_path?ref=$branch" --jq .sha 2>/dev/null || echo "")
+   PAYLOAD=$(jq -n --arg msg "chore(orchestrator): record async run audit $run_id" \
+     --arg content "$(printf '%s' "$AUDIT_JSON" | base64 | tr -d '\n')" \
+     --arg branch "$branch" --arg sha "$SHA" \
+     '{message:$msg, content:$content, branch:$branch} + (if $sha == "" then {} else {sha:$sha} end)')
+   audit_commit_url=$(gh api -X PUT "repos/$GITHUB_REPOSITORY/contents/$audit_path" --input - <<< "$PAYLOAD" --jq .commit.html_url)
    ```
-   git fetch origin feat/issue-<n>-<slug>
-   git checkout feat/issue-<n>-<slug>
-   git add <audit_dir>/<run_id>.json
-   git commit -m "chore(orchestrator): record async run audit <run_id>" --no-verify
-   git push origin feat/issue-<n>-<slug>
+3. If `config.audit.github_check_run`: create or update Check Run `aidd-async/<run_id>`. Capture `check_run_id` and set a final `conclusion` (`success` / `failure` / `action_required`).
+4. Transition labels: remove `config.labels.working`; on success add `config.labels.awaiting_review`, on failure add `config.labels.blocked` and post the error on the issue. Capture `labels_after` from the API response.
+5. Post the completion marker (single PR comment, idempotent via the HTML token):
    ```
-   `--no-verify` is used because the audit commit is an orchestrator artefact, not a feature change. If `delegated_via_skill` is `false`, additionally post a PR comment referencing the contract violation so a human can decide whether to keep the PR.
-4. If `config.audit.github_check_run` is true, call `gh api repos/{owner}/{repo}/check-runs` to create or update a Check Run named `aidd-async/<run_id>` with `status`, `conclusion`, and `output.summary` reflecting the run (including `delegated_via_skill`).
-5. Transition labels on the issue:
-   - On success (PR was opened): remove `config.labels.working`, add `config.labels.awaiting_review`.
-   - On failure: remove `config.labels.working`, add `config.labels.blocked`. Post a comment on the issue with the error details.
-6. Return the audit path and check run id.
+   <!-- aidd-orchestrator:run-complete run_id=<run_id> -->
+   ✅ Async run complete. Audit: <audit_commit_url>.
+   ```
+   Capture `completion_marker_url`. The agent uses this as its sole exit signal.
+6. Run the Test section. Exit only when every assertion prints `OK`.
 
 ## Test
 
-After a successful run: `gh api 'repos/{owner}/{repo}/contents/aidd_docs/async-runs/<YYYY_MM>/<run_id>.json?ref=feat/issue-<n>-<slug>'` returns the file (proving it was committed and pushed); `jq '.run_id, .pr_number, .delegated_via_skill' <local-copy>` returns the run id, PR number, and `true`; `gh api repos/{owner}/{repo}/check-runs/<id>` returns `conclusion: "success"`; `gh issue view <n> --repo <owner>/<repo> --json labels --jq '.labels[].name'` includes `claude/awaiting-review` and excludes `claude/working`. If `delegated_via_skill` is `false`, the PR carries a comment naming the contract violation.
+```bash
+gh api "repos/$GITHUB_REPOSITORY/contents/$audit_path?ref=$branch" --jq .sha >/dev/null \
+  && echo "OK audit_file" || echo "FAIL audit_file"
+
+gh api "repos/$GITHUB_REPOSITORY/check-runs/$check_run_id" --jq .conclusion \
+  | grep -Eq '^(success|neutral|failure|action_required)$' \
+  && echo "OK check_run" || echo "FAIL check_run"
+
+gh api "repos/$GITHUB_REPOSITORY/issues/$issue_number" --jq '[.labels[].name]' \
+  | jq -e 'contains(["claude/awaiting-review"]) and (contains(["claude/working"]) | not)' >/dev/null \
+  && echo "OK labels" || echo "FAIL labels"
+
+gh api "repos/$GITHUB_REPOSITORY/issues/$pr_number/comments" \
+  --jq "[.[] | select(.body | contains(\"aidd-orchestrator:run-complete run_id=$run_id\"))] | length" \
+  | grep -q '^1$' && echo "OK marker" || echo "FAIL marker"
+```
+
+On failure mode (`delegated_via_skill == false` or SDLC errored): assertion 3 expects `claude/blocked` instead of `claude/awaiting-review`.

--- a/plugins/aidd-orchestrator/skills/03-review-async-dev/actions/04-finalize.md
+++ b/plugins/aidd-orchestrator/skills/03-review-async-dev/actions/04-finalize.md
@@ -1,43 +1,58 @@
 # 04 -- Finalize
 
-Closes the loop after a stop decision: tags the audit record, posts a structured summary comment, and updates the Check Run.
+Tag the audit record, post the structured summary, update the Check Run, transition labels, drop the completion marker.
 
 ## Inputs
 
-- `pr_number` (required) -- integer
-- `stop_reason` (required) -- one of `max_iterations`, `blocked_label`, `human_reviewer`
-- `iteration_log` (required) -- accumulated entries written by `03-fix-iteration`
-- `trigger_comment_id` (optional) -- id of the comment that triggered the loop
+- `pr_number`
+- `stop_reason` -- one of `max_iterations`, `blocked_label`, `human_reviewer`, `no_comments`
+- `iteration_log` -- entries from `03-fix-iteration`; may be empty when `stop_reason == "no_comments"`
+- `trigger_comment_id` (optional)
+- `run_id`
 
 ## Outputs
 
 ```json
 {
   "audit_path": "aidd_docs/async-runs/2026_05/2026-05-07T10-12-31Z-i42.json",
+  "audit_commit_url": "https://github.com/org/repo/commit/<sha>",
   "check_run_conclusion": "neutral",
-  "summary_comment_url": "https://github.com/org/repo/pull/117#issuecomment-..."
+  "summary_comment_url": "https://github.com/org/repo/pull/<pr>#issuecomment-...",
+  "labels_after": ["claude/awaiting-review"],
+  "completion_marker_url": "https://github.com/org/repo/pull/<pr>#issuecomment-..."
 }
 ```
 
 ## Depends on
 
-- `02-detect-stop` (only when its `decision == "stop"`)
+- `02-detect-stop` (when `decision == "stop"`)
 
 ## Process
 
-1. Open the existing audit record. Append `{ "loop_closed_at": "<ISO8601>", "stop_reason": "<reason>", "iterations": iteration_log }`.
-2. Update the GitHub Check Run for the run id: `conclusion = "success"` if `stop_reason == "human_reviewer"` and last iteration tests passed, else `"neutral"` for `max_iterations` and `"action_required"` for `blocked_label`.
-3. Render the summary body from the template below; substitute every placeholder. Empty sections must be omitted, never left blank.
-4. Post the summary as a single PR comment via `gh pr comment <pr> --repo <owner>/<repo> --body-file -`.
-5. If `trigger_comment_id` is set, ensure a final reaction is set on the trigger comment: `+1` for success, `confused` for `max_iterations`, `-1` for `blocked_label`. Remove any prior `eyes` reaction first.
-6. Transition labels on the linked issue (`gh pr view <pr> --json closingIssuesReferences`):
-   - On `human_reviewer` (success): remove `config.labels.working`, add `config.labels.awaiting_review`.
-   - On `max_iterations`: remove `config.labels.working`, add `config.labels.awaiting_review` (PR exists, human must look).
-   - On `blocked_label`: remove `config.labels.working`, add `config.labels.blocked`.
+1. Read the existing audit JSON via the Contents API. Append `{ "loop_closed_at": "<ISO8601>", "stop_reason": "<reason>", "iterations": iteration_log }`. Push the update with `gh api -X PUT` (pass the prior `sha`). Capture `audit_commit_url`.
+2. Update Check Run `aidd-async/<run_id>`: `success` for `human_reviewer` (tests passed) or `no_comments`; `neutral` for `max_iterations`; `action_required` for `blocked_label`.
+3. Render the summary body from the template below. When `stop_reason == "no_comments"` and `iteration_log` is empty, show only the header row plus `_no fix iterations on this loop_`.
+4. Post the summary as a single PR comment: `summary_comment_url=$(gh pr comment $pr_number --body-file -)`. Always post, including on `no_comments`.
+5. If `trigger_comment_id` set: remove the prior `eyes` reaction; add the final one (`+1` for `human_reviewer` / `no_comments`, `confused` for `max_iterations`, `-1` for `blocked_label`).
+6. Transition labels on the linked issue:
+   ```bash
+   issue_number=$(gh pr view $pr_number --json closingIssuesReferences --jq '.closingIssuesReferences[0].number')
+   gh api -X DELETE "repos/$GITHUB_REPOSITORY/issues/$issue_number/labels/$(printf '%s' "$WORKING" | jq -sRr @uri)" || true
+   case "$stop_reason" in
+     blocked_label) NEW="$BLOCKED" ;;
+     *)             NEW="$AWAITING" ;;
+   esac
+   gh api -X POST "repos/$GITHUB_REPOSITORY/issues/$issue_number/labels" -f "labels[]=$NEW"
+   ```
+7. Post the completion marker (single PR comment, idempotent):
+   ```
+   <!-- aidd-orchestrator:review-complete run_id=<run_id> -->
+   ✅ Async review complete (`<stop_reason>`). Summary: <summary_comment_url>.
+   ```
+   Capture `completion_marker_url`. The agent uses this as its sole exit signal.
+8. Run the Test section. Exit only when every assertion prints `OK`.
 
 ## Summary template
-
-The body is markdown and must follow this exact structure:
 
 ```markdown
 ## Async review summary
@@ -60,16 +75,43 @@ The body is markdown and must follow this exact structure:
 
 ### Next step
 
-- `human_reviewer` -- A reviewer has commented since the last automated push. The loop is paused. To continue, address the comments and re-trigger with `<retry mention>` or `<retry label>`.
-- `max_iterations` -- The maximum of `<max_iterations>` automatic iterations was reached without convergence. Human review is required before another retry.
-- `blocked_label` -- The `<blocked label>` label is set. Remove it once the blocker is resolved to allow another retry.
+- `human_reviewer` -- A reviewer commented since the last automated push. Re-trigger with `<retry mention>` / `<retry label>` once comments are addressed.
+- `max_iterations` -- Hit `<max_iterations>` without convergence. Human review required before retry.
+- `blocked_label` -- `<blocked label>` is set. Remove it to allow another retry.
+- `no_comments` -- Nothing actionable to address. Re-trigger with a concrete inline review comment.
 
 ---
 *Audit log: `<audit_path>`.*
 ```
 
-The summary stays under ~30 lines on a typical PR. Truncate quoted comment bodies to 80 characters with `...`. Iterations table has one row per iteration; if no fix iterations ran, show only the header row plus a `_no fix iterations on this loop_` note.
+Stay under ~30 lines on a typical PR. Truncate quoted bodies to 80 characters with `...`.
 
 ## Test
 
-Given an audit record with two `fix-iteration` entries and `stop_reason = human_reviewer`: after this action runs, the audit JSON contains `loop_closed_at` and `stop_reason`, the Check Run conclusion is `success`, the trigger comment carries a `+1` reaction, and a PR comment exists whose body matches the template (contains the `## Async review summary` heading, an `Iterations` table with two data rows, a `Next step` section with the `human_reviewer` bullet, and an `Audit log` footer).
+```bash
+gh api "repos/$GITHUB_REPOSITORY/contents/$audit_path?ref=$branch" --jq .content \
+  | base64 -d | jq -e '.loop_closed_at and .stop_reason' >/dev/null \
+  && echo "OK audit_closed" || echo "FAIL audit_closed"
+
+gh api "repos/$GITHUB_REPOSITORY/check-runs/$check_run_id" --jq .conclusion \
+  | grep -Eq '^(success|neutral|failure|action_required)$' \
+  && echo "OK check_run" || echo "FAIL check_run"
+
+gh api "repos/$GITHUB_REPOSITORY/issues/$pr_number/comments" \
+  --jq "[.[] | select(.body | startswith(\"## Async review summary\"))] | length" \
+  | grep -q '^[1-9]' && echo "OK summary" || echo "FAIL summary"
+
+gh api "repos/$GITHUB_REPOSITORY/issues/$issue_number" --jq '[.labels[].name]' \
+  | jq -e --arg sr "$stop_reason" '
+      if $sr == "blocked_label"
+      then contains(["claude/blocked"]) and (contains(["claude/working"]) | not)
+      else contains(["claude/awaiting-review"]) and (contains(["claude/working"]) | not)
+      end' >/dev/null \
+  && echo "OK labels" || echo "FAIL labels"
+
+gh api "repos/$GITHUB_REPOSITORY/issues/$pr_number/comments" \
+  --jq "[.[] | select(.body | contains(\"aidd-orchestrator:review-complete run_id=$run_id\"))] | length" \
+  | grep -q '^1$' && echo "OK marker" || echo "FAIL marker"
+```
+
+`no_comments` variant: assertion 3 still passes (summary contains the `_no fix iterations on this loop_` note); the `Iterations` table has only its header row.


### PR DESCRIPTION
## Summary

Fixes the two silent exit paths surfaced by the #91 dogfood run:

1. **`06-write-audit` aborted on PR-branch switch.** The action did `git checkout feat/issue-N-slug` to commit the audit, but the runner's working tree was on \`main\` and the audit file was an untracked sibling that vanished after the switch. The action now pushes the audit via the Contents API (\`gh api -X PUT contents/...\`) with no working-tree mutation.
2. **\`04-finalize\` was a no-op on \`no_comments\`.** The input enum didn't list \`no_comments\` so the skill exited without posting a summary on the very common "fresh PR + vague \`@claude /review\`" path. Enum + post logic now cover it.

Both actions:
- emit a single \`aidd-orchestrator:run-complete\` / \`:review-complete\` completion-marker PR comment, idempotent via an HTML token. The agent uses it as its sole exit signal.
- carry a Test section with one \`OK\`/\`FAIL\` assertion per persisted artifact (audit, check run, labels, summary, marker). The agent runs Test before exiting.

## Test plan

- [ ] Fresh dummy issue + \`to-implement\` -> PR opens, audit JSON appears on the PR branch via API, issue transitions to \`claude/awaiting-review\`, run-complete marker on the PR.
- [ ] On that PR, \`@claude /review\` -> summary comment + review-complete marker, issue stays in a terminal label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)