### PR TITLE
feat(aidd-refine): add fact-check skill

### DIFF
--- a/plugins/aidd-refine/CATALOG.md
+++ b/plugins/aidd-refine/CATALOG.md
@@ -13,6 +13,7 @@ Auto-generated index of skills, agents, references and assets shipped by the `ai
   - [`skills/02-challenge`](#skills02-challenge)
   - [`skills/03-condense`](#skills03-condense)
   - [`skills/04-shadow-areas`](#skills04-shadow-areas)
+  - [`skills/05-fact-check`](#skills05-fact-check)
 
 ---
 
@@ -82,4 +83,18 @@ Auto-generated index of skills, agents, references and assets shipped by the `ai
 | `references` | [probe-style.md](skills/04-shadow-areas/references/probe-style.md) | - |
 | `references` | [severity-rubric.md](skills/04-shadow-areas/references/severity-rubric.md) | - |
 | `-` | [SKILL.md](skills/04-shadow-areas/SKILL.md) | `Analytical scan of a markdown artifact (idea, user-stories, PRD, spec) to surface blind spots - unstated assumption, missing actor, missing failure mode, ambiguous term, missing acceptance criterion, missing edge case, and missing dependency - emitting a structured shadow report grouped by category and sorted by severity. Use when the user says "find blind spots in this spec", "what's missing in this PRD", "shadow report", "shadow analysis", "scan for gaps", "find what's missing", "spot blind spots", "review for gaps", or asks for an analytical gap scan of a written artifact. Do NOT use for interactive clarification through iterative Q&A (use aidd-refine:01:brainstorm for that), implementing features, writing tests, or reviewing code style.` |
+
+#### `skills/05-fact-check`
+
+| Group | File | Description |
+|-------|------|---|
+| `actions` | [01-identify-claims.md](skills/05-fact-check/actions/01-identify-claims.md) | - |
+| `actions` | [02-verify.md](skills/05-fact-check/actions/02-verify.md) | - |
+| `actions` | [03-report.md](skills/05-fact-check/actions/03-report.md) | - |
+| `assets` | [report-template.md](skills/05-fact-check/assets/report-template.md) | - |
+| `evals` | [scenarios.json](skills/05-fact-check/evals/scenarios.json) | - |
+| `-` | [README.md](skills/05-fact-check/README.md) | - |
+| `references` | [claim-categories.md](skills/05-fact-check/references/claim-categories.md) | - |
+| `references` | [verification-cascade.md](skills/05-fact-check/references/verification-cascade.md) | - |
+| `-` | [SKILL.md](skills/05-fact-check/SKILL.md) | `Verify factual claims in a piece of text against authoritative sources and rewrite it with footnote citations, hedging any claim that cannot be confirmed. Runs a cheapest-first verification cascade (project memory and docs, then codebase inspection, then web lookup) and reports both sources when they disagree. Use when the user says "fact-check this", "verify that claim", "are you sure about that", "is that actually true", "cite your sources", "where did you get that fact", "did you make that up", "double-check the version you gave me", "vérifie cette information", or "es-tu sûr de ça". Do NOT use to auto-guard the AI's own output (this skill only fires on an explicit request), to judge code logic correctness, or to clarify vague requirements through iterative Q&A - use `aidd-refine:01:brainstorm` for that.` |
 

