### PR TITLE
chore(release-please): ship aidd-pm as 1.0.0 stable

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -55,7 +55,7 @@
     },
     "plugins/aidd-pm": {
       "package-name": "aidd-pm",
-      "release-as": "1.0.0-rc.1",
+      "release-as": "1.0.0",
       "extra-files": [
         {
           "type": "json",


### PR DESCRIPTION
## Summary

Replaces `release-as: 1.0.0-rc.1` with `release-as: 1.0.0` for `plugins/aidd-pm` in `release-please-config.json`.

### Why
- aidd-pm has no existing git tag (`git tag --list 'aidd-pm*'` is empty).
- Manifest already records `aidd-pm: 1.0.0`.
- An RC at `1.0.0-rc.1` is semver-lower than `1.0.0` already in the manifest → invalid downgrade.
- Goal: ship aidd-pm as `1.0.0` stable alongside the `v4.0.0` framework cut.

### Effect on release-please PR #77
- Open release-please PR #77 will regenerate.
- `aidd-pm` bump line will change from `1.0.0 -> 1.0.0-rc.1` to `1.0.0 -> 1.0.0` (or stay at `1.0.0` — no change).
- Post-merge follow-up: once aidd-pm `v1.0.0` is tagged, remove the `release-as` line entirely so future bumps come from conventional commits.

## Test plan

- [x] JSON valid (`jq empty release-please-config.json`)
- [ ] Wait for release-please workflow run on main after merge
- [ ] Confirm PR #77 picks up the new version target

🤖 Generated with [Claude Code](https://claude.com/claude-code)