### PR TITLE
docs(readme): bump skill count 32 to 33

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ### A community-maintained marketplace of skills, agents, and rules for Claude Code.
 
 <p>
-  <kbd>6 plugins</kbd> · <kbd>32 skills</kbd> · <kbd>3 agents</kbd> · <kbd>MIT</kbd>
+  <kbd>6 plugins</kbd> · <kbd>33 skills</kbd> · <kbd>3 agents</kbd> · <kbd>MIT</kbd>
 </p>
 
 <p>


### PR DESCRIPTION
## Summary

README header chip drifts from actual count: `find plugins/*/skills -maxdepth 2 -name 'SKILL.md' | wc -l` returns 33, README said 32.

## Test plan

- [x] Local count matches new value
- [ ] GitHub render preview OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)