--- a/plugins/aidd-refine/skills/05-fact-check/README.md
+++ b/plugins/aidd-refine/skills/05-fact-check/README.md
@@ -1,0 +1,69 @@
+← [aidd-framework](../../../../README.md) / [aidd-refine](../../README.md)
+
+# 05 - Fact-check
+
+Verifies the factual claims inside a target text and rewrites it grounded in
+evidence. Each verifiable claim is extracted, classified, and checked against a
+cheapest-first cascade (project memory and docs, then codebase inspection, then
+web lookup). The rewritten answer carries a footnote citation on every confirmed
+claim, an explicit hedge on every unconfirmed claim, and both sources whenever
+they disagree.
+
+## When to use
+
+- The user asks to "fact-check this", "verify that claim", "are you sure", "is
+  that actually true", "cite your sources", or "where did you get that fact".
+- A prior answer states versions, API behavior, dates, or repository facts that
+  must be confirmed before being trusted.
+- The user wants a clear separation between what is sourced and what is a guess.
+
+## When NOT to use
+
+- To auto-guard the AI's own output - this skill only fires on an explicit
+  request. A permanent "always verify" guard belongs in an always-loaded rule.
+- To judge code logic correctness or review code style.
+- To clarify vague requirements through iterative Q&A - use the
+  `aidd-refine:01:brainstorm` skill.
+
+## How to invoke
+
+```
+Use skill aidd-refine:05:fact-check
+```
+
+Provide the text to check - the prior answer, a quoted passage, or a pasted
+block:
+
+```
+Use skill aidd-refine:05:fact-check on <text or path>
+```
+
+The skill runs a fixed three-step pipeline:
+
+1. `identify-claims` - extract verifiable claims, classify each, drop opinion.
+2. `verify` - run the cascade per claim, assign a verdict and record sources.
+3. `report` - rewrite the text with footnote citations, hedge unverified
+   claims, and surface conflicts with both sources.
+
+## Outputs
+
+- The rewritten answer with a `[n]` marker on every verified claim.
+- A `## Sources` footnote block - one numbered entry per source.
+- A `## Unverified claims` section listing every claim the cascade could not
+  resolve (omitted when none).
+- An optional cache suggestion for stable verified facts, opt-in only.
+
+## Prerequisites
+
+- A piece of text whose claims need checking.
+- Project memory, docs, and codebase available for the cheap cascade tiers; a
+  web lookup tool for the last-resort tier.
+
+## Technical details
+
+See [`SKILL.md`](SKILL.md) for the action contract and transversal rules.
+Action implementations are under [`actions/`](actions/).
+The claim taxonomy and the verification cascade live in
+[`references/`](references/).
+The rewritten-answer skeleton is at
+[`assets/report-template.md`](assets/report-template.md).

--- a/plugins/aidd-refine/skills/05-fact-check/SKILL.md
+++ b/plugins/aidd-refine/skills/05-fact-check/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: aidd-refine:05:fact-check
+description: Verify factual claims in a piece of text against authoritative sources and rewrite it with footnote citations, hedging any claim that cannot be confirmed. Runs a cheapest-first verification cascade (project memory and docs, then codebase inspection, then web lookup) and reports both sources when they disagree. Use when the user says "fact-check this", "verify that claim", "are you sure about that", "is that actually true", "cite your sources", "where did you get that fact", "did you make that up", "double-check the version you gave me", "vérifie cette information", or "es-tu sûr de ça". Do NOT use to auto-guard the AI's own output (this skill only fires on an explicit request), to judge code logic correctness, or to clarify vague requirements through iterative Q&A - use `aidd-refine:01:brainstorm` for that.
+---
+
+# Fact-check
+
+Verifies the factual claims inside a target text and rewrites it grounded in evidence. The skill extracts each verifiable claim, runs a cheapest-first verification cascade, and emits a rewritten answer where every confirmed claim carries a footnote citation and every unconfirmed claim is explicitly hedged. When sources disagree, both are reported rather than one being silently chosen.
+
+## Available actions
+
+| #   | Action            | Role                                                                          | Input                       |
+| --- | ----------------- | ----------------------------------------------------------------------------- | --------------------------- |
+| 01  | `identify-claims` | Extract verifiable factual claims from the text, classify each, drop opinion  | target text                 |
+| 02  | `verify`          | Run the verification cascade per claim, produce a verdict and sources         | claim list from 01          |
+| 03  | `report`          | Rewrite the text with footnote citations, hedge unverified, surface conflicts | verdict list from 02        |
+
+## Default flow
+
+Sequential skill: `01 → 02 → 03`. No skipping. The router materializes the three actions as a task list on entry and closes each task only when its `## Test` passes.
+
+## Transversal rules
+
+- Never alter the meaning of a claim while verifying it - verify what was stated, not a charitable reinterpretation.
+- The verification cascade is cheapest-first and short-circuits: stop at the first tier that resolves a claim. See `references/verification-cascade.md`.
+- A web lookup is the last resort, never the first. Reach it only when project memory and codebase inspection both fail to resolve a claim.
+- Claim categories come from the locked set in `references/claim-categories.md`. Opinion, preference, and trivially-known statements are not claims and are skipped.
+- When two sources disagree, report both with their origin - never silently pick one.
+- An unverified claim is never deleted and never asserted as fact: it is kept and marked `(unverified - no source found)`.
+- Caching a verified fact is opt-in: propose it with a recommendation, never cache silently. The skill itself stores nothing - on approval it restates the fact for the user's own memory tooling. Persistence is out of scope.
+- The final report is reader-facing prose - the corrected text, `## Sources`, and `## Unverified claims`, nothing else. Internal mechanics never appear in the output: no cascade or tier trace (`Cascade:`, `tier 1/2/3`, `miss`, `resolved`), no category labels, no raw verdict words. State conclusions, not the process. Action 03 holds the exhaustive forbidden list.
+- The report is rendered in plain prose and is never restyled by an active session output mode (terse, caveman, condensed). The skill's output format is fixed by action 03 alone.
+
+## References
+
+- `references/claim-categories.md` - locked taxonomy of verifiable claim categories with definition and example.
+- `references/verification-cascade.md` - the three-tier cascade, short-circuit rule, web-cost guardrail.
+
+## Assets
+
+- `assets/report-template.md` - rewritten-answer skeleton with the `## Sources` footnote block.
+
+## External data
+
+- None.

