### PR TITLE
docs(framework): add v3 to v4 upgrade guide

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,160 @@
+# Upgrade guide — v3.9.1 → v4.0.0
+
+This release ships a full architecture rewrite. The legacy `commands/` directory was deleted and replaced with a Claude Code plugin marketplace organised around skills.
+
+If you were on `v3.x`, plan for breaking changes:
+
+- All `/command_name` slash commands are gone. They are now skills invoked via plugins (e.g. `/aidd-dev:02-implement`).
+- The repo is now a plugin **marketplace** (`.claude-plugin/marketplace.json`). You install the plugins you want; you do not clone the whole repo into your project.
+- Hooks, agents and templates moved into skill assets inside each plugin.
+
+---
+
+## 1. Why the major bump
+
+`v4.0.0` is a structural rewrite of how the framework is delivered:
+
+1. **The framework is now a Claude Code marketplace.** Instead of cloning the whole repo, you point Claude Code at the marketplace and install plugins on demand.
+2. **The framework is split into 6 plugins.** Each plugin owns a slice of the SDLC (`aidd-context`, `aidd-dev`, `aidd-vcs`, `aidd-pm`, `aidd-orchestrator`, `aidd-refine`) and ships independently.
+3. **Skills replace commands.** Every former `/command` is now a skill with structured frontmatter, evals, and assets. Skills can be invoked explicitly or auto-triggered by Claude Code.
+4. **Hooks, agents and templates moved into the plugins that own them**, not at the repo root.
+
+---
+
+## 2. New plugin layout
+
+| Plugin | Purpose |
+|---|---|
+| `aidd-context` | Project bootstrap, onboarding, memory, learning, mermaid. |
+| `aidd-dev` | Plan → implement → assert → review → test → refactor → debug SDLC loop. |
+| `aidd-vcs` | Commit, pull request, release tag, issue creation. |
+| `aidd-pm` | Ticket info, user stories, PRD, spec. |
+| `aidd-orchestrator` | Async dev orchestration (label/comment-driven Claude runs). |
+| `aidd-refine` | Brainstorm, challenge, condense, shadow-area gap analysis. |
+
+Each plugin ships its own:
+- `.claude-plugin/plugin.json` (manifest + version)
+- `skills/NN-action-name/SKILL.md` (one skill per former command)
+- `CATALOG.md` (auto-generated index)
+- assets, agents, references, evals
+
+---
+
+## 3. Install (new flow)
+
+```bash
+# Add the marketplace once
+claude marketplace add https://github.com/ai-driven-dev/aidd-framework
+
+# Install only what you need
+claude plugin install aidd-context@aidd-framework
+claude plugin install aidd-dev@aidd-framework
+claude plugin install aidd-vcs@aidd-framework
+claude plugin install aidd-refine@aidd-framework
+# … etc.
+```
+
+---
+
+## 4. Command → skill mapping
+
+Drop-in mapping from `v3.9.1` commands to `v4.0.0` skills. Invocation syntax is `/<plugin>:<NN-action>` in Claude Code.
+
+### Removed (no direct replacement)
+
+| v3 command | Status |
+|---|---|
+| `/auto_accept` | Removed — controlled via Claude Code settings now. |
+| `/implement_from_design` | Removed — covered by `aidd-dev:02-implement` with image input. |
+| `/run_projection` | Removed — projection is now part of the plan/implement loop. |
+| `/reflect_issue` | Removed — folded into `aidd-dev:08-debug`. |
+| `/reproduce` | Removed — folded into `aidd-dev:08-debug`. |
+
+### Renamed / relocated
+
+| v3 command | v4 skill |
+|---|---|
+| `/onboard` | `/aidd-context:00-onboard` |
+| `/init` | `/aidd-context:02-project-init` |
+| `/learn` | `/aidd-context:05-learn` |
+| `/mermaid` | `/aidd-context:04-mermaid` |
+| `/generate_agent` | `/aidd-context:*` (generators folded into context skills) |
+| `/generate_architecture` | `/aidd-context:01-bootstrap` |
+| `/generate_command` | `/aidd-context:*` |
+| `/generate_rules` | `/aidd-context:*` |
+| `/generate_skill` | `/aidd-context:*` (also covered by Claude Code's built-in `skill-creator`) |
+| `/brainstorm` | `/aidd-refine:01-brainstorm` |
+| `/challenge` | `/aidd-refine:02-challenge` |
+| `/create_user_stories` | `/aidd-pm:02-user-stories-create` |
+| `/ticket_info` | `/aidd-pm:01-ticket-info` |
+| `/plan` | `/aidd-dev:01-plan` |
+| `/components_behavior` | `/aidd-dev:01-plan` (sub-flow) |
+| `/image_extract_details` | `/aidd-dev:01-plan` (sub-flow) |
+| `/implement` | `/aidd-dev:02-implement` |
+| `/assert` | `/aidd-dev:03-assert` |
+| `/assert_architecture` | `/aidd-dev:03-assert` (sub-flow) |
+| `/assert_frontend` | `/aidd-dev:03-assert` (sub-flow) |
+| `/review_code` | `/aidd-dev:05-review` |
+| `/review_functional` | `/aidd-dev:05-review` |
+| `/test` | `/aidd-dev:06-test` |
+| `/test_journey` | `/aidd-dev:06-test` (journey sub-flow) |
+| `/audit` | `/aidd-dev:04-audit` |
+| `/performance` | `/aidd-dev:07-refactor` |
+| `/security_refactor` | `/aidd-dev:07-refactor` |
+| `/debug` | `/aidd-dev:08-debug` |
+| `/commit` | `/aidd-vcs:01-commit` |
+| `/create_request` | `/aidd-vcs:02-pull-request` |
+| `/tag` | `/aidd-vcs:03-release-tag` |
+| `/new_issue` | `/aidd-vcs:04-issue-create` |
+
+### New in v4 (no v3 equivalent)
+
+| v4 skill | What it does |
+|---|---|
+| `/aidd-context:01-bootstrap` | Imagines a SaaS architecture from scratch. |
+| `/aidd-context:06-discovery` | Finds rules, hooks, memory across the project. |
+| `/aidd-dev:00-sdlc` | Orchestrates the full plan → ship loop interactively. |
+| `/aidd-dev:09-for-sure` | Validates assumptions before commit. |
+| `/aidd-orchestrator:*` | Async, label-driven Claude runs from GitHub issues. |
+| `/aidd-pm:03-prd` | Builds PRD from requirements. |
+| `/aidd-pm:04-spec` | Writes tech spec. |
+| `/aidd-refine:03-condense` | Shrinks long docs without losing intent. |
+| `/aidd-refine:04-shadow-areas` | Detects blind spots in feature specs. |
+
+---
+
+## 5. Step-by-step migration
+
+1. **Backup your v3 setup.** Note any custom commands you added under `commands/` — they will not migrate automatically.
+2. **Delete the legacy `commands/` directory** from your project. That is the only folder that disappears: `aidd_docs/memory/` and any other project files stay as-is.
+3. **Add the marketplace** (see §3).
+4. **Install the plugins you use.** Most users start with `aidd-context` + `aidd-dev` + `aidd-vcs` + `aidd-refine`.
+5. **Re-bootstrap the project.** Run `/aidd-context:02-project-init` to wire the new plugin layout into `.claude/`. Use `/aidd-context:00-onboard` only when you want a guided walkthrough.
+6. **Translate your custom commands.** For each custom command you had under `commands/`, generate a skill (e.g. via the built-in `skill-creator`), place it in your own local plugin, and load it via `.claude/settings.json`.
+7. **Update CI references.** If your CI invoked `/some_command`, switch to the new skill invocation.
+
+---
+
+## 6. FAQ
+
+**Q. Will `v3` keep working?**
+Yes, but it is no longer maintained. Pin to `v3.9.1` if you cannot migrate yet.
+
+**Q. Do I need all 6 plugins?**
+No. Each plugin is independent. Install only what you use.
+
+**Q. Where did my custom hooks go?**
+Hooks were split into the plugins that own them. Look under `plugins/<plugin>/hooks/` in the source, or read each plugin's `CATALOG.md`.
+
+**Q. Where did the agents go?**
+Agents now live inside the plugin that uses them (e.g. `plugins/aidd-dev/agents/`).
+
+**Q. I had `aidd_docs/memory/`. Is it still used?**
+Yes. The memory bank format is unchanged. The skills that read it just moved into `aidd-context`.
+
+**Q. How do I get help?**
+Open an issue: <https://github.com/ai-driven-dev/aidd-framework/issues>.
+
+---
+
+For the raw list of every change, see [`CHANGELOG.md`](CHANGELOG.md).


### PR DESCRIPTION
## Summary

Adds `UPGRADE.md` at repo root covering the v3.9.1 → v4.0.0 migration.

### Contents
- Why the major bump (marketplace + plugin split + skills as commands)
- New 6-plugin layout
- Marketplace install flow
- Full v3 command → v4 skill mapping (renamed, removed, new)
- 7-step migration walkthrough
- FAQ (memory, hooks, agents, plugin selection)

### Why ship before v4 release
Major SemVer bump = users hit breaking changes. CHANGELOG lists commits but no migration path. UPGRADE.md fills that gap before release-please cuts `v4.0.0`.

### Notes
- `docs:` commit type → release-please will append to changelog, no extra version bump.
- Will land in the open release-please PR #77 on the next workflow run.

## Test plan

- [ ] Skim `UPGRADE.md` rendering on GitHub
- [ ] Verify command → skill mapping accuracy against `plugins/*/skills/*/SKILL.md`
- [ ] Confirm release-please PR #77 picks up the doc on next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)