### PR TITLE
docs(aidd-context): refresh descriptions to cover all seven generated artifacts

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "aidd-context",
       "version": "1.0.0",
       "source": "./plugins/aidd-context",
-      "description": "Knowledge production: project bootstrap, project init, context generation, mermaid diagrams, learn, discovery",
+      "description": "Knowledge production: project bootstrap, project init, generation of Claude Code context artifacts (skills, agents, rules, commands, hooks, plugins, marketplaces), mermaid diagrams, learn, discovery",
       "strict": true,
       "recommended": true
     },

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Prefer browsing inside Claude Code? Run `/plugin` and open the **Discover** tab 
 
 `7 skills` · stable
 
-Project init, architecture, context generation, diagrams, learning, discovery.
+Project init, architecture, generation of Claude Code context artifacts (skills, agents, rules, commands, hooks, plugins, marketplaces), diagrams, learning, discovery.
 
 </td>
 <td width="33%" valign="top">

--- a/plugins/aidd-context/.claude-plugin/plugin.json
+++ b/plugins/aidd-context/.claude-plugin/plugin.json
@@ -2,6 +2,6 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "aidd-context",
   "version": "1.0.0",
-  "description": "Knowledge production: project bootstrap, project init, context generation, mermaid diagrams, learn, discovery",
+  "description": "Knowledge production: project bootstrap, project init, generation of Claude Code context artifacts (skills, agents, rules, commands, hooks, plugins, marketplaces), mermaid diagrams, learn, discovery",
   "author": { "name": "AI-Driven Dev" }
 }

--- a/plugins/aidd-context/README.md
+++ b/plugins/aidd-context/README.md
@@ -8,7 +8,7 @@ Knowledge production plugin for the AI-Driven Development framework.
 
 First time? Install with `/plugin install aidd-context@aidd-framework`, then run `aidd-context:00:onboard`.
 
-Covers project bootstrap, project initialisation, context generation, Mermaid diagrams, learning, discovery, and a state-aware onboarding loop.
+Covers project bootstrap, project initialisation, generation of Claude Code context artifacts (skills, agents, rules, commands, hooks, plugins, marketplaces), Mermaid diagrams, learning, discovery, and a state-aware onboarding loop.
 
 ## Skills
 
@@ -17,7 +17,7 @@ Covers project bootstrap, project initialisation, context generation, Mermaid di
 | [1.0]      | [onboard](skills/00-onboard/README.md)                 | Detect the project's aidd-context state and guide the user to ONE next aidd-context action through a state -> recommend -> execute loop.                       |
 | [1.1]      | [bootstrap](skills/01-bootstrap/README.md)             | Imagine and validate the technical architecture of a new SaaS through interactive Q&A, candidate-stack comparison, multi-agent audit, and an INSTALL.md output. |
 | [1.2]      | [project-init](skills/02-project-init/README.md)       | Initialize the project memory bank (rule directories are created lazily by `03-context-generate`).                                                              |
-| [1.3]      | [context-generate](skills/03-context-generate/README.md) | Generate Claude Code context artifacts - router-based skills, agents, and rules.                                                                                |
+| [1.3]      | [context-generate](skills/03-context-generate/README.md) | Generate Claude Code context artifacts - router-based skills, agents, rules, slash commands, hooks, plugin scaffolds, and plugin marketplaces.                  |
 | [1.4]      | [mermaid](skills/04-mermaid/README.md)                 | Generate high-quality Mermaid diagrams from markdown content using a structured plan-validate workflow.                                                         |
 | [1.5]      | [learn](skills/05-learn/README.md)                     | Capture and store learnings from recently implemented features into memory bank, decisions, or coding rules.                                                    |
 | [1.6]      | [discovery](skills/06-discovery/README.md)             | Help users discover installed skills and find the right one for their use case.                                                                                 |

--- a/plugins/aidd-context/skills/03-context-generate/README.md
+++ b/plugins/aidd-context/skills/03-context-generate/README.md
@@ -2,22 +2,28 @@
 
 # 03 - Context Generate
 
-Generates the three Claude Code context artifacts a project consumes:
-router-based **skills** (`SKILL.md` + atomic testable actions + minimal
-evals), **agents**, and **rules**. Evaluations are declared before
-implementation; every action gets a `## Test`.
+Generates the seven Claude Code context artifacts a project can consume:
+
+- **Skills** - router-based: `SKILL.md` router + atomic testable actions + minimal evals.
+- **Agents** - single-file agent definitions following the framework's agent template.
+- **Rules** - framework rule files governing editor / agent behaviour.
+- **Commands** - flat `.md` slash command files (frontmatter + body), for one-shot manual triggers without supporting files.
+- **Hooks** - JSON / TOML entries (or a JS/TS plugin module for OpenCode) for Claude Code lifecycle events, written to the matching scope.
+- **Plugins** - full plugin scaffold (`.claude-plugin/plugin.json`, README, dirs, optional seed skill).
+- **Marketplaces** - `.claude-plugin/marketplace.json` catalogs that distribute one or more plugins.
+
+Evaluations are declared before implementation; every action carries a `## Test`.
 
 ## When to use
 