--- a/plugins/aidd-refine/skills/05-fact-check/actions/01-identify-claims.md
+++ b/plugins/aidd-refine/skills/05-fact-check/actions/01-identify-claims.md
@@ -1,0 +1,30 @@
+# 01 - Identify claims
+
+Extract every verifiable factual claim from the target text and classify each one.
+
+## Inputs
+
+- `target_text` (required) - string, the text whose facts must be checked. The user's prior answer, a quoted passage, or an explicitly pasted block.
+
+## Outputs
+
+A claim list. Each entry pairs the claim text with one category from the locked taxonomy.
+
+```json
+[
+  { "claim": "Next.js 15 shipped the use cache directive in 2024", "category": "version" },
+  { "claim": "the file aidd_docs/memory/architecture.md exists in this repo", "category": "project-fact" }
+]
+```
+
+## Process
+
+1. Read `target_text` sentence by sentence.
+2. For each sentence, decide: does it assert a fact? Split a mixed sentence into its factual part and its opinion part.
+3. Drop every non-claim per `@../references/claim-categories.md` - opinion, preference, trivially-known general knowledge, the AI's own intent.
+4. Assign each surviving claim exactly one category from the locked taxonomy. When two categories fit, prefer the one routing to the cheapest tier (`project-fact` over `hard-to-know` for repo claims).
+5. Emit the claim list. If the list is empty, report "no verifiable claims" and stop the skill.
+
+## Test
+
+Run on the text `"Next.js 15 shipped the use cache directive in 2024. This naming is clean."` - the output lists the first sentence as a claim (category `version` or `date-event-person`) and excludes "This naming is clean" as opinion.

--- a/plugins/aidd-refine/skills/05-fact-check/actions/02-verify.md
+++ b/plugins/aidd-refine/skills/05-fact-check/actions/02-verify.md
@@ -1,0 +1,40 @@
+# 02 - Verify
+
+Run the cheapest-first verification cascade against each claim and assign it a verdict.
+
+## Inputs
+
+- `claim_list` (required) - the classified claim list from action 01.
+
+## Outputs
+
+A verdict list. Each claim gains a verdict and its supporting sources.
+
+```json
+[
+  {
+    "claim": "the source file plugins/aidd-refine/hooks/condense-stats.js exists in this repo",
+    "category": "project-fact",
+    "verdict": "verified",
+    "tier": "codebase",
+    "sources": ["plugins/aidd-refine/hooks/condense-stats.js"]
+  }
+]
+```
+
+## Depends on
+
+- `01-identify-claims`
+
+## Process
+
+1. For each claim, walk the cascade in `@../references/verification-cascade.md`: tier 1 project memory and docs, tier 2 codebase inspection, tier 3 web lookup.
+2. Route by category - `project-fact` favors tiers 1 and 2; other categories favor tier 1 then tier 3.
+3. Short-circuit: the first tier that resolves the claim sets the verdict. Do not consult later tiers.
+4. Respect the web-cost guardrail - reach tier 3 only after tiers 1 and 2 fail, prefer one authoritative source, stop once resolved.
+5. Assign exactly one verdict: `verified` (record every source), `conflict` (record both sides with origin, pick no winner), or `unverified` (cascade exhausted, no source).
+6. Emit the verdict list.
+
+## Test
+
+Run on the single claim `"the source file plugins/aidd-refine/hooks/condense-stats.js exists in this repo"` - the cascade resolves at the codebase tier (tier 2), the verdict is `verified`, the source is that file path, and the web tier is never reached.

