### PR TITLE
feat(aidd-context): multitool discovery - detect/propose/confirm gate + per-tool scan

### DIFF
--- a/plugins/aidd-context/skills/06-discovery/README.md
+++ b/plugins/aidd-context/skills/06-discovery/README.md
@@ -2,11 +2,13 @@
 
 # 06 - Discovery
 
-Enumerates installed surfaces of the AI tool (skills, agents, commands,
-plugins, MCP servers, rules, hooks, memory files) and recommends the
-single best match for the user's stated intent. Lists only what is
-actually installed - never invents - and stops at the recommendation
-without invoking the target.
+Enumerates installed surfaces across the AI tool(s) the project uses
+(skills, agents, commands, plugins, MCP servers, rules, hooks, memory
+files) and recommends the single best match for the user's stated
+intent. Detects which tools are installed, proposes them, and scans
+only the confirmed surfaces (per `references/ai-mapping.md`). Lists only
+what is actually installed - never invents - and stops at the
+recommendation without invoking the target.
 
 ## When to use
 

--- a/plugins/aidd-context/skills/06-discovery/SKILL.md
+++ b/plugins/aidd-context/skills/06-discovery/SKILL.md
@@ -5,10 +5,29 @@ description: Enumerate installed surfaces of the AI tool (skills, agents, comman
 
 # Skill: discovery
 
-Scans installed surfaces of the AI tool and guides the user to the most relevant item for their current intent.
+Scans installed surfaces of the AI tool(s) the project uses and guides the user to the most relevant item for their current intent.
+
+## Tool detection (run first)
+
+Before scanning, detect which AI tools the project uses, propose the set, and confirm the scan scope. This gate applies to actions 01-07; `08-find-memory` is tool-independent and skips it.
+
+1. **Detect.** Scan the project root for these signals:
+
+   | Signal                            | Tool                                       |
+   | --------------------------------- | ------------------------------------------ |
+   | `.claude/` or `CLAUDE.md`         | Claude Code                                |
+   | `.cursor/`                        | Cursor                                     |
+   | `.opencode/`                      | OpenCode                                   |
+   | `.codex/`                         | Codex CLI                                  |
+   | `.github/copilot-instructions.md`, or any `.github/` Copilot surface dir (`agents/`, `prompts/`, `instructions/`, `skills/`, `hooks/`) | GitHub Copilot |
+   | `AGENTS.md`                       | Cursor / OpenCode / Codex CLI (list all)   |
+
+2. **Propose.** List the detected tools. If no signal is found, propose all five cold (Claude Code, Cursor, OpenCode, GitHub Copilot, Codex CLI). Never default silently to Claude Code.
+3. **Confirm.** Ask which tools to scan (1..N). Then run the matching action, scanning only the confirmed tools' surfaces resolved from `references/ai-mapping.md`. A tool with no surface for the requested artifact is skipped (note it; never error).
 
 ## Rules
 
+- Never hardcode a tool in an action. Per-tool scan paths and formats live in `references/ai-mapping.md` only.
 - List only what is actually installed; never invent.
 - Describe each item's purpose in one line.
 - Recommend a single best match; mention alternatives only if very close.

--- a/plugins/aidd-context/skills/06-discovery/actions/01-find-skill.md
+++ b/plugins/aidd-context/skills/06-discovery/actions/01-find-skill.md
@@ -5,18 +5,18 @@ Enumerate installed skills across all plugins, capture the user's intent, recomm
 ## Inputs
 
 - Free-form user intent (what they want to accomplish).
-- Installed plugins available to the current AI tool.
+- Confirmed tools from the SKILL.md tool gate.
 
 ## Outputs
 
 A markdown table of installed skills + a recommendation block.
 
 ```text
-| Plugin       | Skill           | Purpose                           |
-| ------------ | --------------- | --------------------------------- |
-| aidd-context | 02:project-init | Bootstrap memory bank + scaffold  |
-| aidd-dev     | 00:sdlc         | End-to-end dev SDLC orchestrator  |
-| ...          | ...             | ...                               |
+| Tool   | Plugin       | Skill           | Purpose                           |
+| ------ | ------------ | --------------- | --------------------------------- |
+| claude | aidd-context | 02:project-init | Bootstrap memory bank + scaffold  |
+| claude | aidd-dev     | 00:sdlc         | End-to-end dev SDLC orchestrator  |
+| ...    | ...          | ...             | ...                               |
 
 Recommendation: <best-match skill id>
 Why: <one sentence>
@@ -25,9 +25,9 @@ Invoke with: /<skill-id>
 
 ## Process
 
-1. **Enumerate installed skills.** Use the AI tool's native skill discovery to list every installed plugin and its skills.
+1. **Enumerate skills.** For each confirmed tool, list its skills from the skills surface and plugin install locations in `@../references/ai-mapping.md`.
 2. **Extract metadata.** For each `SKILL.md`, read `name` and `description` from the frontmatter. Skip malformed entries and log them.
-3. **Render the table.** Columns: `Plugin | Skill | Purpose`. Sort by plugin then skill id. One row per skill.
+3. **Render the table.** Columns: `Tool | Plugin | Skill | Purpose`. Sort by tool then plugin then skill id. One row per skill.
 4. **Ask the user for intent.** `What do you want to accomplish?` Wait for an explicit reply.
 5. **Match.** Score each skill against the stated intent. Pick the single best match. If two are clearly tied, list both.
 6. **Print the recommendation block.** Chosen skill id, one-sentence rationale, exact invocation string.

--- a/plugins/aidd-context/skills/06-discovery/actions/02-find-agent.md
+++ b/plugins/aidd-context/skills/06-discovery/actions/02-find-agent.md
@@ -5,18 +5,18 @@ Enumerate installed agents across all plugins, capture the user's intent, recomm
 ## Inputs
 
 - Free-form user intent (what they want delegated).
-- Installed plugins available to the current AI tool.
+- Confirmed tools from the SKILL.md tool gate.
 
 ## Outputs
 
 A markdown table of installed agents + a recommendation block.
 
 ```text
-| Plugin       | Agent       | Purpose                             |
-| ------------ | ----------- | ----------------------------------- |
-| aidd-dev     | implementer | Code milestones from a handed plan  |
-| aidd-dev     | reviewer    | Independent critic in fresh context |
-| ...          | ...         | ...                                 |
+| Tool   | Plugin       | Agent       | Purpose                             |
+| ------ | ------------ | ----------- | ----------------------------------- |
+| claude | aidd-dev     | implementer | Code milestones from a handed plan  |
+| claude | aidd-dev     | reviewer    | Independent critic in fresh context |
+| ...    | ...          | ...         | ...                                 |
 
 Recommendation: <best-match agent name>
 Why: <one sentence>
@@ -25,9 +25,9 @@ Invoke with: Agent(subagent_type="<name>", ...)
 
 ## Process
 
-1. **Enumerate installed agents.** Use the AI tool's native agent discovery to list every agent file. Exclude files under `assets/`, `templates/`, `references/`, or any file whose name matches `*-template.md` or `*.example.md`.
+1. **Enumerate agents.** For each confirmed tool, list its agent files from the agents surface and plugin install locations in `@../references/ai-mapping.md`. Exclude files under `assets/`, `templates/`, `references/`, or any file whose name matches `*-template.md` or `*.example.md`.
 2. **Extract metadata.** Read `name` and `description` from the frontmatter of each agent file. Skip entries whose `name` or `description` contains placeholder syntax (`<...>`, `{{...}}`) and log them as template artifacts.
-3. **Render the table.** Columns: `Plugin | Agent | Purpose`. Sort by plugin then agent name. One row per agent.
+3. **Render the table.** Columns: `Tool | Plugin | Agent | Purpose`. Sort by tool then plugin then agent name. One row per agent.
 4. **Ask the user for intent.** `What do you need delegated?` Wait for an explicit reply.
 5. **Match.** Pick the single best agent. If two are tied, list both.
 6. **Print the recommendation block.** Agent name, one-sentence rationale, invocation pattern.

--- a/plugins/aidd-context/skills/06-discovery/actions/03-find-command.md
+++ b/plugins/aidd-context/skills/06-discovery/actions/03-find-command.md
@@ -5,18 +5,18 @@ Enumerate installed slash commands across all plugins, capture the user's intent
 ## Inputs
 
 - Free-form user intent.
-- Installed plugins available to the current AI tool.
+- Confirmed tools from the SKILL.md tool gate.
 
 ## Outputs
 
 A markdown table of installed commands + a recommendation block.
 
 ```text
-| Plugin       | Command          | Purpose                       |
-| ------------ | ---------------- | ----------------------------- |
-| aidd-vcs     | /commit          | Stage + commit with conv-cc   |
-| aidd-vcs     | /pull-request    | Open PR with summary          |
-| ...          | ...              | ...                           |
+| Tool   | Plugin       | Command          | Purpose                       |
+| ------ | ------------ | ---------------- | ----------------------------- |
+| claude | aidd-vcs     | /commit          | Stage + commit with conv-cc   |
+| claude | aidd-vcs     | /pull-request    | Open PR with summary          |
+| ...    | ...          | ...              | ...                           |
 
 Recommendation: <best-match command>
 Why: <one sentence>
@@ -25,9 +25,9 @@ Invoke with: <exact /command string>
 
 ## Process
 
-1. **Enumerate installed commands.** Use the AI tool's native command discovery to list every installed slash command.
+1. **Enumerate commands.** For each confirmed tool, list its slash commands from the commands surface and plugin install locations in `@../references/ai-mapping.md`.
 2. **Extract metadata.** Read `name`, `description`, and `argument-hint` (if present) from each command's frontmatter. Skip malformed entries and log them.
-3. **Render the table.** Columns: `Plugin | Command | Purpose`. Sort by plugin then command name. One row per command.
+3. **Render the table.** Columns: `Tool | Plugin | Command | Purpose`. Sort by tool then plugin then command name. One row per command.
 4. **Ask the user for intent.** `What do you want to run?` Wait for an explicit reply.
 5. **Match.** Pick the single best command. If two are tied, list both.
 6. **Print the recommendation block.** Command, one-sentence rationale, exact invocation string with placeholders for any required arguments.

--- a/plugins/aidd-context/skills/06-discovery/actions/04-find-plugin.md
+++ b/plugins/aidd-context/skills/06-discovery/actions/04-find-plugin.md
@@ -5,19 +5,19 @@ Enumerate installed plugins, summarize each one's scope, and recommend the plugi
 ## Inputs
 
 - Free-form user intent (broad goal, not a specific skill).
-- Installed plugins available to the current AI tool.
+- Confirmed tools from the SKILL.md tool gate.
 
 ## Outputs
 
 A markdown table of installed plugins + a recommendation block.
 
 ```text
-| Plugin             | Scope                                                 |
-| ------------------ | ----------------------------------------------------- |
-| aidd-context       | Onboarding, memory bank, context generation, mermaid  |
-| aidd-dev           | Dev SDLC: spec / plan / implement / review            |
-| aidd-vcs           | Commit, PR, release tag, issue                        |
-| ...                | ...                                                   |
+| Tool   | Plugin             | Scope                                                 |
+| ------ | ------------------ | ----------------------------------------------------- |
+| claude | aidd-context       | Onboarding, memory bank, context generation, mermaid  |
+| claude | aidd-dev           | Dev SDLC: spec / plan / implement / review            |
+| claude | aidd-vcs           | Commit, PR, release tag, issue                        |
+| ...    | ...                | ...                                                   |
 
 Recommendation: <best-match plugin>
 Why: <one sentence>
@@ -26,9 +26,9 @@ Next step: see the plugin's onboard or skill list via `01-find-skill`.
 
 ## Process
 
-1. **Enumerate installed plugins.** Use the AI tool's native plugin discovery to list every enabled plugin.
+1. **Enumerate plugins.** For each confirmed tool, list enabled plugins from its plugin install location(s) in `@../references/ai-mapping.md`.
 2. **Extract metadata.** Read the plugin's `plugin.json` (or equivalent) for `name` and `description`. Fall back to the plugin's README or CATALOG for a one-line scope.
-3. **Render the table.** Columns: `Plugin | Scope`. One row per plugin.
+3. **Render the table.** Columns: `Tool | Plugin | Scope`. Sort by tool then plugin. One row per plugin.
 4. **Ask the user for intent.** `What are you trying to achieve at a high level?` Wait for an explicit reply.
 5. **Match.** Pick the single best plugin. If two are tied, list both.
 6. **Print the recommendation block.** Plugin name, one-sentence rationale, suggested next step (drill into the plugin via `01-find-skill`).

--- a/plugins/aidd-context/skills/06-discovery/actions/05-find-mcp.md
+++ b/plugins/aidd-context/skills/06-discovery/actions/05-find-mcp.md
@@ -5,7 +5,7 @@ Enumerate connected MCP servers, summarize their capabilities, and recommend the
 ## Inputs
 
 - Free-form user intent (which external system the user wants to reach).
-- MCP servers configured for the current AI tool.
+- Confirmed tools from the SKILL.md tool gate.
 
 ## Outputs
 
@@ -25,7 +25,7 @@ Tool prefix: <mcp__server__tool> (or invocation hint for the current AI)
 
 ## Process
 
-1. **Enumerate connected MCP servers.** Read the AI tool's MCP config (`.mcp.json` for Claude Code, equivalent paths per tool; see `@../references/ai-mapping.md`).
+1. **Enumerate connected MCP servers.** For each confirmed tool, read its MCP config file and servers key from `@../references/ai-mapping.md` (## MCP config per tool).
 2. **Extract metadata.** For each server, list the tools it exposes and group them by capability area.
 3. **Render the table.** Columns: `Server | Capabilities | Source`. One row per server.
 4. **Ask the user for intent.** `Which external system or capability do you need?` Wait for an explicit reply.

--- a/plugins/aidd-context/skills/06-discovery/actions/06-find-rule.md
+++ b/plugins/aidd-context/skills/06-discovery/actions/06-find-rule.md
@@ -5,7 +5,7 @@ Enumerate installed rules across every AI tool surface, recommend the best match
 ## Inputs
 
 - Free-form user intent.
-- Installed AI tool surfaces (one or more of: Claude, Cursor, Copilot, OpenCode).
+- Confirmed tools from the SKILL.md tool gate.
 
 ## Outputs
 

--- a/plugins/aidd-context/skills/06-discovery/actions/07-find-hook.md
+++ b/plugins/aidd-context/skills/06-discovery/actions/07-find-hook.md
@@ -1,12 +1,11 @@
 # 07 - Find hook
 
-Enumerate installed hooks across every plugin and the project's Claude settings, recommend the best match for the user's stated intent.
+Enumerate installed hooks across every confirmed tool's hook surfaces, recommend the best match for the user's stated intent.
 
 ## Inputs
 
 - Free-form user intent.
-- Installed plugins and their `hooks/hooks.json` files.
-- Project `.claude/settings.json` and `.claude/settings.local.json` if present.
+- Confirmed tools from the SKILL.md tool gate.
 
 ## Outputs
 
@@ -26,7 +25,7 @@ Source: <relative path to hooks.json or settings.json>
 
 ## Process
 
-1. **Enumerate hooks.** Scan `plugins/*/hooks/hooks.json` and the project's `.claude/settings.json` + `.claude/settings.local.json` `hooks` blocks.
+1. **Enumerate hooks.** For each confirmed tool, scan its hook surface(s) and parse each per the format noted in `@../references/ai-mapping.md` (project/user hook config, plugin-bundled `hooks/hooks.json`, or a JS module). Tag each row with its owning tool.
 2. **Extract metadata.** For each registered hook, capture owning plugin (or `project`), event name, trigger pattern or matcher, script path, and a one-line purpose drawn from the script's header comment when present.
 3. **Render the table.** Columns: `Plugin | Event | Trigger / Matcher | Script | Purpose`. Sort by event then plugin.
 4. **Ask the user for intent.** `Which event or behavior do you want to intercept?` Wait for an explicit reply.

--- a/plugins/aidd-context/skills/06-discovery/actions/08-find-memory.md
+++ b/plugins/aidd-context/skills/06-discovery/actions/08-find-memory.md
@@ -1,6 +1,6 @@
 # 08 - Find memory
 
-Enumerate the project memory files under `aidd_docs/memory/`, recommend the best match for the user's stated intent.
+Enumerate the project memory files under `aidd_docs/memory/`, recommend the best match for the user's stated intent. Tool-independent: this action skips the SKILL.md tool-detection gate.
 
 ## Inputs
 

--- a/plugins/aidd-context/skills/06-discovery/references/ai-mapping.md
+++ b/plugins/aidd-context/skills/06-discovery/references/ai-mapping.md
@@ -1,10 +1,6 @@
-# NOTE: synced from skills/03-context-generate/references/ai-mapping.md. Keep in sync when the source changes.
+# AI mapping (discovery scan paths)
 
-# AI mapping
-
-## Purpose
-
-Where to look for each artifact type per AI tool, for discovery purposes.
+Where to look for each artifact type per AI tool. Scan-only: the paths and formats the find actions read. This is discovery's own minimal map - the single source of per-tool surfaces; actions never hardcode a tool.
 
 ## AI quick map - content artifacts
 
@@ -16,15 +12,25 @@ Where to look for each artifact type per AI tool, for discovery purposes.
 | GitHub Copilot | `.github/agents/*.agent.md` | `.github/prompts/*.prompt.md`                 | `.github/instructions/*.instructions.md` | `.github/skills/`                     | `.github/copilot-instructions.md` |
 | Codex CLI      | `.codex/agents/{name}.toml` | **Not supported**                             | Not supported                            | `.agents/skills/aidd-{name}/SKILL.md` | `AGENTS.md`                       |
 
-## AI quick map - hooks, plugins, marketplaces
+## AI quick map - hooks, plugins
 
-| AI             | Hooks                                                                                          | Plugin manifest                  | Marketplace catalog                                                  |
-| -------------- | ---------------------------------------------------------------------------------------------- | -------------------------------- | -------------------------------------------------------------------- |
-| Claude Code    | `.claude/settings.json` `hooks` key OR `<plugin>/hooks/hooks.json` OR inline in skill/agent header | `.claude-plugin/plugin.json`     | `.claude-plugin/marketplace.json`                                    |
-| Cursor         | `.cursor/hooks.json` (project), `~/.cursor/hooks.json` (user), `<plugin>/hooks.json` (plugin) | `.cursor-plugin/plugin.json`     | `.cursor-plugin/marketplace.json`                                    |
-| OpenCode       | Plugin code only: JS/TS module under `.opencode/plugins/`                                     | Not supported                    | None                                                                 |
-| GitHub Copilot | `<plugin>/hooks.json` OR `<plugin>/hooks/hooks.json` (plugin-bundled only)                    | `plugin.json` at plugin root     | Configured via `chat.plugins.marketplaces` setting; no per-repo file |
-| Codex CLI      | `.codex/hooks.json` (project / user) OR `[hooks]` table in `.codex/config.toml`               | `.codex-plugin/plugin.json`      | `.agents/plugins/marketplace.json` (project, personal)               |
+| AI             | Hooks                                                                                          | Plugin manifest              |
+| -------------- | ---------------------------------------------------------------------------------------------- | ---------------------------- |
+| Claude Code    | `.claude/settings.json` `hooks` key OR `<plugin>/hooks/hooks.json` OR inline in skill/agent header | `.claude-plugin/plugin.json` |
+| Cursor         | `.cursor/hooks.json` (project), `~/.cursor/hooks.json` (user), `<plugin>/hooks/hooks.json` (plugin) | `.cursor-plugin/plugin.json` |
+| OpenCode       | JS/TS module under `.opencode/plugins/` (parse as JS, not JSON)                                | Not supported                |
+| GitHub Copilot | `.github/hooks/*.json` (workspace), `~/.copilot/hooks` (user), `<plugin>/hooks.json` or `<plugin>/hooks/hooks.json` (plugin) | `plugin.json` at plugin root |
+| Codex CLI      | `.codex/hooks.json` (project / user) OR `[hooks]` table in `.codex/config.toml`               | `.codex-plugin/plugin.json`  |
+
+## MCP config per tool
+
+| Tool           | MCP config file                                  | Servers key   |
+| -------------- | ------------------------------------------------ | ------------- |
+| Claude Code    | `.mcp.json` (project root)                       | `mcpServers`  |
+| Cursor         | `.cursor/mcp.json`                               | `mcpServers`  |
+| OpenCode       | `opencode.json`                                  | `mcp`         |
+| GitHub Copilot | `.vscode/mcp.json` (VS Code); `~/.copilot/mcp-config.json` (CLI) | `servers` (VS Code); `mcpServers` (CLI) |
+| Codex CLI      | `.codex/config.toml`                             | `[mcp_servers.*]` |
 
 ## Path layout per tool
 


### PR DESCRIPTION
## What

Applies the multitool model to `aidd-context:06-discovery`, mirroring the 03-context-generate work but with discovery's **own strict-minimum files** (no shared references, accepted duplication).

## Changes

- **Tool-detection gate** added to `SKILL.md` (read-scoped): detect installed tools from D1 signals -> propose -> confirm scan scope; no-signal proposes all five cold (never default Claude). Applies to actions 01-07; `find-memory` is tool-independent and skips it.
- **Copilot detection broadened**: any `.github/` Copilot surface dir (`agents/`, `prompts/`, `instructions/`, `skills/`, `hooks/`) signals Copilot, not only `copilot-instructions.md`.
- **Actions de-tooled**: each scans the confirmed tools' surfaces per `references/ai-mapping.md`; zero hardcoded tools in action bodies. `find-hook` is no longer Claude-only (scans every tool's hook surface incl. OpenCode JS modules); `find-rule`/`find-mcp` drop inline tool lists. Added a `Tool` column to find-skill/agent/command/plugin tables.
- **`ai-mapping.md` decoupled** from 03 into discovery's own minimal scan map: dropped the sync note + unused marketplace column, added an MCP-config-per-tool table, corrected Copilot hook surfaces.

## Verification

Full **dual test** against a planted 5-tool fixture:
- **Real `claude -p` skill invocation** (6 actions): detected tools, scanned per-tool surfaces, listed artifacts; OpenCode JS hook recognized; unsupported pairs skipped not errored.
- **Strict sub-agent action-followers** (4): caught two bugs the smart `claude -p` masked by inference -> the Copilot-detection gap and the missing `Tool` column. Both fixed and re-verified (5 tools detected, all artifacts found per tool).

Static: 0 broken `@`-refs, 0 em-dash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
