### PR TITLE
chore(framework): require DCO check and add admin PR-bypass to main ruleset

### DIFF
--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -2,6 +2,9 @@
   "name": "main protection",
   "target": "branch",
   "enforcement": "active",
+  "bypass_actors": [
+    {"actor_id": 5, "actor_type": "RepositoryRole", "bypass_mode": "pull_request"}
+  ],
   "conditions": {
     "ref_name": {
       "include": ["refs/heads/main"],
@@ -25,7 +28,8 @@
         "strict_required_status_checks_policy": false,
         "required_status_checks": [
           {"context": "lefthook (framework-local checks)"},
-          {"context": "Commitlint"}
+          {"context": "Commitlint"},
+          {"context": "Verify Developer Certificate of Origin sign-off"}
         ]
       }
     },


### PR DESCRIPTION
Syncs `.github/rulesets/main.json` with the live ruleset: adds the DCO sign-off required check and an admin PR-only bypass so bot/release-please PRs can merge. Merging this via admin bypass also confirms the new flow works.