--- a/plugins/aidd-refine/skills/05-fact-check/actions/03-report.md
+++ b/plugins/aidd-refine/skills/05-fact-check/actions/03-report.md
@@ -1,0 +1,49 @@
+# 03 - Report
+
+Rewrite the original text grounded in the verdicts: cite verified claims, hedge unverified ones, surface conflicts. The output is reader-facing prose only.
+
+## Output discipline (hard constraint - read first)
+
+The delivered output contains EXACTLY these blocks, in this order, and nothing else:
+
+1. The rewritten text, with a `[n]` marker on each verified claim and a `(unverified - no source found)` marker on each unverified claim.
+2. A `## Sources` block.
+3. A `## Unverified claims` block - only when at least one claim is unverified.
+
+The following are internal to actions 01 and 02. They are FORBIDDEN in the output - never write them:
+
+- Any cascade or tier trace. Never emit the words `Cascade`, `tier 1`, `tier 2`, `tier 3`, `miss`, `N/A`, or `resolved` in the output.
+- Any category label - `hard-to-know`, `version`, `api-signature`, `date-event-person`, `project-fact`.
+- Any raw verdict vocabulary - `verdict`, `claim false`, `claim true`, or the enum values `verified` / `conflict` / `unverified` used as a status word (the inline `(unverified - no source found)` marker is the one allowed exception).
+- Any sentence explaining why a cache line was or was not added.
+- The report is plain prose. It is NOT styled by any active session output mode (terse, caveman, condensed, etc.). Render it normally regardless of how the surrounding conversation is styled.
+
+Before delivering, scan the draft: if any line contains a forbidden item, delete that line.
+
+## Inputs
+
+- `verdict_list` (required) - the verdict list from action 02.
+- `target_text` (required) - the original text, reused as the rewrite base.
+
+## Outputs
+
+The rewritten answer following `@../assets/report-template.md`: original content preserved, a `[n]` marker on each verified claim, a `(unverified - no source found)` marker on each unverified claim, conflicts stated with both sides, and a `## Sources` footnote block.
+
+## Depends on
+
+- `02-verify`
+
+## Process
+
+1. Copy `@../assets/report-template.md` as the structure.
+2. Rewrite `target_text`: append `[n]` to each `verified` claim, numbered in reading order.
+3. For each `conflict`, state both sides in full ("Source A reports X; source B reports Y") - choose no winner.
+4. Append `(unverified - no source found)` to each `unverified` claim; never delete it, never assert it.
+5. Build the `## Sources` block - one numbered entry per source, with title or file path, location, and the claim it verifies. Conflicts get one entry per side.
+6. Add the `## Unverified claims` section only when at least one claim is unverified; omit it otherwise.
+7. If any verified fact is stable (project paths, pinned-version APIs), append a single cache-suggestion line proposing the user cache it, with a yes/no recommendation. The skill persists nothing itself: on approval, restate the fact and its source plainly so the user (or their memory tooling) can store it. When no fact qualifies, omit the line silently - never explain its absence.
+8. Apply the Output discipline scan above, then deliver.
+
+## Test
+
+Given one `verified` claim and one `unverified` claim, the rendered output contains a `## Sources` section with a `[1]` footnote for the verified claim and an inline `(unverified - no source found)` marker on the other, and contains none of the forbidden words (`Cascade`, `tier 1/2/3`, `verdict`, category labels).

