### PR TITLE
chore(release-please): drop per-plugin release-as pins after v4.0.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -25,7 +25,6 @@
     },
     "plugins/aidd-context": {
       "package-name": "aidd-context",
-      "release-as": "1.0.0",
       "extra-files": [
         {
           "type": "json",
@@ -36,7 +35,6 @@
     },
     "plugins/aidd-dev": {
       "package-name": "aidd-dev",
-      "release-as": "1.0.0",
       "extra-files": [
         {
           "type": "json",
@@ -47,7 +45,6 @@
     },
     "plugins/aidd-vcs": {
       "package-name": "aidd-vcs",
-      "release-as": "1.0.0",
       "extra-files": [
         {
           "type": "json",
@@ -58,7 +55,6 @@
     },
     "plugins/aidd-pm": {
       "package-name": "aidd-pm",
-      "release-as": "1.0.0",
       "extra-files": [
         {
           "type": "json",
@@ -69,7 +65,6 @@
     },
     "plugins/aidd-orchestrator": {
       "package-name": "aidd-orchestrator",
-      "release-as": "1.0.0",
       "extra-files": [
         {
           "type": "json",
@@ -80,7 +75,6 @@
     },
     "plugins/aidd-refine": {
       "package-name": "aidd-refine",
-      "release-as": "1.0.0",
       "extra-files": [
         {
           "type": "json",


### PR DESCRIPTION
## Summary

Post-release cleanup. The v4.0.0 cut pinned every plugin to `release-as: "1.0.0"` so they would not slide to 4.0.0 alongside the marketplace. Those tags now exist (`aidd-context-v1.0.0` ... `aidd-refine-v1.0.0`).

Remove the six `release-as: "1.0.0"` pins so the next release cycle follows natural semver per plugin:

- `feat:` -> minor bump (1.0.0 -> 1.1.0)
- `fix:` / `refactor:` -> patch bump (1.0.0 -> 1.0.1)

The marketplace (`.`) was never pinned and continues from 4.0.0.

## Verification

After merge, the next release-please PR proposes per-plugin versions derived only from conventional commits since each `aidd-*-v1.0.0` tag. No package is forced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)