### PR TITLE
chore: repoint auto-add workflow to AIDD Roadmap project (#8)

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -13,5 +13,5 @@ jobs:
     steps:
       - uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
         with:
-          project-url: https://github.com/orgs/ai-driven-dev/projects/7
+          project-url: https://github.com/orgs/ai-driven-dev/projects/8
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
## Quoi

Repointe `add-to-project.yml` de l'ancien board org #7 vers le nouveau Project dédié #8 "AIDD Roadmap".

## Pourquoi

Le Project #8 devient la source unique du backlog et de la roadmap (audit de backlog 2026-05-21). Les nouvelles issues `aidd-framework` doivent y atterrir automatiquement.

Le workflow natif "Auto-add to project" du Project #8 ne gère qu'un repo (affecté à `aidd-cli`) ; cette Action couvre `aidd-framework`.

Plan : `aidd_docs/tasks/2026_05/2026_05_21-execution-plan-monorepo-oss.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)