### PR TITLE
ci(framework): exempt bot commits from DCO

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -41,6 +41,12 @@ jobs:
               echo "skip merge commit ${sha}"
               continue
             fi
+            # Skip commits authored by a bot (release-please, dependabot, ...);
+            # the DCO applies to human contributions.
+            author_name="$(git show -s --format='%an' "${sha}")"
+            case "${author_name}" in
+              *"[bot]") echo "skip bot commit ${sha} (${author_name})"; continue ;;
+            esac
             if git show -s --format='%B' "${sha}" | grep -qiE "^Signed-off-by: .+ <.+@.+>"; then
               echo "ok ${sha}"
             else

--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -42,7 +42,7 @@ Versions live in `.release-please-manifest.json`. Forcing a version / pre-releas
 
 Two bypass actors (both `pull_request` mode, so neither can push directly to `main`):
 - the **aidd-bot GitHub App** (`Integration`) - release-please and the Dependabot auto-merge mint a token from it (`actions/create-github-app-token`), so their PRs trigger the required checks *and* the App merges them past the human-review rule.
-- the **`admin` team** (`alexsoyes`, `blafourcade`, `victor-langlois`) - lead maintainers can merge their own PR without a second review. Everyone else needs a code-owner review.
+- the **`admin` team** - lead maintainers can merge their own PR without a second review. Everyone else needs a code-owner review.
 
 The App: ID in secret `AIDD_BOT_APP_ID`, key in `AIDD_BOT_PRIVATE_KEY`. If the App is broken/uninstalled, release and Dependabot PRs stop merging - fix the App rather than re-adding an admin bypass.
 


### PR DESCRIPTION
Release-please/Dependabot commits are bot-authored and have no DCO sign-off; the check now skips [bot] commits so their PRs are not blocked. Also drops the admin name list from MAINTAINERS.md.