### PR TITLE
fix(aidd-dev): add routing dispatch to choice-router skills for weak-model hosts

### DIFF
--- a/plugins/aidd-dev/skills/01-plan/SKILL.md
+++ b/plugins/aidd-dev/skills/01-plan/SKILL.md
@@ -14,10 +14,26 @@ Produces implementation plans from requirements, state machines for component be
 
 Spawn the `planner` agent to execute this skill. For tools that do not support `context: fork` frontmatter: invoke the `planner` agent explicitly with this skill's content as the prompt.
 
+## Available actions
+
+| #   | Action                   | When to use                                                                 |
+| --- | ------------------------ | --------------------------------------------------------------------------- |
+| 01  | `plan`                   | Turn requirements into a technical implementation plan saved to a task file |
+| 02  | `components-behavior`    | Define a frontend component's behavior as a state machine (Mermaid)         |
+| 03  | `image-extract-details`  | Analyze a design image into a hierarchical component inventory              |
+
+## Routing (run first)
+
+The planner auto-adapts to the INPUT - do not ask the user to choose. Detect the input type and route; do NOT always fall to action 01.
+
+- A design image or mockup is provided -> `03-image-extract-details` (then feed the inventory into planning).
+- The request is about a frontend component's behavior, states, or transitions -> `02-components-behavior`.
+- Anything else (requirements, a feature to build) -> `01-plan`.
+
+Actions may chain (e.g. extract from image, then plan). Read and follow each selected action file.
+
 ## Actions
 
-```markdown
-@actions/01-plan.md
-@actions/02-components-behavior.md
-@actions/03-image-extract-details.md
-```
+- `@actions/01-plan.md`
+- `@actions/02-components-behavior.md`
+- `@actions/03-image-extract-details.md`

--- a/plugins/aidd-dev/skills/03-assert/SKILL.md
+++ b/plugins/aidd-dev/skills/03-assert/SKILL.md
@@ -8,10 +8,26 @@ model: sonnet
 
 Validates correctness of implementations through iterative assertion loops, architecture checks, and browser-based frontend verification.
 