-- Creating a new skill, agent, or rule from scratch.
+- Creating a new skill, agent, rule, slash command, hook, plugin, or marketplace from scratch.
 - Refactoring an existing skill: adding, removing, or splitting actions.
 - Migrating a legacy slash command into a router-based skill.
+- Scaffolding a brand-new plugin or stand-up of a plugin marketplace catalogue.
 
 ## When NOT to use
 
-- To edit a single action inside an existing skill → edit the action file
-  directly.
-- To create slash commands (no router needed for those).
+- To edit a single action inside an existing skill -> edit the action file directly.
 - To write MCP servers.
 - To modify project-level `CLAUDE.md` files.
 
@@ -29,44 +35,43 @@ Use skill aidd-context:03:context-generate
 
 For skill generation, the skill walks 6 atomic actions:
 
-1. `capture-intent` - clarify the desired output and decide
-   generate-vs-modify.
+1. `capture-intent` - clarify the desired output and decide generate-vs-modify.
 2. `design-evals` - write a minimal `scenarios.json`.
 3. `decompose-actions` - list actions and their `## Test` sentences.
 4. `draft-skill` - write the `SKILL.md` router.
 5. `write-actions` - write each action file.
-6. `validate` - spawn one agent per action, run its `## Test`, and
-   aggregate into a pass/fail report.
+6. `validate` - spawn one agent per action, run its `## Test`, and aggregate into a pass/fail report.
 
-Agent and rule generation each have their own single action (see
-`actions/agents/` and `actions/rules/`).
+The other six artifact types have their own sub-flows under `actions/<sub-domain>/`:
+
+- `actions/agents/` - single-action agent generation.
+- `actions/rules/` - single-action rule generation with deterministic category selection.
+- `actions/commands/` - single-action flat slash command generation.
+- `actions/hooks/` - single-action hook entry generation, branching on target tool (Claude/Cursor/Codex -> JSON; OpenCode -> JS module; Copilot -> plugin-bundled).
+- `actions/plugins/` - 4-action plugin scaffold flow (capture-intent -> scaffold-tree -> seed-first-skill -> validate).
+- `actions/marketplaces/` - 3-action marketplace catalog flow (init -> add-plugin-entry -> validate).
 
 ## Outputs
 
-- A new or refactored skill directory: `SKILL.md` + `actions/*.md` +
-  `evals/scenarios.json` (when auto-triggered) + optional `references/`
-  and `assets/`.
+- A new or refactored skill directory: `SKILL.md` + `actions/*.md` + `evals/scenarios.json` (when auto-triggered) + optional `references/` and `assets/`.
 - Or a generated agent file from `assets/agents/agent-template.md`.
 - Or a generated rule file from `assets/rules/rule-template.md`.
+- Or a flat slash command file from `assets/commands/command-template.md`.
+- Or a hook entry merged into the matching scope's hooks surface (JSON file, TOML table, or JS module per target tool).
+- Or a fresh plugin tree with `.claude-plugin/plugin.json` + README + selected slot dirs.
+- Or a marketplace catalogue `.claude-plugin/marketplace.json` + one or more plugin entries.
 
 ## Prerequisites
 
-- Project initialized with the AIDD context layer (run `02-project-init`
-  first if `aidd_docs/` is missing).
-- A clear user intent: what surface to generate (skill / agent / rule) and
-  the domain it covers.
+- Project initialized with the AIDD context layer (run `02-project-init` first if `aidd_docs/` is missing).
+- A clear user intent: which surface to generate and the domain it covers.
 
 ## Rules
 
 R1-R10 in [`SKILL.md`](SKILL.md) are the non-bypassable invariants:
-`SKILL.md` is a pure router, one skill = one domain, references one-level
-deep, `SKILL.md` ≤ 500 lines, descriptions must include explicit triggers
-and a "Do NOT use for..." clause, every action has a `## Test`, and
-auto-trigger skills ship at least 3 eval scenarios.
+`SKILL.md` is a pure router, one skill = one domain, references one-level deep, `SKILL.md` ≤ 500 lines, descriptions must include explicit triggers and a "Do NOT use for..." clause, every action has a `## Test`, and auto-trigger skills ship at least 3 eval scenarios.
 
 ## Technical details
 
 See [`SKILL.md`](SKILL.md) for the full action contract and rules,
