### PR TITLE
feat(ci): build and attach per-tool framework distributions on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,57 @@ jobs:
             "/tmp/aidd-framework-marketplace-${VERSION}.zip" \
             --clobber
 
+  build-per-tool:
+    name: Build and attach per-tool distribution
+    needs: [release-please]
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      # 9-cell matrix: 4 marketplace (claude/cursor/copilot/codex) + 5 flat
+      # (+opencode, which is flat-only). Mirrors the CLI golden snapshot matrix.
+      matrix:
+        include:
+          - { tool: claude, mode: marketplace, flag: "" }
+          - { tool: cursor, mode: marketplace, flag: "" }
+          - { tool: copilot, mode: marketplace, flag: "" }
+          - { tool: codex, mode: marketplace, flag: "" }
+          - { tool: claude, mode: flat, flag: "--flat" }
+          - { tool: cursor, mode: flat, flag: "--flat" }
+          - { tool: copilot, mode: flat, flag: "--flat" }
+          - { tool: codex, mode: flat, flag: "--flat" }
+          - { tool: opencode, mode: flat, flag: "--flat" }
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+
+      - name: Build the target-native distribution
+        # Pin the CLI version: a future CLI release must not silently change
+        # framework dist output. Bump deliberately alongside a framework change.
+        run: |
+          VERSION="${{ needs.release-please.outputs.version }}"
+          NAME="aidd-framework-${{ matrix.tool }}-${{ matrix.mode }}-${VERSION}"
+          OUT="dist/${{ matrix.tool }}/${{ matrix.mode }}"
+          mkdir -p "$OUT"
+          npx --yes @ai-driven-dev/cli@4.6.1 framework build \
+            --source . --target ${{ matrix.tool }} --out "$OUT" ${{ matrix.flag }}
+          STAGE="$(mktemp -d)/${NAME}"
+          mkdir -p "$STAGE"
+          cp -R "$OUT"/. "$STAGE"/
+          ( cd "$(dirname "$STAGE")" && zip -q -r "/tmp/${NAME}.zip" "${NAME}" )
+
+      - name: Attach per-tool distribution to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ needs.release-please.outputs.version }}"
+          TAG="${{ needs.release-please.outputs.tag_name }}"
+          NAME="aidd-framework-${{ matrix.tool }}-${{ matrix.mode }}-${VERSION}"
+          gh release upload "${TAG}" "/tmp/${NAME}.zip" --clobber
+
   build-plugin:
     name: Build and attach plugin
     needs: [release-please]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,9 +84,9 @@ Automated by [release-please](https://github.com/googleapis/release-please) in m
 
 - Every push to `main` opens / updates a `chore: release main` PR (changelog + version bumps).
 - Merging it tags each bumped package and creates the GitHub Releases; CI then attaches the bundles:
-  - `aidd-framework-marketplace-X.Y.Z.zip` - the Claude Code marketplace (`.claude-plugin/` + `plugins/`).
+  - `aidd-framework-marketplace-X.Y.Z.zip` - the Claude Code marketplace (`.claude-plugin/` + `plugins/`); kept as the legacy Claude alias of `aidd-framework-claude-marketplace-X.Y.Z.zip`.
   - `<plugin>-vX.Y.Z.zip` - per released plugin.
-- **Planned:** per-tool archives (Cursor, Copilot, Codex, OpenCode - in marketplace or flat format per tool) will be attached to each release by the `aidd-cli` once it lands. Until then the marketplace is Claude Code native and other-tool users adapt it manually.
+  - `aidd-framework-<tool>-<mode>-X.Y.Z.zip` - **per-tool distributions** built by `aidd-cli` (`framework build`) on the root release: 4 marketplace (claude/cursor/copilot/codex) + 5 flat (+opencode, flat-only) = 9 archives. Produced by the `build-per-tool` matrix job in `.github/workflows/ci.yml`, pinned to a specific `@ai-driven-dev/cli` version.
 
 Config: `release-please-config.json` + `.release-please-manifest.json` (pre-releases, forced versions, and recovery are driven through those files).
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 
 The **AIDD Framework** is a marketplace of **skills, agents, rules, and conventions** that make the AI-Driven Development flow concrete inside your AI coding assistant - the full SDLC (plan → implement → review → ship) under rigorous human supervision. It is the open toolset of the [AI-Driven Dev](https://www.ai-driven-dev.fr/) community.
 
-The framework is **authored for Claude Code**, and this repository is its native marketplace. For every release, our CLI **also generates archives adapted to each tool we support** - Cursor, GitHub Copilot, Codex, OpenCode (marketplace or flat format per tool) - so you grab the build that matches your assistant. (Those per-tool archives ship with the `aidd-cli`; the Claude install is live today.)
+The framework is **authored for Claude Code**, and this repository is its native marketplace. Every release **also attaches archives adapted to each tool we support** - Cursor, GitHub Copilot, Codex, OpenCode (marketplace or flat format per tool) - so you grab the build that matches your assistant. See [Another AI tool?](#another-ai-tool) for the per-tool download + install table.
 
 Founded by Alex Soyes - [Blog](https://alexsoyes.com/) · [GitHub](https://github.com/alexsoyes) · [LinkedIn](https://www.linkedin.com/in/alexsoyes/) · [X](https://x.com/alexsoyes).
 
@@ -105,7 +105,25 @@ flowchart TD
 - **Whole loop in one command?** `/aidd-dev:00-sdlc` runs plan → implement → review → ship.
 - **More plugins?** Browse the [catalog](#plugins) or the `/plugin` Discover tab.
 
-> **Another AI tool?** The marketplace is Claude Code native. For Cursor, GitHub Copilot, Codex, or OpenCode, grab the per-release archive the `aidd-cli` builds for that tool (coming) - and map each tier to that tool's model via the **LLM tier reference** below.
+### Another AI tool?
+
+The marketplace is Claude Code native. For Cursor, GitHub Copilot, Codex, or OpenCode, each
+[release](https://github.com/ai-driven-dev/aidd-framework/releases/latest) attaches a target-native
+archive. Download the one for your tool, unzip it, and install per the table - then map each tier to
+that tool's model via the **LLM tier reference** below.
+
+| Tool | Download (release asset) | Install |
+| --- | --- | --- |
+| **Claude Code** | — (native) | `/plugin marketplace add ai-driven-dev/aidd-framework` (no download needed) |
+| **GitHub Copilot** | `aidd-framework-copilot-marketplace-<version>.zip` | unzip, then `aidd marketplace add aidd-framework ./aidd-framework-copilot-marketplace-<version>` |
+| **Codex** | `aidd-framework-codex-marketplace-<version>.zip` | unzip, then `aidd marketplace add aidd-framework ./aidd-framework-codex-marketplace-<version>` |
+| **Cursor** | `aidd-framework-cursor-flat-<version>.zip` | unzip into your project (materializes `.cursor/`) |
+| **OpenCode** | `aidd-framework-opencode-flat-<version>.zip` | unzip into your project (materializes `.opencode/`) |
+
+> Today this is **download → unzip → install** (no one-command remote fetch yet). Marketplace
+> archives (`-marketplace-`) register through `aidd marketplace add`; flat archives (`-flat-`)
+> materialize straight into a project workspace. A flat variant of every tool and a marketplace
+> variant for Claude/Copilot/Codex are attached too - pick the format that fits your workflow.
 
 > **Private repo?** `/plugin marketplace add` needs read access (`gh auth login` or a PAT) - see the Anthropic [install docs](https://code.claude.com/docs/en/discover-plugins).
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -7,7 +7,7 @@ Most "how do I…" answers live in the README; this page covers what isn't docum
 - **Install / first run** → [Quick start](../README.md#quick-start).
 - **Update plugins** → [Versioning and updates](../README.md#versioning-and-updates).
 - **Private repo?** Yes - `/plugin marketplace add` just needs GitHub read access (via `gh auth login` or a PAT).
-- **Cursor / Copilot / Codex / OpenCode?** This repo is the Claude Code distribution; for another tool, grab the per-release archive the `aidd-cli` builds for it (coming).
+- **Cursor / Copilot / Codex / OpenCode?** This repo is the Claude Code distribution; for another tool, grab the per-release archive (`aidd-framework-<tool>-<mode>-<version>.zip`) attached to each [release](https://github.com/ai-driven-dev/aidd-framework/releases/latest), unzip, and install per the [Another AI tool?](../README.md#another-ai-tool) table.
 
 ## Cost and quotas
 

--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -28,7 +28,7 @@ release-please opens/updates a `chore: release main` PR on each push to `main`.
 3. CI tags each bumped package, creates the GitHub Releases, and attaches the bundles:
    - `aidd-framework-marketplace-X.Y.Z.zip` (`.claude-plugin/` + `plugins/`)
    - `<plugin>-vX.Y.Z.zip`
-   - per-tool archives (Cursor, Copilot, Codex, OpenCode) - **planned**, produced by the `aidd-cli` once it lands.
+   - `aidd-framework-<tool>-<mode>-X.Y.Z.zip` - per-tool distributions (9 archives: 4 marketplace claude/cursor/copilot/codex + 5 flat incl. opencode), produced by the `build-per-tool` matrix job in `ci.yml` via `aidd-cli framework build`. **Pinned** to a specific `@ai-driven-dev/cli` version - bump it deliberately when adopting CLI build changes.
 
 Versions live in `.release-please-manifest.json`. Forcing a version / pre-release: `release-as` in `release-please-config.json` (remove it after the release ships).
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -23,7 +23,7 @@ Run `/reload-plugins` in the same session, or restart the tool if a hook config 
 ## Limitations (what AIDD does not do)
 
 - **Not autonomous by default.** Skills run under human supervision; you drive each step.
-- **Authored for Claude Code.** Other tools get a per-release archive built by the `aidd-cli`; native parity is a roadmap item, not a guarantee today.
+- **Authored for Claude Code.** Other tools get a per-release archive built by the `aidd-cli` (download → unzip → install; see [Another AI tool?](../README.md#another-ai-tool)); native parity is a roadmap item, not a guarantee today.
 - **Plugins assume their own context.** A skill that expects a git repo, a `package.json`, or a ticketing tool will not work without it - check the plugin's README.
 - **No hosted service.** AIDD is prompt content you install into your own tool; there is no AIDD server, account, or telemetry.
 


### PR DESCRIPTION
## What

At each root release, build a target-native distribution for every supported tool and attach it as a release asset — so non-Claude users get a ready-to-install archive. Flips the docs that already promised this ("coming"/"planned") to live instructions.

## CI (`ci.yml`)

New `build-per-tool` matrix job (gated on `release_created`), generalizing the existing Claude-only `build-and-attach`:

- 9 cells = 4 marketplace (claude/cursor/copilot/codex) + 5 flat (+opencode, flat-only) — mirrors the CLI golden matrix.
- Builds via `npx @ai-driven-dev/cli@4.6.1 framework build` (**pinned** — a future CLI release must not silently change output).
- Attaches `aidd-framework-<tool>-<mode>-<version>.zip` to the release.
- Legacy `aidd-framework-marketplace-<v>.zip` (Claude) kept; `build-plugin` untouched.

## Docs (flip "(coming)/(planned)" → live)

- `README.md` — new **Another AI tool?** section with a per-tool download+install table.
- `CONTRIBUTING.md` / `docs/MAINTAINERS.md` — releases now list per-tool archives + the pinned-CLI build job.
- `docs/FAQ.md`, `docs/TROUBLESHOOTING.md` — point to the live archives + table.

## Consumption is not uniform (verified against the CLI catalog reader)

`aidd marketplace add` ingests only `.plugin/` (copilot) and `.claude-plugin/` (claude, codex) marketplace manifests — **not** `.cursor-plugin/`. So:

- claude / codex / copilot → **marketplace** archive → `aidd marketplace add ./dir`
- cursor / opencode → **flat** archive → unzip into project

## Verification

- 9 cells built locally (published-CLI logic), layouts match golden, no framework-internal leak.
- Ingestion smoke: `marketplace add` + `plugin install aidd-dev` succeed on copilot **and** codex marketplace cells (the transformed paths).
- 9 archives already uploaded to the current `v4.3.1` release for immediate access; this PR automates it for future releases.
- `ci.yml` YAML validated (5 jobs, 9 matrix cells); lefthook pre-commit green.

## Deferred (separate issue)

- **A** committed `dist/` + git-subdir one-command (claude/codex/copilot only).
- **E+** CLI `fetchUrl` archive (`.zip`/`.tgz`) download+extract → one-command `marketplace add <release-url>` for all tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)