+## Available actions
+
+| #   | Action                | When to use                                                                  |
+| --- | --------------------- | ---------------------------------------------------------------------------- |
+| 01  | `assert`              | Iterate until a feature works by running the project's coding assertions     |
+| 02  | `assert-architecture` | Verify the codebase conforms to documented architecture (C4, ADRs, tree)     |
+| 03  | `assert-frontend`     | Iterate until a frontend feature works by inspecting the running UI          |
+
+## Routing (run first)
+
+Assert comprehensively: these actions are complementary facets, not mutually exclusive choices. Select every action applicable to the target; do NOT stop at action 01. Do not ask the user to pick - decide from what the feature needs.
+
+- `01-assert` - ALWAYS run for a feature assertion (the project's coding assertions are the baseline).
+- `03-assert-frontend` - ALSO run when the feature has a UI and a running frontend URL is available.
+- `02-assert-architecture` - run when the request is about architecture conformance (C4 / ADRs / tree), either standalone or added to a feature assertion when conformance is in scope.
+
+Run the applicable actions in order (01, then 03 if UI, then 02 if conformance). Read and follow each selected action file.
+
 ## Actions
 
-```markdown
-@actions/01-assert.md
-@actions/02-assert-architecture.md
-@actions/03-assert-frontend.md
-```
+- `@actions/01-assert.md`
+- `@actions/02-assert-architecture.md`
+- `@actions/03-assert-frontend.md`

--- a/plugins/aidd-dev/skills/05-review/SKILL.md
+++ b/plugins/aidd-dev/skills/05-review/SKILL.md
@@ -14,9 +14,23 @@ Performs code quality reviews against project rules and functional reviews again
 
 Spawn the `reviewer` agent to execute this skill. For tools that do not support `context: fork` frontmatter: invoke the `reviewer` agent explicitly with this skill's content as the prompt.
 
+## Available actions
+
+| #   | Action              | When to use                                                              |
+| --- | ------------------- | ------------------------------------------------------------------------ |
+| 01  | `review-code`       | Quality review of a diff against project rules and clean-code principles |
+| 02  | `review-functional` | Verify the diff matches the plan's acceptance criteria, flows, edge cases |
+
+## Routing (run first)
+
+Pick the ONE action matching the user's intent; do NOT default to action 01.
+
+- "review the code", "check code quality", "rules compliance", "clean code review" -> `01-review-code`
+- "does it match the plan", "functional review", "behavior vs acceptance criteria" -> `02-review-functional`
+
+If the intent is ambiguous, ask one clarifying question before picking. Then read and follow only the matching action file.
+
 ## Actions
 
-```markdown
-@actions/01-review-code.md
-@actions/02-review-functional.md
-```
+- `@actions/01-review-code.md`
+- `@actions/02-review-functional.md`

--- a/plugins/aidd-dev/skills/06-test/SKILL.md
+++ b/plugins/aidd-dev/skills/06-test/SKILL.md
@@ -8,9 +8,23 @@ model: sonnet
 
 Identifies untested behaviors, iterates on test creation until quality criteria are met, and validates complete user journeys through browser automation.
 
+## Available actions
+
+| #   | Action         | When to use                                                            |
+| --- | -------------- | ---------------------------------------------------------------------- |
+| 01  | `test`         | Find untested behaviors and write/iterate tests until they pass        |
+| 02  | `test-journey` | Validate a full user journey end-to-end in the browser                 |
+
+## Routing (run first)
+
+Pick the ONE action matching the user's intent; do NOT default to action 01.
+
+- "write tests", "add test coverage", "what's untested", "iterate on tests" -> `01-test`
+- "test the user journey", "end-to-end", "walk through the flow in the browser" -> `02-test-journey`
+
+If the intent is ambiguous, ask one clarifying question before picking. Then read and follow only the matching action file.
+
 ## Actions
 
-```markdown
-@actions/01-test.md
-@actions/02-test-journey.md
-```
+- `@actions/01-test.md`
+- `@actions/02-test-journey.md`

--- a/plugins/aidd-dev/skills/07-refactor/SKILL.md
+++ b/plugins/aidd-dev/skills/07-refactor/SKILL.md
@@ -7,9 +7,23 @@ description: Optimize code for performance and fix security vulnerabilities foll
 
 Improves code performance and hardens security through structured analysis and targeted fixes.
 
+## Available actions
+
+| #   | Action        | When to use                                                           |
+| --- | ------------- | --------------------------------------------------------------------- |
+| 01  | `performance` | Improve performance of a code region without changing its behavior    |
+| 02  | `security`    | Identify and fix security vulnerabilities, then add coverage          |
+
+## Routing (run first)
+
+Pick the ONE action matching the user's intent; do NOT default to action 01.
+
+- "make it faster", "optimize performance", "this is slow" -> `01-performance`
+- "fix security", "vulnerabilities", "harden this", "OWASP" -> `02-security`
+
+If the intent is ambiguous, ask one clarifying question before picking. Then read and follow only the matching action file.
+
 ## Actions
 
-```markdown
-@actions/01-performance.md
-@actions/02-security.md
-```
+- `@actions/01-performance.md`
+- `@actions/02-security.md`

--- a/plugins/aidd-dev/skills/08-debug/SKILL.md
+++ b/plugins/aidd-dev/skills/08-debug/SKILL.md
@@ -8,10 +8,26 @@ model: opus
 
 Diagnoses issues through structured hypothesis validation, root cause analysis, and test-driven bug fixing from issue creation to PR.
 
+## Available actions
+
+| #   | Action          | When to use                                                                   |
+| --- | --------------- | ----------------------------------------------------------------------------- |
+| 01  | `reproduce`     | A known bug must be fixed end to end: reproduce, test-driven fix, branch, PR   |
+| 02  | `debug`         | Root cause unknown: enumerate hypotheses, validate each, confirm the cause     |
+| 03  | `reflect-issue` | Stuck or prior fixes failed: re-open the search space, instrument logs first   |
+
+## Routing (run first)
+
+This skill offers three distinct actions. Pick the ONE matching the user's intent; do NOT default to action 01.
+
+- "fix this bug", "reproduce and fix", "from issue to PR" -> `01-reproduce`
+- "why does this happen", "find the root cause", "debug this", "what's causing X" -> `02-debug`
+- "I'm stuck", "previous fixes didn't work", "rethink the causes", "add logs to narrow it down" -> `03-reflect-issue`
+
+If the intent is ambiguous, ask one clarifying question before picking. Then read and follow only the matching action file.
+
 ## Actions
 
-```markdown
-@actions/01-reproduce.md
-@actions/02-debug.md
-@actions/03-reflect-issue.md
-```
+- `@actions/01-reproduce.md`
+- `@actions/02-debug.md`
+- `@actions/03-reflect-issue.md`


### PR DESCRIPTION
## What

Bare `@`-include router skills in aidd-dev (debug, plan, assert, review, test, refactor) had no dispatch logic. Claude infers the action from intent, but weaker hosts (GitHub Copilot) hit N actions with no decision rule and always run the first (`01`). Reported: on Copilot, debug always went to `01-reproduce`.

## Fix

Routing block added to each SKILL.md body (decision lives in SKILL.md, robust whether or not the host expands `@`-includes). Three models, by the real nature of each skill's actions:

- **debug / review / test / refactor** - pick-one by intent; never default to 01; ask if ambiguous.
- **assert** - comprehensive (not pick-one): `01-assert` always, `+03-assert-frontend` when the feature has a running UI, `+02-assert-architecture` for conformance. No question.
- **plan** - auto-route by input (image -> `03`, component behavior -> `02`, else `01`); may chain; the planner self-adapts. No question.

`09-for-sure` left unchanged (genuinely sequential 01->02->03).

## Verification

Verified on Claude via real `claude -p` (root-cause intent routes to `02-debug` rejecting 01/03; security routes to `02-security`). 0 em-dash, every SKILL.md carries a routing block + action table.

**Caveat:** not reproducible through `claude -p` (Claude already routes by intent - the bug is Copilot-only). Structural fix matching the in-repo proven pattern; reporter to confirm on real Copilot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