-[`actions/skills/`](actions/skills/) for the skill-generation actions,
-`references/naming-conventions.md` for tool-vs-activity naming, and
-`assets/skills/`, `assets/agents/`, `assets/rules/` for the templates.
+`actions/<sub-domain>/` for the sub-domain flows, and the `references/` and `assets/` directories for naming conventions, plugin/marketplace/hook/slash-command specs, and templates.

--- a/plugins/aidd-orchestrator/CATALOG.md
+++ b/plugins/aidd-orchestrator/CATALOG.md
@@ -9,9 +9,6 @@ Auto-generated index of skills, agents, references and assets shipped by the `ai
 - [`.claude-plugin`](#claude-plugin)
 - [`skills`](#skills)
   - [`skills/00-async-dev`](#skills00-async-dev)
-  - [`skills/01-setup-async-dev`](#skills01-setup-async-dev)
-  - [`skills/02-run-async-dev`](#skills02-run-async-dev)
-  - [`skills/03-review-async-dev`](#skills03-review-async-dev)
 
 ---
 
@@ -27,60 +24,8 @@ Auto-generated index of skills, agents, references and assets shipped by the `ai
 
 | Group | File | Description |
 |-------|------|---|
-| `actions` | [01-dispatch.md](skills/00-async-dev/actions/01-dispatch.md) | - |
 | `evals` | [scenarios.json](skills/00-async-dev/evals/scenarios.json) | - |
 | `-` | [README.md](skills/00-async-dev/README.md) | - |
