### PR TITLE
docs: fix coherence defects in README, docs, and plugin READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ### A community-maintained marketplace of skills, agents, and rules for Claude Code.
 
 <p>
-  <kbd>6 plugins</kbd> · <kbd>30 skills</kbd> · <kbd>3 agents</kbd> · <kbd>MIT</kbd>
+  <kbd>6 plugins</kbd> · <kbd>31 skills</kbd> · <kbd>3 agents</kbd> · <kbd>MIT</kbd>
 </p>
 
 <p>
@@ -67,7 +67,7 @@ Inside any Claude Code session, register this marketplace and install a plugin:
 
 If the marketplace repo is private, `/plugin marketplace add <owner>/<repo>` requires that you be authenticated with read access to that repo (typically via `gh auth login` or a PAT on the machine running Claude Code). See the Anthropic [Discover and install plugins](https://code.claude.com/docs/en/discover-plugins) docs for the full install flow.
 
-Browse the plugin catalog below and install whichever plugins fit your workflow. Each plugin ships its own onboarding skill (`<plugin>:00:onboard`) that walks you through the skills it owns - so once you install `aidd-context`, running `Use skill aidd-context:00:onboard` guides you through that plugin specifically. There is no cross-plugin tour today; pick a plugin from the table below, install it, then run its onboard skill.
+Browse the plugin catalog below and install whichever plugins fit your workflow. The `aidd-context` plugin ships an onboarding skill - after installing it, run `Use skill aidd-context:00:onboard` for a guided tour of that plugin. The other plugins have no onboard skill; pick one from the table below, install it, and consult its README for the skills it owns. There is no cross-plugin tour today.
 
 Prefer browsing inside Claude Code? Run `/plugin` and open the **Discover** tab once the marketplace is registered.
 
@@ -94,7 +94,7 @@ Project init, architecture, generation of Claude Code context artifacts (skills,
 
 `10 skills` · stable
 
-SDLC loop: plan, implement, assert, review, test, refactor, debug.
+SDLC loop: sdlc, plan, implement, assert, audit, review, test, refactor, debug, for-sure.
 
 </td>
 <td width="33%" valign="top">
@@ -119,20 +119,20 @@ Ticket info, user stories, PRD, spec drafting.
 </td>
 <td width="33%" valign="top">
 
+### 🪞 [aidd-refine](plugins/aidd-refine/README.md)
+
+`5 skills` · stable
+
+Meta-cognition: brainstorm, challenge, condense, shadow-areas, fact-check.
+
+</td>
+<td width="33%" valign="top">
+
 ### 🎼 [aidd-orchestrator](plugins/aidd-orchestrator/README.md)
 
 `1 skill` · stable (`async-dev`)
 
 Label an issue, get a PR; re-label, get the review applied. Router-based skill: one entry point, three sub-flows (setup, run, review).
-
-</td>
-<td width="33%" valign="top">
-
-### 🪞 [aidd-refine](plugins/aidd-refine/README.md)
-
-`4 skills` · stable
-
-Meta-cognition: brainstorm, challenge, condense, shadow-areas.
 
 </td>
 </tr>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -101,7 +101,7 @@ Each action is a self-contained markdown file with inputs, outputs, depends-on, 
 
 ## SDLC capability discovery
 
-Two plugins (currently `aidd-dev:00:sdlc` and `aidd-orchestrator`) advertise themselves as SDLC orchestrators in their `description` frontmatter. Other plugins discover them at runtime by matching the description (never by hardcoded plugin name), which keeps the system swappable: replace `aidd-dev` with any plugin that advertises SDLC orchestration and the orchestrator's `02:run-async-dev` skill will delegate to it instead.
+Two plugins (currently `aidd-dev:00:sdlc` and `aidd-orchestrator`) advertise themselves as SDLC orchestrators in their `description` frontmatter. Other plugins discover them at runtime by matching the description (never by hardcoded plugin name), which keeps the system swappable: replace `aidd-dev` with any plugin that advertises SDLC orchestration and the orchestrator's `00:async-dev` skill will delegate to it instead.
 
 ```mermaid
 ---

--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -1,8 +1,6 @@
 # Skills catalog
 
-Aggregated index of every skill across the framework. Sourced from each plugin's `SKILL.md` `description` frontmatter; regenerate by running the same logic the lefthook `summarize-plugin-catalogs` step uses, scoped to the framework root.
-
-Generated: 2026-05-15
+Aggregated index of every skill across the framework. Sourced from each plugin's `SKILL.md` `description` frontmatter; regenerate with `node scripts/generate-skills-catalog.mjs`.
 
 ## aidd-context
 
@@ -41,7 +39,7 @@ VCS workflow plugin for the AI-Driven Development framework.
 
 | Skill | Description |
 |-------|-------------|
-| [`aidd-vcs:01:commit`](../plugins/aidd-vcs/skills/01-commit/README.md) | Create an atomic git commit with conventional message format. Use when the user says "commit", "git commit", "create a commit", "commit my changes", "commit and push", or invokes `/aidd-vcs:01:commit`. Do NOT use for amending existing commits, force-pushing, rebasing, opening pull requests, or release tagging. |
+| [`aidd-vcs:01:commit`](../plugins/aidd-vcs/skills/01-commit/README.md) | Create an atomic git commit with conventional message format. Use when the user says "commit", "git commit", "create a commit", "commit my changes", "commit and push", or invokes `/commit`. Do NOT use for amending existing commits, force-pushing, rebasing, opening pull requests, or release tagging. |
 | [`aidd-vcs:02:pull-request`](../plugins/aidd-vcs/skills/02-pull-request/README.md) | Create a draft pull or merge request from the current branch. Use when the user says "open a pr", "open a pull request", "create a pr", "create a merge request", "open mr", "draft a pr for this branch", or invokes `/pull-request`. Do NOT use for committing changes, pushing a branch directly, tagging releases, merging an existing request, or amending commits. |
 | [`aidd-vcs:03:release-tag`](../plugins/aidd-vcs/skills/03-release-tag/README.md) | Cut a semver release with annotated tag and release notes. Use when the user says "release", "tag", "tag this release", "bump version", "release v1.2.0", "cut a release", or invokes `/release-tag`. Do NOT use for plain commits without a tag, opening pull requests, pushing a branch only, or amending existing tags. |
 | [`aidd-vcs:04:issue-create`](../plugins/aidd-vcs/skills/04-issue-create/README.md) | Create an issue in the configured ticketing tool. Use when the user says "new issue", "create an issue", "file a bug", "file an issue", "report bug", "open an issue", or invokes `/issue-create`. Do NOT use for committing changes, opening pull requests, tagging releases, or commenting on existing issues. |
@@ -57,14 +55,6 @@ Product management plugin for the AI-Driven Development framework.
 | [`aidd-pm:03:prd`](../plugins/aidd-pm/skills/03-prd/README.md) | Generate a structured Product Requirements Document from a feature description or user stories, validated with the user before save. Use when the user says "prd", "draft prd", "write prd", "product requirements for X", "generate a prd", or invokes `/prd`. Do NOT use for writing user stories, drafting a technical implementation plan, or writing source code. |
 | [`aidd-pm:04:spec`](../plugins/aidd-pm/skills/04-spec/README.md) | Generate or refine a project spec from a free-form human request, an existing PRD, or reviewer findings. Use when the user says "draft spec", "spec for X", "refine the spec", "generate spec from prd", "/spec", or when an orchestrator needs a normalized contract before planning. Do NOT use for writing source code, drafting a full PRD, or modifying a validated and locked spec. |
 
-## aidd-orchestrator
-
-Orchestration plugin for the AI-Driven Development framework.
-
-| Skill | Description |
-|-------|-------------|
-| [`aidd-orchestrator:00:async-dev`](../plugins/aidd-orchestrator/skills/00-async-dev/README.md) | Single router-based skill covering the full async-dev pipeline (setup, run, review). Picks the sub-flow from `$ARGUMENTS` keyword (`setup` / `run` / `review`), trigger source (label `to-implement` / `to-review`, comment `@claude /implement` / `/review`), repo state (workflow + config presence, PR linked), or natural-language intent. Use when the user wants to install async-dev, implement a ready issue, address review comments on a PR, or for any webhook-triggered run. Do NOT use for plain status checks or for SDLC orchestration unrelated to issue/PR automation. |
-
 ## aidd-refine
 
 Meta-cognition plugin for the AI-Driven Development framework.
@@ -74,6 +64,16 @@ Meta-cognition plugin for the AI-Driven Development framework.
 | [`aidd-refine:01:brainstorm`](../plugins/aidd-refine/skills/01-brainstorm/README.md) | Interactive brainstorming session to clarify and refine requests through iterative questioning. Use when user mentions unclear requirements, vague ideas, or needs clarification on features. Do NOT use for clear technical specs, implementation details, or when requirements are already well-defined. |
 | [`aidd-refine:02:challenge`](../plugins/aidd-refine/skills/02-challenge/README.md) | Rethink prior work to verify correctness against an agreed plan, classifying findings as deal-breakers, suggestions, or correct, with a confidence score. Use when the user says "challenge this", "rethink your plan", "is this correct", "review my last decision", "challenge my decision", "challenge what you did", "is my decision right", "criticize this", "find flaws", or asks for a critical review of just-completed work. Do NOT use for line-by-line code review against a style guide, implementing features, writing tests, or generating new code. |
 | [`aidd-refine:03:condense`](../plugins/aidd-refine/skills/03-condense/README.md) | Toggle terse output mode with intensity levels (lite, full, ultra) so prose drops articles, filler, and pleasantries while code, quoted errors, and security warnings stay verbatim. Also reports real token usage and estimated savings under condense mode for the current session. Use when the user says "condense", "condense output", "be more concise", "shorter answers", "tighten output", "/condense", "/condense full", "/condense ultra", "stop condense", "normal mode", "/condense-stats", "how much have we saved", or "token savings". Do NOT use for editing existing prose, summarizing a long document, or compressing source code (only output style is affected, not content). |
+| [`aidd-refine:04:shadow-areas`](../plugins/aidd-refine/skills/04-shadow-areas/README.md) | Analytical scan of a markdown artifact (idea, user-stories, PRD, spec) to surface blind spots - unstated assumption, missing actor, missing failure mode, ambiguous term, missing acceptance criterion, missing edge case, and missing dependency - emitting a structured shadow report grouped by category and sorted by severity. Use when the user says "find blind spots in this spec", "what's missing in this PRD", "shadow report", "shadow analysis", "scan for gaps", "find what's missing", "spot blind spots", "review for gaps", or asks for an analytical gap scan of a written artifact. Do NOT use for interactive clarification through iterative Q&A (use aidd-refine:01:brainstorm for that), implementing features, writing tests, or reviewing code style. |
+| [`aidd-refine:05:fact-check`](../plugins/aidd-refine/skills/05-fact-check/README.md) | Verify factual claims in a piece of text against authoritative sources and rewrite it with footnote citations, hedging any claim that cannot be confirmed. Runs a cheapest-first verification cascade (project memory and docs, then codebase inspection, then web lookup) and reports both sources when they disagree. Use when the user says "fact-check this", "verify that claim", "are you sure about that", "is that actually true", "cite your sources", "where did you get that fact", "did you make that up", "double-check the version you gave me", "vérifie cette information", or "es-tu sûr de ça". Do NOT use to auto-guard the AI's own output (this skill only fires on an explicit request), to judge code logic correctness, or to clarify vague requirements through iterative Q&A - use `aidd-refine:01:brainstorm` for that. |
+
+## aidd-orchestrator
+
+Orchestration plugin for the AI-Driven Development framework.
+
+| Skill | Description |
+|-------|-------------|
+| [`aidd-orchestrator:00:async-dev`](../plugins/aidd-orchestrator/skills/00-async-dev/README.md) | Single entry point for the async-dev pipeline (setup, run, review). Hybrid router decides which sub-flow to execute from $ARGUMENTS keyword (`setup` / `run` / `review`), trigger source (label `to-implement` / `to-review`, comment `@claude /implement` / `/review`), repo state (workflow + config presence, PR linked to issue), or natural-language intent. Use when the user says "set up async dev", "run async dev on issue #N", "address review on PR #N", "/async-dev", "claude on issues", or when triggered by a webhook with the matching labels or comments. Do NOT use for plain status checks on the async pipeline or for SDLC orchestration unrelated to issue/PR automation. |
 
 ## See also
 

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -52,7 +52,7 @@ A GitHub label the `async-dev` use case uses to track an issue through the pipel
 
 ## `claude/working` lock
 
-The label the `run-async-dev` skill adds to an issue at the start of a run and removes when the PR opens. It exists to prevent two concurrent agents from picking up the same issue. It is set after dependency resolution and before any code is written.
+The label the `async-dev` skill adds to an issue at the start of a run and removes when the PR opens. It exists to prevent two concurrent agents from picking up the same issue. It is set after dependency resolution and before any code is written.
 
 ## Run id
 

--- a/plugins/aidd-dev/README.md
+++ b/plugins/aidd-dev/README.md
@@ -8,7 +8,7 @@ Code transformation plugin for the AI-Driven Development framework.
 
 First time? Install with `/plugin install aidd-dev@aidd-framework`, then run `aidd-dev:00:sdlc`.
 
-Covers the full SDLC coding loop: orchestrator, planning, assertions, audits, code review, testing, refactoring, debugging, and the for-sure workflow. Also hosts AI agents.
+Covers the full SDLC coding loop: orchestrator, planning, implementation, assertions, audits, code review, testing, refactoring, debugging, and the for-sure workflow. Also hosts AI agents.
 
 ## Skills
 

--- a/plugins/aidd-refine/README.md
+++ b/plugins/aidd-refine/README.md
@@ -8,7 +8,7 @@ Meta-cognition plugin for the AI-Driven Development framework.
 
 First time? Install with `/plugin install aidd-refine@aidd-framework`, then run `aidd-refine:01:brainstorm`.
 
-Four skills that refine inputs and outputs through reflection: clarify vague requests, challenge prior work for correctness, toggle a condensed output mode, and analytically scan artifacts for blind spots.
+Five skills that refine inputs and outputs through reflection: clarify vague requests, challenge prior work for correctness, toggle a condensed output mode, analytically scan artifacts for blind spots, and verify factual claims against authoritative sources.
 
 ## Skills
 
@@ -18,3 +18,4 @@ Four skills that refine inputs and outputs through reflection: clarify vague req
 | [5.2]      | [challenge](skills/02-challenge/README.md)  | Rethink prior work to verify correctness against an agreed plan, classifying findings with a confidence score.                                                                                |
 | [5.3]      | [condense](skills/03-condense/README.md)   | Toggle terse output mode with intensity levels so prose drops fluff while code, errors, and warnings stay verbatim.                                                                           |
 | [5.4]      | [shadow-areas](skills/04-shadow-areas/README.md) | Analytical scan of a written artifact for blind spots: each gap is classified by category and severity, paired with a direct-question probe.                                              |
+| [5.5]      | [fact-check](skills/05-fact-check/README.md) | Verify factual claims against authoritative sources and rewrite the text with footnote citations, hedging anything that cannot be confirmed.                                              |


### PR DESCRIPTION
## Summary

Resolves the 2026-05-20 coherence audit — issues #137 (HIGH), #138 (MEDIUM), #139 (LOW).

### #137 — wrong facts / removed references
- `README.md` onboarding claim corrected — only `aidd-context` ships a `00:onboard` skill, not every plugin.
- `docs/ARCHITECTURE.md`, `docs/GLOSSARY.md` — `run-async-dev` (removed in the 4.0.0 orchestrator refactor) → `async-dev`.
- `docs/CATALOG.md` — `aidd-vcs:01:commit` invocation refreshed to `/commit` (regenerated).

### #138 — skill count drift (31, not 30)
- `README.md` badge `30 skills` → `31`; `aidd-refine` tile `4 skills` → `5`, prose adds `fact-check`.
- `plugins/aidd-refine/README.md` — count `Four` → `Five`, `05-fact-check` table row added.
- `docs/CATALOG.md` — `aidd-refine` section now lists all 5 skills (regenerated).

### #139 — ordering and incomplete enumerations
- Plugin table (README) and `docs/CATALOG.md` reordered `refine` before `orchestrator` to match the bracket-ID ordinals.
- `plugins/aidd-dev/README.md` enumeration completed (`implement`); `README.md` aidd-dev tile completed (`sdlc`, `audit`, `for-sure`).

## Catalog generator

`docs/CATALOG.md` is regenerated here by the new generator (companion PR `ai-driven-dev/aidd#265`), which also wires it into the pre-commit lefthook so it no longer drifts.

Closes #137
Closes #138
Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)