### PR TITLE
chore(framework): unify version management across marketplace and plugins via release-please

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,25 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
       version: ${{ steps.release.outputs.version }}
+      paths_released: ${{ steps.release.outputs.paths_released }}
+      aidd_context_release_created: ${{ steps.release.outputs['plugins/aidd-context--release_created'] }}
+      aidd_context_version: ${{ steps.release.outputs['plugins/aidd-context--version'] }}
+      aidd_context_tag_name: ${{ steps.release.outputs['plugins/aidd-context--tag_name'] }}
+      aidd_dev_release_created: ${{ steps.release.outputs['plugins/aidd-dev--release_created'] }}
+      aidd_dev_version: ${{ steps.release.outputs['plugins/aidd-dev--version'] }}
+      aidd_dev_tag_name: ${{ steps.release.outputs['plugins/aidd-dev--tag_name'] }}
+      aidd_vcs_release_created: ${{ steps.release.outputs['plugins/aidd-vcs--release_created'] }}
+      aidd_vcs_version: ${{ steps.release.outputs['plugins/aidd-vcs--version'] }}
+      aidd_vcs_tag_name: ${{ steps.release.outputs['plugins/aidd-vcs--tag_name'] }}
+      aidd_pm_release_created: ${{ steps.release.outputs['plugins/aidd-pm--release_created'] }}
+      aidd_pm_version: ${{ steps.release.outputs['plugins/aidd-pm--version'] }}
+      aidd_pm_tag_name: ${{ steps.release.outputs['plugins/aidd-pm--tag_name'] }}
+      aidd_orchestrator_release_created: ${{ steps.release.outputs['plugins/aidd-orchestrator--release_created'] }}
+      aidd_orchestrator_version: ${{ steps.release.outputs['plugins/aidd-orchestrator--version'] }}
+      aidd_orchestrator_tag_name: ${{ steps.release.outputs['plugins/aidd-orchestrator--tag_name'] }}
+      aidd_refine_release_created: ${{ steps.release.outputs['plugins/aidd-refine--release_created'] }}
+      aidd_refine_version: ${{ steps.release.outputs['plugins/aidd-refine--version'] }}
+      aidd_refine_tag_name: ${{ steps.release.outputs['plugins/aidd-refine--tag_name'] }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
@@ -85,8 +104,7 @@ jobs:
           tar czf "/tmp/aidd-framework-${VERSION}.tar.gz" \
             plugins/ \
             .claude-plugin/ \
-            aidd_docs/ \
-            version.txt
+            aidd_docs/
 
       - name: Build per-tool tarballs
         run: |
@@ -118,4 +136,55 @@ jobs:
             "/tmp/aidd-copilot-remote-${VERSION}.tar.gz" \
             "/tmp/aidd-codex-${VERSION}.tar.gz" \
             "/tmp/aidd-codex-remote-${VERSION}.tar.gz" \
+            --clobber
+
+  build-plugin:
+    name: Build and attach plugin
+    needs: [release-please]
+    if: needs.release-please.outputs.paths_released != '' && needs.release-please.outputs.paths_released != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        plugin: [aidd-context, aidd-dev, aidd-vcs, aidd-pm, aidd-orchestrator, aidd-refine]
+    steps:
+      - name: Check if this plugin was released
+        id: check
+        run: |
+          PATHS='${{ needs.release-please.outputs.paths_released }}'
+          if echo "$PATHS" | jq -e --arg p "plugins/${{ matrix.plugin }}" 'map(. == $p) | any' > /dev/null 2>&1; then
+            echo "released=true" >> $GITHUB_OUTPUT
+          else
+            echo "released=false" >> $GITHUB_OUTPUT
+          fi
+
+      - uses: actions/checkout@v4
+        if: steps.check.outputs.released == 'true'
+
+      - name: Get plugin version
+        id: version
+        if: steps.check.outputs.released == 'true'
+        run: |
+          VERSION=$(jq -r '.version' "plugins/${{ matrix.plugin }}/.claude-plugin/plugin.json")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Build plugin tarball
+        if: steps.check.outputs.released == 'true'
+        run: |
+          PLUGIN="${{ matrix.plugin }}"
+          VERSION="${{ steps.version.outputs.version }}"
+          tar czf "/tmp/${PLUGIN}-v${VERSION}.tar.gz" \
+            -C "plugins/${PLUGIN}" \
+            .
+
+      - name: Attach plugin tarball to release
+        if: steps.check.outputs.released == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PLUGIN="${{ matrix.plugin }}"
+          VERSION="${{ steps.version.outputs.version }}"
+          TAG="${PLUGIN}-v${VERSION}"
+          gh release upload "${TAG}" \
+            "/tmp/${PLUGIN}-v${VERSION}.tar.gz" \
             --clobber

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,7 +1,9 @@
 {
-  ".": "3.9.1",
+  ".": "4.0.0",
   "plugins/aidd-context": "1.0.0",
   "plugins/aidd-dev": "1.0.0",
   "plugins/aidd-vcs": "1.0.0",
-  "plugins/aidd-pm": "1.0.0-rc.1"
+  "plugins/aidd-pm": "1.0.0-rc.1",
+  "plugins/aidd-orchestrator": "1.0.0",
+  "plugins/aidd-refine": "1.0.0"
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -193,4 +193,22 @@ Issues are automatically added to the [AIDD - Produit](https://github.com/orgs/a
 
 ---
 
+## Commit Scope Rules
+
+The commit scope drives release-please's per-package version bumps in this monorepo. Each plugin versions independently; `marketplace.json` tracks the root (`.`) version.
+
+| Scope | Package path | Released tag pattern | What bumps |
+|---|---|---|---|
+| `aidd-context` | `plugins/aidd-context` | `aidd-context-vX.Y.Z` | Plugin only |
+| `aidd-dev` | `plugins/aidd-dev` | `aidd-dev-vX.Y.Z` | Plugin only |
+| `aidd-vcs` | `plugins/aidd-vcs` | `aidd-vcs-vX.Y.Z` | Plugin only |
+| `aidd-pm` | `plugins/aidd-pm` | `aidd-pm-vX.Y.Z` | Plugin only (currently pinned to `1.0.0-rc.1`) |
+| `aidd-orchestrator` | `plugins/aidd-orchestrator` | `aidd-orchestrator-vX.Y.Z` | Plugin only |
+| `aidd-refine` | `plugins/aidd-refine` | `aidd-refine-vX.Y.Z` | Plugin only |
+| `framework` or `marketplace` | `.` (root) | `vX.Y.Z` | `marketplace.json` via `extra-files` |
+
+`commitlint.config.cjs` enforces these scopes. Root releases attach `aidd-framework-vX.Y.Z.tar.gz` and per-tool bundles; plugin releases attach only `<plugin>-vX.Y.Z.tar.gz`.
+
+---
+
 ■ [Back to framework](./README.md)

--- a/aidd_docs/async-runs/2026_05/auto-20260514T155557Z-i81.json
+++ b/aidd_docs/async-runs/2026_05/auto-20260514T155557Z-i81.json
@@ -1,0 +1,42 @@
+{
+  "schema_version": "1.0.0",
+  "run_at": "2026-05-14T00:00:00Z",
+  "trigger": {
+    "kind": "label",
+    "issue_number": 81,
+    "comment_url": ""
+  },
+  "issue": {
+    "number": 81,
+    "title": "chore(framework): unify version management across marketplace and plugins via release-please",
+    "url": "https://github.com/ai-driven-dev/aidd-framework/issues/81"
+  },
+  "outcome": "success",
+  "branch": "chore/issue-81-version-management",
+  "commits_ahead_of_default": 3,
+  "pull_request": {
+    "number": 114,
+    "url": "https://github.com/ai-driven-dev/aidd-framework/pull/114",
+    "state": "open",
+    "base": "main",
+    "head": "chore/issue-81-version-management"
+  },
+  "sdlc": {
+    "capability": "aidd-dev:00-sdlc",
+    "mode": "auto",
+    "phases_completed": ["spec-skipped", "plan", "implement", "review", "ship"],
+    "review_verdict": "ship",
+    "completion_score": 100,
+    "quality_score": 92
+  },
+  "files_changed": [
+    "release-please-config.json",
+    ".release-please-manifest.json",
+    ".github/workflows/ci.yml",
+    "CONTRIBUTING.md"
+  ],
+  "label_transitions": {
+    "removed": "to-implement",
+    "added": "claude/working"
+  }
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -63,6 +63,26 @@
           "jsonpath": "$.version"
         }
       ]
+    },
+    "plugins/aidd-orchestrator": {
+      "package-name": "aidd-orchestrator",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": ".claude-plugin/plugin.json",
+          "jsonpath": "$.version"
+        }
+      ]
+    },
+    "plugins/aidd-refine": {
+      "package-name": "aidd-refine",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": ".claude-plugin/plugin.json",
+          "jsonpath": "$.version"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary

- Registers `aidd-orchestrator` and `aidd-refine` as full release-please packages in `release-please-config.json`
- Syncs `.release-please-manifest.json` root from `3.9.1` → `4.0.0` (matches `marketplace.json`) and adds all 6 plugin entries
- Removes deleted `version.txt` from the CI source tarball step
- Adds a `build-plugin` matrix job that builds and attaches `aidd-<plugin>-v<VERSION>.tar.gz` only when that plugin is released
- Documents commit scope → release-please package mapping in `CONTRIBUTING.md`

## QA checklist

- [x] `release-please-config.json` has all 6 plugins (aidd-context, aidd-dev, aidd-vcs, aidd-pm, aidd-orchestrator, aidd-refine)
- [x] `.release-please-manifest.json` root is `"4.0.0"`, all 6 plugins listed, `aidd-pm` preserved at `"1.0.0-rc.1"`
- [x] `ci.yml` contains zero `version.txt` references
- [x] `ci.yml` has a `build-plugin` matrix job (6 plugins) with `paths_released` gating
- [x] `CONTRIBUTING.md` has a `## Commit Scope Rules` section with a 7-row table
- [x] `commitlint.config.cjs` untouched
- [x] No `plugin.json` file modified

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)