-| `-` | [SKILL.md](skills/00-async-dev/SKILL.md) | `Pure dispatcher for the async-dev pipeline. Use when the user says "async dev", "/async-dev", "claude on issues", or when the entry point is ambiguous (e.g. "set up async dev and run on issue 42"). Detects intent (setup vs run vs review) from `$ARGUMENTS`, trigger source (env, label, PR comment), and repo state, then delegates to the matching specialized skill. Holds no business logic; every step is delegated. Do NOT use when the user explicitly names setup, run, or review (invoke the matching skill directly), or for plain status checks on the async pipeline.` |
-
-#### `skills/01-setup-async-dev`
-
-| Group | File | Description |
-|-------|------|---|
-| `actions` | [01-detect-context.md](skills/01-setup-async-dev/actions/01-detect-context.md) | - |
-| `actions` | [02-ask-config.md](skills/01-setup-async-dev/actions/02-ask-config.md) | - |
-| `actions` | [03-generate-workflow.md](skills/01-setup-async-dev/actions/03-generate-workflow.md) | - |
-| `actions` | [04-generate-local-script.md](skills/01-setup-async-dev/actions/04-generate-local-script.md) | - |
-| `actions` | [05-write-config.md](skills/01-setup-async-dev/actions/05-write-config.md) | - |
-| `actions` | [06-bootstrap-labels.md](skills/01-setup-async-dev/actions/06-bootstrap-labels.md) | - |
-| `actions` | [07-install-user-scope-plugins.md](skills/01-setup-async-dev/actions/07-install-user-scope-plugins.md) | - |
-| `actions` | [08-configure-remote-secrets.md](skills/01-setup-async-dev/actions/08-configure-remote-secrets.md) | - |
-| `actions` | [09-bootstrap-scheduling.md](skills/01-setup-async-dev/actions/09-bootstrap-scheduling.md) | - |
-| `actions` | [10-commit-and-push.md](skills/01-setup-async-dev/actions/10-commit-and-push.md) | - |
-| `actions` | [11-smoke-test.md](skills/01-setup-async-dev/actions/11-smoke-test.md) | - |
-| `assets` | [config-template.json](skills/01-setup-async-dev/assets/config-template.json) | - |
-| `assets` | [local-daemon-template.sh](skills/01-setup-async-dev/assets/local-daemon-template.sh) | - |
-| `assets` | [local-poll-template.sh](skills/01-setup-async-dev/assets/local-poll-template.sh) | - |
-| `evals` | [scenarios.json](skills/01-setup-async-dev/evals/scenarios.json) | - |
-| `-` | [README.md](skills/01-setup-async-dev/README.md) | - |
-| `references` | [auth-modes.md](skills/01-setup-async-dev/references/auth-modes.md) | - |
-| `references` | [claude-action-auth.md](skills/01-setup-async-dev/references/claude-action-auth.md) | - |
-| `references` | [local-mode-scheduling.md](skills/01-setup-async-dev/references/local-mode-scheduling.md) | - |
-| `-` | [SKILL.md](skills/01-setup-async-dev/SKILL.md) | `Installs and configures the aidd-orchestrator plugin end-to-end in a target repo, up to and including the first triggered run. Use when the user runs "/setup async dev", "configure async dev", "install async-dev plugin", or asks to set up Claude auto-implementation on issues. Do NOT use for running the async pipeline (use the run skill) or handling PR review loops (use the review skill).` |
-
-#### `skills/02-run-async-dev`
-
-| Group | File | Description |
-|-------|------|---|
-| `actions` | [01-poll-ready.md](skills/02-run-async-dev/actions/01-poll-ready.md) | - |
-| `actions` | [02-resolve-deps.md](skills/02-run-async-dev/actions/02-resolve-deps.md) | - |
-| `actions` | [03-acquire-lock.md](skills/02-run-async-dev/actions/03-acquire-lock.md) | - |
-| `actions` | [04-check-sdlc.md](skills/02-run-async-dev/actions/04-check-sdlc.md) | - |
-| `actions` | [05-delegate-sdlc.md](skills/02-run-async-dev/actions/05-delegate-sdlc.md) | - |
-| `actions` | [06-write-audit.md](skills/02-run-async-dev/actions/06-write-audit.md) | - |
-| `evals` | [scenarios.json](skills/02-run-async-dev/evals/scenarios.json) | - |
-| `-` | [README.md](skills/02-run-async-dev/README.md) | - |
-| `-` | [SKILL.md](skills/02-run-async-dev/SKILL.md) | `Runs one async development pipeline cycle: polls issues labeled with the `to-implement` label (or its mention equivalent), resolves dependencies, locks the issue with `claude/working`, delegates implementation to whichever SDLC capability is loaded at runtime, verifies the outcome against the real state of git and the VCS host, and writes a `run-result.json` artifact for the workflow's post-job to finalize lifecycle effects. Use when a fresh issue is labeled or mentioned for implementation, or when the user says "run async dev", "implement ready issues", "process the async queue". Do NOT use for setup or for handling change-request review comment loops; other skills in this plugin cover those.` |
-
-#### `skills/03-review-async-dev`
-
-| Group | File | Description |
-|-------|------|---|
-| `actions` | [01-collect-comments.md](skills/03-review-async-dev/actions/01-collect-comments.md) | - |
-| `actions` | [02-detect-stop.md](skills/03-review-async-dev/actions/02-detect-stop.md) | - |
-| `actions` | [03-fix-iteration.md](skills/03-review-async-dev/actions/03-fix-iteration.md) | - |
-| `actions` | [04-finalize.md](skills/03-review-async-dev/actions/04-finalize.md) | - |
-| `evals` | [scenarios.json](skills/03-review-async-dev/evals/scenarios.json) | - |
-| `-` | [README.md](skills/03-review-async-dev/README.md) | - |
-| `references` | [stop-conditions.md](skills/03-review-async-dev/references/stop-conditions.md) | - |
-| `-` | [SKILL.md](skills/03-review-async-dev/SKILL.md) | `Handles the post-PR review-fix loop for runs created by this plugin's run skill. Triggered when the human labels the linked issue with `to-review` (or comments `@claude /review` on the PR). Collects review comments, decides whether to keep iterating, delegates fixes to whichever SDLC capability is loaded at runtime, replies to each addressed comment, resolves the threads, and posts a structured summary when stop conditions trigger. Use when the user (or a webhook / cron) says "handle review comments", "iterate on PR <n>", "address review feedback automatically", or invokes this skill on a specific PR. Do NOT use for the initial implementation or for setup; other skills in this plugin cover those.` |
+| `references` | [routing.md](skills/00-async-dev/references/routing.md) | - |
+| `-` | [SKILL.md](skills/00-async-dev/SKILL.md) | `Single entry point for the async-dev pipeline (setup, run, review). Hybrid router decides which sub-flow to execute from $ARGUMENTS keyword (`setup` / `run` / `review`), trigger source (label `to-implement` / `to-review`, comment `@claude /implement` / `/review`), repo state (workflow + config presence, PR linked to issue), or natural-language intent. Use when the user says "set up async dev", "run async dev on issue #N", "address review on PR #N", "/async-dev", "claude on issues", or when triggered by a webhook with the matching labels or comments. Do NOT use for plain status checks on the async pipeline or for SDLC orchestration unrelated to issue/PR automation.` |
 


### PR DESCRIPTION
## Summary

`aidd-context:03:context-generate` now produces seven artifact types (skills, agents, rules, commands, hooks, plugins, marketplaces) since #128. Documentation surfaces still listed only the original three. Refresh.

## Files

- `plugins/aidd-context/.claude-plugin/plugin.json` description
- `.claude-plugin/marketplace.json` aidd-context entry description
- `README.md` aidd-context card
- `plugins/aidd-context/README.md` tagline + skills table row
- `plugins/aidd-context/skills/03-context-generate/README.md` full rewrite (enumerates seven artifacts + sub-flow entry points)
- `plugins/aidd-orchestrator/CATALOG.md` regenerated to match on-disk content

## Test plan

- [x] `claude plugin validate` on aidd-context still green
- [x] Catalog regeneration produces no further diff
- [x] No source-code change; doc-only refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)