### PR TITLE
fix(ci): build per-tool dist outside source tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,9 @@ jobs:
         run: |
           VERSION="${{ needs.release-please.outputs.version }}"
           NAME="aidd-framework-${{ matrix.tool }}-${{ matrix.mode }}-${VERSION}"
-          OUT="dist/${{ matrix.tool }}/${{ matrix.mode }}"
+          # --out must live outside --source: the CLI refuses to build when one
+          # path contains the other. Stage under RUNNER_TEMP, not the repo tree.
+          OUT="${RUNNER_TEMP}/dist/${{ matrix.tool }}/${{ matrix.mode }}"
           mkdir -p "$OUT"
           npx --yes @ai-driven-dev/cli@4.6.1 framework build \
             --source . --target ${{ matrix.tool }} --out "$OUT" ${{ matrix.flag }}


### PR DESCRIPTION
## Problem

The `build-per-tool` matrix added in #188 failed on **every** cell during the `v4.4.0` release (run [26976800551](https://github.com/ai-driven-dev/aidd-framework/actions/runs/26976800551)), so `v4.4.0` shipped without its per-tool distribution tarballs (only the marketplace bundle made it).

Each cell failed at the *Build the target-native distribution* step:

```
Error: Refusing to build: --out '.../aidd-framework/dist/claude/marketplace'
and --source '.../aidd-framework' must not contain each other.
```

`@ai-driven-dev/cli@4.6.1` refuses to build when `--out` is nested inside `--source`. The workflow wrote `--out` to `dist/` **inside** the checked-out repo (`--source .`), so all 9 cells aborted before producing any artifact.

This regression was never exercised before because the `v4.3.1` per-tool tarballs were uploaded manually.

## Fix

Stage the build output under `$RUNNER_TEMP` instead of the repo tree, so `--out` lives outside `--source`. No other changes — the subsequent `cp`/`zip` follow the `OUT` variable.

```diff
-          OUT="dist/${{ matrix.tool }}/${{ matrix.mode }}"
+          OUT="${RUNNER_TEMP}/dist/${{ matrix.tool }}/${{ matrix.mode }}"
```

## Validation

The matrix only runs when a release is created, so this is validated on the next release after merge. The currently-incomplete `v4.4.0` assets are being backfilled separately.

https://claude.ai/code/session_01YKNHPfAQYnN4nPSca3pPxt

---
_Generated by [Claude Code](https://claude.ai/code/session_01YKNHPfAQYnN4nPSca3pPxt)_