### PR TITLE
chore(release-please): pin plugins to release-as 1.0.0 for v4 marketplace cut

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -25,6 +25,7 @@
     },
     "plugins/aidd-context": {
       "package-name": "aidd-context",
+      "release-as": "1.0.0",
       "extra-files": [
         {
           "type": "json",
@@ -35,6 +36,7 @@
     },
     "plugins/aidd-dev": {
       "package-name": "aidd-dev",
+      "release-as": "1.0.0",
       "extra-files": [
         {
           "type": "json",
@@ -45,6 +47,7 @@
     },
     "plugins/aidd-vcs": {
       "package-name": "aidd-vcs",
+      "release-as": "1.0.0",
       "extra-files": [
         {
           "type": "json",
@@ -66,6 +69,7 @@
     },
     "plugins/aidd-orchestrator": {
       "package-name": "aidd-orchestrator",
+      "release-as": "1.0.0",
       "extra-files": [
         {
           "type": "json",
@@ -76,6 +80,7 @@
     },
     "plugins/aidd-refine": {
       "package-name": "aidd-refine",
+      "release-as": "1.0.0",
       "extra-files": [
         {
           "type": "json",


### PR DESCRIPTION
## Summary

Commit `5b0fc9d` carries `Release-As: 4.0.0`. release-please applies that footer to **every** package, so PR #77 currently bumps all 5 unrestricted plugins to 4.0.0 alongside the marketplace.

Intent for the v4 cut:

- **Marketplace** -> `4.0.0` (first OSS-ready stable)
- **Plugins** -> `1.0.0` (first stable of each plugin)
- After this cut, plugins follow natural semver from 1.0.0 forward.

## Change

Pin `release-as: "1.0.0"` for each plugin in `release-please-config.json`. `aidd-pm` was already pinned; this commit adds the same line for `aidd-context`, `aidd-dev`, `aidd-vcs`, `aidd-orchestrator`, `aidd-refine`. Marketplace (`.`) stays unpinned so the global `Release-As: 4.0.0` footer drives it to 4.0.0.

## Verification

After merge of this PR, release-please will regenerate PR #77 with:

| Package | Now in manifest | Proposed after this PR |
|---|---|---|
| `.` (marketplace) | 3.9.1 | 4.0.0 |
| aidd-context | 1.0.0 | 1.0.0 |
| aidd-dev | 1.0.0 | 1.0.0 |
| aidd-vcs | 1.0.0 | 1.0.0 |
| aidd-pm | 1.0.0 | 1.0.0 (already pinned) |
| aidd-orchestrator | 1.0.0 | 1.0.0 |
| aidd-refine | 1.0.0 | 1.0.0 |

## Follow-up (required after PR #77 merges)

Remove the per-plugin `release-as` pins so future feat / fix commits drive natural semver (e.g. aidd-context 1.0.0 -> 1.1.0 on next feat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)