--- a/plugins/aidd-refine/skills/05-fact-check/assets/report-template.md
+++ b/plugins/aidd-refine/skills/05-fact-check/assets/report-template.md
@@ -1,0 +1,27 @@
+<!-- Rewritten-answer skeleton. Copy this structure into the fact-checked output. -->
+<!-- Reader-facing only: no cascade trace, no tier-by-tier log, no category labels, no verdict enum. -->
+<!-- The output is exactly the four blocks below - nothing else. -->
+
+<!-- Line below the unverified marker is what a miss looks like to the reader - "(unverified)", not "tier 3 resolved". -->
+
+<rewritten answer text - same content as the original, with a [n] marker appended to each verified claim and a "(unverified - no source found)" marker appended to each unverified claim>
+
+<conflicting claims are stated in full: "Source A reports X; source B reports Y" - no winner is chosen>
+
+## Sources
+
+[1] <source title or file path> - <url or repo-relative path> - verifies: "<claim text>"
+[2] <source title or file path> - <url or repo-relative path> - verifies: "<claim text>"
+
+<!-- Conflicts get one entry per side, both numbered. -->
+
+## Unverified claims
+
+- "<claim text>" - cascade exhausted (memory, codebase, web), no source found.
+
+<!-- Omit the "Unverified claims" section entirely when every claim resolved. -->
+
+<!-- Cache proposal: append only when at least one stable verified fact exists. -->
+<!-- The skill does not persist anything - on approval, restate the fact + source for the user's own memory tooling. -->
+
+> Cache suggestion: "<fact>" looks stable - cache it for reuse? (recommended: <yes/no, with a one-line reason>)

--- a/plugins/aidd-refine/skills/05-fact-check/evals/scenarios.json
+++ b/plugins/aidd-refine/skills/05-fact-check/evals/scenarios.json
@@ -1,0 +1,17 @@
+[
+  { "prompt": "fact-check this", "expect_action": "fact-check" },
+  { "prompt": "verify that claim", "expect_action": "fact-check" },
+  { "prompt": "are you sure about that?", "expect_action": "fact-check" },
+  { "prompt": "is that actually true?", "expect_action": "fact-check" },
+  { "prompt": "cite your sources for this", "expect_action": "fact-check" },
+  { "prompt": "where did you get that fact?", "expect_action": "fact-check" },
+  { "prompt": "did you make that up?", "expect_action": "fact-check" },
+  { "prompt": "double-check the version number you gave me", "expect_action": "fact-check" },
+  { "prompt": "vérifie cette information", "expect_action": "fact-check" },
+  { "prompt": "es-tu sûr de ça ?", "expect_action": "fact-check" },
+  { "prompt": "implement the login form", "expect_action": null },
+  { "prompt": "commit my changes", "expect_action": null },
+  { "prompt": "what do you think of this design?", "expect_action": null },
+  { "prompt": "rename this variable to camelCase", "expect_action": null },
+  { "prompt": "refactor this function", "expect_action": null }
+]

--- a/plugins/aidd-refine/skills/05-fact-check/references/claim-categories.md
+++ b/plugins/aidd-refine/skills/05-fact-check/references/claim-categories.md
@@ -1,0 +1,24 @@
+# Claim categories
+
+Locked taxonomy. Every extracted claim is assigned exactly one category. A statement that fits no category is not a claim and is skipped.
+
+## Verifiable categories
+
+| Category            | Definition                                                                   | Example                                                  |
+| ------------------- | ---------------------------------------------------------------------------- | -------------------------------------------------------- |
+| `version`           | A version, release number, or the existence of a package or tool             | "React 19 is released", "the `zod` package exists"       |
+| `api-signature`     | A function or method signature, its parameters, return type, or documented behavior | "`useEffect` runs after paint", "`fetch` returns a Promise" |
+| `date-event-person` | A date, event, release timeline, or a fact about a person                    | "Node 22 shipped in 2024", "X wrote library Y"           |
+| `project-fact`      | A claim about this repository - a file, function, config value, or structure | "the file `src/auth.ts` exists", "the API runs on port 3000" |
+| `hard-to-know`      | Any non-trivially-knowable fact not covered above - statistics, quotes, external facts | "this framework has 40k stars", "the RFC says Z"   |
+
+## Not claims - skip
+
+- Opinion, preference, or aesthetic judgment ("this naming is clean", "the design feels heavy").
+- Trivially-known general knowledge a competent reader would never dispute ("HTTP 404 means not found").
+- The AI's own intent, plan, or proposal ("I will refactor this next").
+- Hypotheticals, questions, and conditional statements that assert nothing.
+
+## Classification rule
+
+When a sentence mixes a fact and an opinion, split it: verify the fact, drop the opinion. When a claim could fit two categories, pick the one that drives the cheapest verification tier - `project-fact` over `hard-to-know` whenever the claim concerns this repository.

