### PR TITLE
chore: refresh stale references to deleted async-dev skills + three-artifact context-generate

### DIFF
--- a/plugins/aidd-context/hooks/routing/tests/held-out-prompts.json
+++ b/plugins/aidd-context/hooks/routing/tests/held-out-prompts.json
@@ -78,9 +78,9 @@
   { "prompt": "challenge this", "expect": "aidd-refine:02-challenge", "category": "challenge-en" },
   { "prompt": "brainstorm", "expect": "aidd-refine:01-brainstorm", "category": "brainstorm-en" },
 
-  { "prompt": "setup async dev", "expect": "aidd-orchestrator:01-setup-async-dev", "category": "orch-setup-en" },
-  { "prompt": "run async pipeline", "expect": "aidd-orchestrator:02-run-async-dev", "category": "orch-run-en" },
-  { "prompt": "handle review feedback", "expect": "aidd-orchestrator:03-review-async-dev", "category": "orch-review-en" },
+  { "prompt": "setup async dev", "expect": "aidd-orchestrator:00-async-dev", "category": "orch-setup-en" },
+  { "prompt": "run async pipeline", "expect": "aidd-orchestrator:00-async-dev", "category": "orch-run-en" },
+  { "prompt": "handle review feedback", "expect": "aidd-orchestrator:00-async-dev", "category": "orch-review-en" },
 
   { "prompt": "list all skills", "expect": "aidd-context:06-discovery", "category": "discovery" },
   { "prompt": "what hooks are installed", "expect": "aidd-context:06-discovery", "category": "discovery" },

--- a/plugins/aidd-context/skills/02-project-init/assets/README.md
+++ b/plugins/aidd-context/skills/02-project-init/assets/README.md
@@ -36,12 +36,12 @@ Skills are grouped into plugins by domain. Install only the plugins you need.
 
 | Plugin            | Purpose                                                                            | Example skills                                              |
 | ----------------- | ---------------------------------------------------------------------------------- | ----------------------------------------------------------- |
-| aidd-context      | Bootstrap, project init, context generation, mermaid diagrams, learn, discovery    | `02:project-init`, `03:context-generate`, `04:mermaid`      |
+| aidd-context      | Bootstrap, project init, generation of Claude Code context artifacts (skills, agents, rules, commands, hooks, plugins, marketplaces), mermaid diagrams, learn, discovery | `02:project-init`, `03:context-generate`, `04:mermaid`      |
 | aidd-refine       | Meta-cognition: brainstorm, challenge prior work, condensed communication mode     | `01:brainstorm`, `02:challenge`, `03:condense`              |
 | aidd-pm           | Product management: ticket info, user stories, PRD, spec                            | `01:ticket-info`, `02:user-stories-create`, `03:prd`, `05:spec` |
 | aidd-dev          | Code transformation: Dev SDLC orchestrator, plan, implement, assert, audit, review, test, refactor, debug, for-sure | `00:sdlc`, `01:plan`, `02:implement`, `05:review`, `06:test` |
 | aidd-vcs          | VCS workflows: commit, pull/merge request, release tag, issue creation             | `01:commit`, `02:pull-request`, `04:issue-create`           |
-| aidd-orchestrator | Async orchestration of the SDLC on labeled issues (optional, extra)                | `02:run-async-dev`, `03:review-async-dev`                   |
+| aidd-orchestrator | Async orchestration of the SDLC on labeled issues (optional, extra)                | `00:async-dev` (router with setup / run / review sub-flows) |
 
 > See [CATALOG.md](../../../../../docs/CATALOG.md) for the exhaustive list of skills and actions.
 


### PR DESCRIPTION
## Summary

Pre-release sweep found two surfaces still referencing the pre-refactor state.

### Fixed

- \`plugins/aidd-context/skills/02-project-init/assets/README.md\` (template that gets injected into user projects):
  - \`aidd-context\` row now lists the seven generated artifacts.
  - \`aidd-orchestrator\` row now references the single \`00-async-dev\` router instead of the three deleted skills.
- \`plugins/aidd-context/hooks/routing/tests/held-out-prompts.json\`: 3 routing eval prompts now expect \`aidd-orchestrator:00-async-dev\` instead of the deleted \`01-setup\` / \`02-run\` / \`03-review\` slugs.

### Not fixed (intentional)

- \`UPGRADE.md\` v4 → v4.1 appendix migration table still mentions the old slugs - that's the migration guide, not a stale reference.
- Generic tagline-style \"skills, agents, rules\" mentions in root README + project-init template - pre-existing phrasing, not capability lists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)