### PR TITLE
docs(aidd-context): document seven artifacts and tool-agnostic wording

### DIFF
--- a/plugins/aidd-context/CATALOG.md
+++ b/plugins/aidd-context/CATALOG.md
@@ -113,7 +113,7 @@ Auto-generated index of skills, agents, references and assets shipped by the `ai
 | `references` | [rule-writing.md](skills/03-context-generate/references/rule-writing.md) | - |
 | `references` | [skill-structure.md](skills/03-context-generate/references/skill-structure.md) | - |
 | `references` | [slash-command.md](skills/03-context-generate/references/slash-command.md) | - |
-| `-` | [SKILL.md](skills/03-context-generate/SKILL.md) | `Generate Claude Code context artifacts - skills (router-based: SKILL.md + atomic testable actions + minimal evals), agents, and rules. Use when the user wants to create, refactor, add or remove actions in a skill, migrate a slash command into a skill, or generate a new agent or rule. Do NOT use for editing a single action inside an existing skill (edit directly), creating slash commands (no router needed), writing MCP servers, or modifying project-level CLAUDE.md files.` |
+| `-` | [SKILL.md](skills/03-context-generate/SKILL.md) | `Generate context artifacts - skills (router-based), agents, rules, slash commands, hooks, plugins, and marketplaces. Use when the user wants to create, refactor, add or remove actions in a skill, migrate a legacy slash command into a router-based skill, or generate a new agent, rule, command, hook, plugin, or marketplace. Do NOT use for editing a single action inside an existing skill (edit directly), writing MCP servers, or modifying project-level files.` |
 
 #### `skills/04-mermaid`
 

--- a/plugins/aidd-context/skills/03-context-generate/README.md
+++ b/plugins/aidd-context/skills/03-context-generate/README.md
@@ -2,13 +2,13 @@
 
 # 03 - Context Generate
 
-Generates the seven Claude Code context artifacts a project can consume:
+Generates the seven context artifacts a project can consume:
 
 - **Skills** - router-based: `SKILL.md` router + atomic testable actions + minimal evals.
 - **Agents** - single-file agent definitions following the framework's agent template.
 - **Rules** - framework rule files governing editor / agent behaviour.
 - **Commands** - flat `.md` slash command files (frontmatter + body), for one-shot manual triggers without supporting files.
-- **Hooks** - JSON / TOML entries (or a JS/TS plugin module for OpenCode) for Claude Code lifecycle events, written to the matching scope.
+- **Hooks** - JSON / TOML entries (or a JS/TS plugin module for OpenCode) for lifecycle events, written to the matching scope.
 - **Plugins** - full plugin scaffold (`.claude-plugin/plugin.json`, README, dirs, optional seed skill).
 - **Marketplaces** - `.claude-plugin/marketplace.json` catalogs that distribute one or more plugins.
 

--- a/plugins/aidd-context/skills/03-context-generate/SKILL.md
+++ b/plugins/aidd-context/skills/03-context-generate/SKILL.md
@@ -1,15 +1,19 @@
 ---
 name: aidd-context:03:context-generate
-description: Generate Claude Code context artifacts - skills (router-based: SKILL.md + atomic testable actions + minimal evals), agents, and rules. Use when the user wants to create, refactor, add or remove actions in a skill, migrate a slash command into a skill, or generate a new agent or rule. Do NOT use for editing a single action inside an existing skill (edit directly), creating slash commands (no router needed), writing MCP servers, or modifying project-level CLAUDE.md files.
+description: Generate context artifacts - skills (router-based), agents, rules, slash commands, hooks, plugins, and marketplaces. Use when the user wants to create, refactor, add or remove actions in a skill, migrate a legacy slash command into a router-based skill, or generate a new agent, rule, command, hook, plugin, or marketplace. Do NOT use for editing a single action inside an existing skill (edit directly), writing MCP servers, or modifying project-level files.
 ---
 
 # Context Generate
 
-Generates the three context artifacts a project consumes:
+Generates the seven context artifacts a project consumes:
 
-- **Skills** - router-based: `SKILL.md` router + atomic testable actions, evaluations declared before implementation.
+- **Skills** - router-based: `SKILL.md` router + atomic testable actions + minimal evals.
 - **Agents** - single-file agent definitions following the framework's agent template.
-- **Rules** - framework rule files that govern editor/agent behavior.
+- **Rules** - framework rule files governing editor/agent behavior.
+- **Commands** - flat `.md` slash command files (frontmatter + body), for one-shot manual triggers.
+- **Hooks** - JSON / TOML entries (or a JS/TS plugin module for OpenCode) bound to lifecycle events.
+- **Plugins** - full plugin scaffold (`.claude-plugin/plugin.json`, README, dirs, optional seed skill).
+- **Marketplaces** - `.claude-plugin/marketplace.json` catalogs that distribute one or more plugins.
 
 ## Skill-generation actions
 
@@ -26,8 +30,12 @@ Files: `actions/skills/01-capture-intent.md` … `actions/skills/06-validate.md`
 
 ## Other generation actions
 
-- `actions/agents/01-generate-agent.md` - generate a project agent file from `assets/agents/agent-template.md`.
-- `actions/rules/01-generate-rules.md` - generate framework rules from `assets/rules/rule-template.md`.
+- `actions/agents/01-generate-agent.md` - generate an agent file from `assets/agents/agent-template.md`.
+- `actions/rules/01-generate-rules.md` - generate a rule file from `assets/rules/rule-template.md`.
+- `actions/commands/01-generate-command.md` - generate a flat slash command from `assets/commands/command-template.md`.
+- `actions/hooks/01-generate-hook.md` - generate a hook entry, branching on the target tool's hooks surface.
+- `actions/plugins/01..04` - plugin scaffold flow: capture-intent → scaffold-tree → seed-first-skill → validate.
+- `actions/marketplaces/01..03` - marketplace catalog flow: init-marketplace → add-plugin-entry → validate.
 
 ## Default skill flow
 
@@ -70,3 +78,7 @@ Materialize the flow as a task list at skill entry; a task closes only when its 
 - `assets/skills/evals-template.md` - `scenarios.json` minimal schema
 - `assets/agents/agent-template.md` - agent file skeleton
 - `assets/rules/rule-template.md` - rule file skeleton
+- `assets/commands/command-template.md` - flat slash command skeleton
+- `assets/hooks/hooks-template.json` - hook entry skeleton (JSON); `hook-template.js` for OpenCode
+- `assets/plugins/plugin-template.json` - plugin manifest skeleton; `plugin-readme-template.md`, `plugin-entry-template.json`
+- `assets/marketplaces/marketplace-template.json` - marketplace catalog skeleton

--- a/plugins/aidd-context/skills/03-context-generate/actions/marketplaces/01-init-marketplace.md
+++ b/plugins/aidd-context/skills/03-context-generate/actions/marketplaces/01-init-marketplace.md
@@ -27,4 +27,4 @@ plugins_root: <repo-root>/<plugin_root>/
 
 ## Test
 
-`<repo-root>/.claude-plugin/marketplace.json` exists and validates via `claude plugin validate .` (or `/plugin validate .` inside Claude Code) with zero errors; the `plugins` array is an empty `[]` ready for entries from `@02-add-plugin-entry.md`.
+`<repo-root>/.claude-plugin/marketplace.json` exists and validates via `claude plugin validate .` (or `/plugin validate .` inside AI tool) with zero errors; the `plugins` array is an empty `[]` ready for entries from `@02-add-plugin-entry.md`.


### PR DESCRIPTION
## What

`SKILL.md` and `README.md` of the `03-context-generate` skill still described **three** artifacts (skills, agents, rules) while the commands, hooks, plugins, and marketplaces actions already exist on disk. This brings the docs in sync with the actual surface.

- `SKILL.md` — description rewritten to cover all seven artifacts; body, action list, and asset list expanded.
- `README.md` — drop `Claude Code`-specific phrasing for tool-agnostic wording.
- `actions/marketplaces/01-init-marketplace.md` — `inside Claude Code` -> `inside AI tool`.
- `CATALOG.md` — auto-regenerated by the `summarize-plugin-catalogs` pre-commit hook to sync the cached description.

## Release-please impact

All four files are under `plugins/aidd-context/`, so once merged release-please will open a release PR bumping **`aidd-context` only**: `1.0.0 -> 1.0.1` (patch, `docs` type), under the **Documentation** changelog section, and rewrite `plugins/aidd-context/.claude-plugin/plugin.json` `$.version`. Root `.` (4.1.0) is untouched.

> Merge with **squash** keeps the PR title as the conventional commit release-please reads. Do not edit the title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)