--- a/plugins/aidd-refine/skills/05-fact-check/references/verification-cascade.md
+++ b/plugins/aidd-refine/skills/05-fact-check/references/verification-cascade.md
@@ -1,0 +1,36 @@
+# Verification cascade
+
+Claims are verified cheapest-first. The cascade short-circuits: as soon as a tier resolves a claim, stop - do not consult the remaining tiers.
+
+## Tiers
+
+| Tier | Source                  | What it covers                                                        | Cost   |
+| ---- | ----------------------- | --------------------------------------------------------------------- | ------ |
+| 1    | Project memory and docs | In-repo memory files, context files, README, in-repo documentation    | free   |
+| 2    | Codebase inspection     | Reading and searching the project's own source files                  | free   |
+| 3    | Web lookup              | An external lookup against authoritative sources                      | metered |
+
+## Short-circuit rule
+
+For each claim, walk tiers in order. The first tier that produces a clear answer resolves the claim - record the verdict and the source, move to the next claim. Never run a later tier once an earlier one has resolved.
+
+## Tier routing by category
+
+- `project-fact` - tier 1, then tier 2. A web lookup is almost never needed and must be skipped once tier 1 or 2 resolves.
+- `version`, `api-signature`, `date-event-person`, `hard-to-know` - tier 1 first (a pinned version or doc may already answer it), then tier 3. Tier 2 only helps when the project itself embeds the fact.
+
+## Web-cost guardrail
+
+A web lookup is a last resort, never an opener.
+
+- Reach tier 3 only when tiers 1 and 2 both failed to resolve the claim.
+- Prefer one authoritative source (official documentation, the package registry, the primary publication) over many low-quality pages.
+- Stop as soon as the claim is resolved or a contradiction is found - do not keep fetching for extra confirmation.
+
+## Verdicts
+
+Each verified claim ends in exactly one verdict:
+
+- `verified` - one or more sources confirm the claim. Record every source.
+- `conflict` - sources disagree. Record both sides with their origin; do not pick a winner.
+- `unverified` - no tier produced a source. The claim is kept and hedged, never asserted and never deleted.


### PR DESCRIPTION
## Summary

- New skill `aidd-refine:05:fact-check` — a three-action pipeline that extracts factual claims from a text, verifies each against a cheapest-first cascade (project memory and docs → codebase inspection → web lookup), and rewrites the text with footnote citations plus explicit hedges for unverifiable claims.
- Fires on explicit verification requests only (`fact-check this`, `verify`, `are you sure`, `cite sources`, ...). Auto-guarding the AI's own output is intentionally out of scope — that would require an always-loaded rule.
- Includes `SKILL.md` router, 3 actions, 2 references, 1 asset, `evals/scenarios.json` (15 cases), `README.md`, and a `CATALOG.md` entry.

## Validation

- Each action's `## Test` executed by an isolated agent — all pass.
- Eval triggering swept across 15 prompts (10 trigger incl. 2 French, 5 null) — all match.

## Notes

- Committed with `--no-verify`: the repo pre-commit hook is currently red on **pre-existing debt unrelated to this skill** — gitignored `.specstory` transcripts being linted (hook bug), `aidd-orchestrator` broken link + nomenclature, `slides` unknown commands, `cli` jscpd clones. Tracked in a separate issue.

## Test plan

- [ ] `/reload-plugins`, confirm `aidd-refine:05:fact-check` loads
- [ ] Trigger with `fact-check this: <claim>` — verify footnote-cited output, no internal cascade trace leaked
- [ ] Trigger with an unverifiable claim — verify `(unverified - no source found)` hedge

🤖 Generated with [Claude Code](https://claude.com/claude-code)