### PR TITLE
docs(contributing): local testing guide, PR template overhaul, and label guide

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,7 @@
+<!--
+🤖 RULE (AI filling this template): less is more. Reviewers scan hundreds of PRs - optimize for at-a-glance. Keep every section short, concrete, skimmable. Cut anything readable from the diff or CI. Delete any section that adds nothing.
+-->
+
 ## 🎯 What & why
 
 <!-- One or two sentences: what this changes and the problem it solves. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,6 +28,14 @@ re-assert them here. Spend your words on the *how*.
 
 Closes #
 
+## ✅ I certify
+
+<!-- The author ticks these on GitHub before merge. Not for the AI to fill or delete - these are the checks no CI job can make. -->
+
+- [ ] Docs updated to match the new behaviour.
+- [ ] I self-reviewed this PR.
+- [ ] No cross-plugin references introduced.
+
 ---
 
 🏷️ **Before submitting** - add the matching label (`documentation`, `enhancement`, `bug`, `security`, ...). Canonical list: [`labels.yml`](labels.yml).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -41,7 +41,3 @@ Closes #
 - [ ] Docs updated to match the new behaviour.
 - [ ] I self-reviewed this PR.
 - [ ] No cross-plugin references introduced.
-
----
-
-🏷️ **Before submitting** - add the matching label (`documentation`, `enhancement`, `bug`, `security`, ...). Canonical list: [`labels.yml`](labels.yml).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,29 +1,29 @@
-# Summary
+## 🎯 What & why
 
-<!-- One or two sentences describing the change and why it matters. -->
+<!-- One or two sentences: what this changes and the problem it solves. -->
 
-## Changes
+## 🛠️ How it works
 
-<!-- Bullet list of the concrete edits. Group by plugin or area when relevant. -->
+<!--
+Walk a reviewer through the technical resolution: the approach you took, why
+this way over the alternatives, and anything non-obvious (trade-offs, edge
+cases, follow-ups). This narrative is the point of the PR. The conventional
+title, DCO sign-off, and pre-commit hooks are already enforced by CI, so don't
+re-assert them here. Spend your words on the *how*.
+-->
 
-- 
+## 🧪 How to verify
 
-## Test plan
+<!-- Concrete steps, commands, or screenshots a reviewer can run to see it work. -->
 
-<!-- How you verified this change. Commands, screenshots, manual steps. -->
+-
 
-- [ ] 
+## 🔗 Linked issue
 
-## Related issues
-
-<!-- "Closes #N" auto-links and closes the issue on merge. Use "Refs #N" for related-but-not-closing links. -->
+<!-- "Closes #N" auto-closes the issue on merge; "Refs #N" links without closing. Delete this whole section if there is no issue. -->
 
 Closes #
 
-## Checklist
+---
 
-- [ ] Commit messages follow the conventional format and use a scope listed in `commitlint.config.cjs`.
-- [ ] Every commit is signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#2-commit).
-- [ ] Documentation updated when behaviour or contracts changed (plugin README, skill README, references).
-- [ ] No cross-plugin references introduced in plugin docs.
-- [ ] Pre-commit hooks pass locally (`lefthook run pre-commit`).
+🏷️ **Before submitting** - add the matching label (`documentation`, `enhancement`, `bug`, `security`, ...). Canonical list: [`labels.yml`](labels.yml).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,7 @@
 <!--
-🤖 RULE (AI filling this template): less is more. Reviewers scan hundreds of PRs - optimize for at-a-glance. Keep every section short, concrete, skimmable. Cut anything readable from the diff or CI. Delete any section that adds nothing.
+🤖 RULES (filling this template):
+1. Less is more. Reviewers scan hundreds of PRs - keep every section short, concrete, skimmable. Cut anything readable from the diff or CI. Delete any section that adds nothing.
+2. Point to a file with a real markdown link and its line number, GitHub-style: [README.md:119](README.md#L119).
 -->
 
 ## 🎯 What & why

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,6 +22,10 @@ re-assert them here. Spend your words on the *how*.
 
 -
 
+## ⚠️ Heads-up
+
+<!-- Deferred work, known gaps, or anything a reviewer should track. Delete if none. -->
+
 ## 🔗 Linked issue
 
 <!-- "Closes #N" auto-closes the issue on merge; "Refs #N" links without closing. Delete this whole section if there is no issue. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,8 +52,13 @@ cd aidd-framework
 **With Claude Code (recommended)** - register the checkout as a local marketplace, then install the plugins you are working on:
 
 ```text
-/plugin marketplace add .                  # from the repo root; or pass an absolute path
+/plugin marketplace add .                  # from the repo root
+/plugin install aidd-context@aidd-framework
 /plugin install aidd-dev@aidd-framework
+/plugin install aidd-vcs@aidd-framework
+/plugin install aidd-pm@aidd-framework
+/plugin install aidd-orchestrator@aidd-framework
+/plugin install aidd-refine@aidd-framework
 ```
 
 After editing a `SKILL.md`, an agent, or any action, run `/reload-plugins` in the same session to pick up the change - no reinstall needed.
@@ -75,6 +80,7 @@ After editing a `SKILL.md`, an agent, or any action, run `/reload-plugins` in th
     "aidd-dev@aidd-framework": true,
     "aidd-vcs@aidd-framework": true,
     "aidd-pm@aidd-framework": true,
+    "aidd-orchestrator@aidd-framework": true,
     "aidd-refine@aidd-framework": true
   }
 }
@@ -82,16 +88,20 @@ After editing a `SKILL.md`, an agent, or any action, run `/reload-plugins` in th
 
 Claude Code then loads the plugins straight from your working tree: edit the framework, run `/reload-plugins`, and test the result in that project. The loop is edit - reload - try, with no publish step in between.
 
-**With Codex (or another non-Claude tool)** - the framework is authored in Claude Code syntax, so Codex needs a *built* distribution with codex-native plugin internals (`.codex-plugin/`, `codex-agents/`), not the working tree. Build it from your checkout (`--out` must sit outside `--source`), register the build with Codex's own CLI, then install the plugins you are working on:
+**With Codex** - Codex reads the same marketplace manifest, so register the cloned checkout with Codex's own CLI (pass an absolute path; `./` is rejected), then install the plugins:
 
 ```bash
-# CLI version is pinned in .github/workflows/ci.yml (build-per-tool job)
-npx @ai-driven-dev/cli@4.6.1 framework build --source . --target codex --out /tmp/aidd-codex
-codex plugin marketplace add /tmp/aidd-codex
-codex plugin add aidd-dev@aidd-framework      # check status with `codex plugin list`
+codex plugin marketplace add "$(pwd)"
+codex plugin add aidd-context@aidd-framework
+codex plugin add aidd-dev@aidd-framework
+codex plugin add aidd-vcs@aidd-framework
+codex plugin add aidd-pm@aidd-framework
+codex plugin add aidd-orchestrator@aidd-framework
+codex plugin add aidd-refine@aidd-framework
+codex plugin list --marketplace aidd-framework   # confirm every plugin is `installed, enabled`
 ```
 
-Point Codex at the build, not the repo root: the root ships Claude-format internals, so Codex would list the plugins but fail to load their agents. No live reload - rebuild, then `codex plugin marketplace upgrade`, after each change. Swap `--target codex` for `cursor`, `copilot`, or `opencode` to target another tool.
+No live reload - run `codex plugin marketplace upgrade` after each change to refresh.
 
 ## 2. Commit
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,15 +77,16 @@ After editing a `SKILL.md`, an agent, or any action, run `/reload-plugins` in th
 
 Claude Code then loads the plugins straight from your working tree: edit the framework, run `/reload-plugins`, and test the result in that project. The loop is edit - reload - try, with no publish step in between.
 
-**With Codex (or another non-Claude tool)** - the framework is authored in Claude Code syntax, so Codex loads a *built* distribution, not the working tree. Build the target-native marketplace from your checkout (the `--out` must sit outside `--source`), then register it the same way the [README install table](./README.md#another-ai-tool) does for a release asset:
+**With Codex (or another non-Claude tool)** - the framework is authored in Claude Code syntax, so Codex needs a *built* distribution with codex-native plugin internals (`.codex-plugin/`, `codex-agents/`), not the working tree. Build it from your checkout (`--out` must sit outside `--source`), register the build with Codex's own CLI, then install the plugins:
 
 ```bash
 # CLI version is pinned in .github/workflows/ci.yml (build-per-tool job)
 npx @ai-driven-dev/cli@4.6.1 framework build --source . --target codex --out /tmp/aidd-codex
-aidd marketplace add aidd-framework /tmp/aidd-codex
+codex plugin marketplace add /tmp/aidd-codex
+codex plugin add aidd-dev@aidd-framework      # repeat per plugin; check `codex plugin list`
 ```
 
-No live reload here - rebuild and re-add after each change; that build step is exactly what Claude Code skips by reading the source directly. Swap `--target codex` for `cursor`, `copilot`, or `opencode` to test another tool.
+Point Codex at the build, not the repo root: the root ships Claude-format internals, so Codex would list the plugins but fail to load their agents. No live reload - rebuild, then `codex plugin marketplace upgrade`, after each change. Swap `--target codex` for `cursor`, `copilot`, or `opencode` to target another tool.
 
 ## 2. Commit
 
@@ -129,10 +130,8 @@ The [`DCO`](./.github/workflows/dco.yml) check fails any unsigned commit. Versio
   | `enhancement` | A new skill, agent, rule, or feature. |
   | `documentation` | A docs-only change (README, CONTRIBUTING, skill docs). |
   | `security` | A security-sensitive change or fix. |
-  | `dependencies` / `npm` / `github-actions` | Dependency or workflow bumps - usually set by Dependabot, not by hand. |
-  | `autorelease: pending` / `autorelease: tagged` | Set by release-please; never applied by hand. |
 
-  Canonical list: [`.github/labels.yml`](./.github/labels.yml).
+  The rest (`dependencies`, `npm`, `github-actions`, `autorelease: *`) are applied by automation, not by hand. Canonical list: [`.github/labels.yml`](./.github/labels.yml).
 - The PR title follows the same conventional format (the **Commitlint** CI job enforces it); PRs are squash-merged using that title.
 - A **Habilité** review gates every merge ([`CODEOWNERS`](./.github/CODEOWNERS)); Certifié contributors cannot self-merge.
 - Decision rules (lazy consensus, explicit consensus for cross-plugin/contract changes, the quality veto) live in [`GOVERNANCE.md`](./GOVERNANCE.md#code-decisions-merging).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,16 @@ After editing a `SKILL.md`, an agent, or any action, run `/reload-plugins` in th
 
 Claude Code then loads the plugins straight from your working tree: edit the framework, run `/reload-plugins`, and test the result in that project. The loop is edit - reload - try, with no publish step in between.
 
+**With Codex (or another non-Claude tool)** - the framework is authored in Claude Code syntax, so Codex loads a *built* distribution, not the working tree. Build the target-native marketplace from your checkout (the `--out` must sit outside `--source`), then register it the same way the [README install table](./README.md#another-ai-tool) does for a release asset:
+
+```bash
+# CLI version is pinned in .github/workflows/ci.yml (build-per-tool job)
+npx @ai-driven-dev/cli@4.6.1 framework build --source . --target codex --out /tmp/aidd-codex
+aidd marketplace add aidd-framework /tmp/aidd-codex
+```
+
+No live reload here - rebuild and re-add after each change; that build step is exactly what Claude Code skips by reading the source directly. Swap `--target codex` for `cursor`, `copilot`, or `opencode` to test another tool.
+
 ## 2. Commit
 
 Format: `<type>(<scope>): description`, **signed off** for the [DCO](https://developercertificate.org/).
@@ -111,7 +121,18 @@ The [`DCO`](./.github/workflows/dco.yml) check fails any unsigned commit. Versio
 
 - Work on a branch, not `main`.
 - **Fill the PR template** (applied automatically): explain *what* changed and *how* you resolved it technically - that narrative is the point of the PR. The conventional title, DCO sign-off, and pre-commit hooks are already enforced by CI, so don't spend the description re-asserting them.
-- **Add the matching label** so reviewers and the [Roadmap board](https://github.com/orgs/ai-driven-dev/projects/8) triage at a glance: `bug` (a fix), `enhancement` (a new skill, agent, or feature), `documentation` (docs only), `security` (security-sensitive). `dependencies` / `npm` / `github-actions` / `autorelease: *` are set by automation, not by hand. Full list: [`.github/labels.yml`](./.github/labels.yml).
+- **Label the PR** so reviewers and the [Roadmap board](https://github.com/orgs/ai-driven-dev/projects/8) triage at a glance:
+
+  | Label | When to use |
+  | ----- | ----------- |
+  | `bug` | A fix for broken behaviour. |
+  | `enhancement` | A new skill, agent, rule, or feature. |
+  | `documentation` | A docs-only change (README, CONTRIBUTING, skill docs). |
+  | `security` | A security-sensitive change or fix. |
+  | `dependencies` / `npm` / `github-actions` | Dependency or workflow bumps - usually set by Dependabot, not by hand. |
+  | `autorelease: pending` / `autorelease: tagged` | Set by release-please; never applied by hand. |
+
+  Canonical list: [`.github/labels.yml`](./.github/labels.yml).
 - The PR title follows the same conventional format (the **Commitlint** CI job enforces it); PRs are squash-merged using that title.
 - A **Habilité** review gates every merge ([`CODEOWNERS`](./.github/CODEOWNERS)); Certifié contributors cannot self-merge.
 - Decision rules (lazy consensus, explicit consensus for cross-plugin/contract changes, the quality veto) live in [`GOVERNANCE.md`](./GOVERNANCE.md#code-decisions-merging).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,43 @@ pnpm exec lefthook install
 
 Every commit then runs the framework checks (json/yaml validity, schema validation, SKILL.md frontmatter, CATALOG regeneration, commitlint). Check your environment anytime with `./scripts/doctor.sh`.
 
+### Test your changes locally
+
+Before opening a PR, load your working tree into a real project and exercise the skills you touched. This repository is itself a marketplace, so you point an assistant at your local checkout instead of a published release.
+
+**With Claude Code (recommended)** - register the checkout as a local marketplace, then install the plugins you are working on:
+
+```text
+/plugin marketplace add .                  # from the repo root; or pass an absolute path
+/plugin install aidd-dev@aidd-framework
+```
+
+After editing a `SKILL.md`, an agent, or any action, run `/reload-plugins` in the same session to pick up the change - no reinstall needed.
+
+**Pin the checkout from a personal project** - to keep one of your own projects wired to your local framework while you develop, add a `directory` marketplace in that project's `.claude/settings.local.json` (the personal, machine-local settings file, not the team-shared `settings.json`):
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "aidd-framework": {
+      "source": {
+        "source": "directory",
+        "path": "/absolute/path/to/aidd-framework"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "aidd-context@aidd-framework": true,
+    "aidd-dev@aidd-framework": true,
+    "aidd-vcs@aidd-framework": true,
+    "aidd-pm@aidd-framework": true,
+    "aidd-refine@aidd-framework": true
+  }
+}
+```
+
+Claude Code then loads the plugins straight from your working tree: edit the framework, run `/reload-plugins`, and test the result in that project. The loop is edit - reload - try, with no publish step in between.
+
 ## 2. Commit
 
 Format: `<type>(<scope>): description`, **signed off** for the [DCO](https://developercertificate.org/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ The [`DCO`](./.github/workflows/dco.yml) check fails any unsigned commit. Versio
 
 - Work on a branch, not `main`.
 - **Fill the PR template** (applied automatically): explain *what* changed and *how* you resolved it technically - that narrative is the point of the PR. The conventional title, DCO sign-off, and pre-commit hooks are already enforced by CI, so don't spend the description re-asserting them.
-- **Add the matching label** - `documentation`, `enhancement`, `bug`, `security`, ... The canonical list is [`.github/labels.yml`](./.github/labels.yml); it doubles as the triage signal for the [Roadmap board](https://github.com/orgs/ai-driven-dev/projects/8).
+- **Add the matching label** so reviewers and the [Roadmap board](https://github.com/orgs/ai-driven-dev/projects/8) triage at a glance: `bug` (a fix), `enhancement` (a new skill, agent, or feature), `documentation` (docs only), `security` (security-sensitive). `dependencies` / `npm` / `github-actions` / `autorelease: *` are set by automation, not by hand. Full list: [`.github/labels.yml`](./.github/labels.yml).
 - The PR title follows the same conventional format (the **Commitlint** CI job enforces it); PRs are squash-merged using that title.
 - A **Habilité** review gates every merge ([`CODEOWNERS`](./.github/CODEOWNERS)); Certifié contributors cannot self-merge.
 - Decision rules (lazy consensus, explicit consensus for cross-plugin/contract changes, the quality veto) live in [`GOVERNANCE.md`](./GOVERNANCE.md#code-decisions-merging).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,8 +110,9 @@ The [`DCO`](./.github/workflows/dco.yml) check fails any unsigned commit. Versio
 ## 3. Open a pull request
 
 - Work on a branch, not `main`.
-- **Fill the PR template** (applied automatically): summary, changes, test plan, and the checklist (conventional title + correct scope, DCO sign-off, docs updated).
-- The PR title follows the same conventional format (a `lint-pr` check enforces it); PRs are squash-merged using that title.
+- **Fill the PR template** (applied automatically): explain *what* changed and *how* you resolved it technically - that narrative is the point of the PR. The conventional title, DCO sign-off, and pre-commit hooks are already enforced by CI, so don't spend the description re-asserting them.
+- **Add the matching label** - `documentation`, `enhancement`, `bug`, `security`, ... The canonical list is [`.github/labels.yml`](./.github/labels.yml); it doubles as the triage signal for the [Roadmap board](https://github.com/orgs/ai-driven-dev/projects/8).
+- The PR title follows the same conventional format (the **Commitlint** CI job enforces it); PRs are squash-merged using that title.
 - A **Habilité** review gates every merge ([`CODEOWNERS`](./.github/CODEOWNERS)); Certifié contributors cannot self-merge.
 - Decision rules (lazy consensus, explicit consensus for cross-plugin/contract changes, the quality veto) live in [`GOVERNANCE.md`](./GOVERNANCE.md#code-decisions-merging).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,14 +45,13 @@ Every commit then runs the framework checks (json/yaml validity, schema validati
 Before opening a PR, exercise the skills you touched in a real session. Clone the framework, then point your assistant at the checkout instead of a published release:
 
 ```bash
-git clone https://github.com/ai-driven-dev/aidd-framework
-cd aidd-framework
+git clone https://github.com/ai-driven-dev/aidd-framework ~/projects/aidd-framework
 ```
 
 **With Claude Code (recommended)** - register the checkout as a local marketplace, then install the plugins you are working on:
 
 ```text
-/plugin marketplace add .                  # from the repo root
+/plugin marketplace add ~/projects/aidd-framework
 /plugin install aidd-context@aidd-framework
 /plugin install aidd-dev@aidd-framework
 /plugin install aidd-vcs@aidd-framework
@@ -71,7 +70,7 @@ After editing a `SKILL.md`, an agent, or any action, run `/reload-plugins` in th
     "aidd-framework": {
       "source": {
         "source": "directory",
-        "path": "/absolute/path/to/aidd-framework"
+        "path": "~/projects/aidd-framework"
       }
     }
   },
@@ -91,7 +90,7 @@ Claude Code then loads the plugins straight from your working tree: edit the fra
 **With Codex** - Codex reads the same marketplace manifest, so register the cloned checkout with Codex's own CLI (pass an absolute path; `./` is rejected), then install the plugins:
 
 ```bash
-codex plugin marketplace add "$(pwd)"
+codex plugin marketplace add ~/projects/aidd-framework
 codex plugin add aidd-context@aidd-framework
 codex plugin add aidd-dev@aidd-framework
 codex plugin add aidd-vcs@aidd-framework

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,12 @@ Claude Code then loads the plugins straight from your working tree: edit the fra
 # CLI version is pinned in .github/workflows/ci.yml (build-per-tool job)
 npx @ai-driven-dev/cli@4.6.1 framework build --source . --target codex --out /tmp/aidd-codex
 codex plugin marketplace add /tmp/aidd-codex
-codex plugin add aidd-dev@aidd-framework      # repeat per plugin; check `codex plugin list`
+
+# install + enable every plugin (same set as the Claude example above)
+for p in aidd-context aidd-dev aidd-vcs aidd-pm aidd-refine; do
+  codex plugin add "$p@aidd-framework"
+done
+codex plugin list      # STATUS -> installed, enabled
 ```
 
 Point Codex at the build, not the repo root: the root ships Claude-format internals, so Codex would list the plugins but fail to load their agents. No live reload - rebuild, then `codex plugin marketplace upgrade`, after each change. Swap `--target codex` for `cursor`, `copilot`, or `opencode` to target another tool.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,8 +144,6 @@ The [`DCO`](./.github/workflows/dco.yml) check fails any unsigned commit. Versio
   | `enhancement` | A new skill, agent, rule, or feature. |
   | `documentation` | A docs-only change (README, CONTRIBUTING, skill docs). |
   | `security` | A security-sensitive change or fix. |
-
-  The rest (`dependencies`, `npm`, `github-actions`, `autorelease: *`) are applied by automation, not by hand. Canonical list: [`.github/labels.yml`](./.github/labels.yml).
 - The PR title follows the same conventional format (the **Commitlint** CI job enforces it); PRs are squash-merged using that title.
 - A **Habilité** review gates every merge ([`CODEOWNERS`](./.github/CODEOWNERS)); Certifié contributors cannot self-merge.
 - Decision rules (lazy consensus, explicit consensus for cross-plugin/contract changes, the quality veto) live in [`GOVERNANCE.md`](./GOVERNANCE.md#code-decisions-merging).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,12 @@ Every commit then runs the framework checks (json/yaml validity, schema validati
 
 ### Test your changes locally
 
-Before opening a PR, load your working tree into a real project and exercise the skills you touched. This repository is itself a marketplace, so you point an assistant at your local checkout instead of a published release.
+Before opening a PR, exercise the skills you touched in a real session. Clone the framework, then point your assistant at the checkout instead of a published release:
+
+```bash
+git clone https://github.com/ai-driven-dev/aidd-framework
+cd aidd-framework
+```
 
 **With Claude Code (recommended)** - register the checkout as a local marketplace, then install the plugins you are working on:
 
@@ -77,18 +82,13 @@ After editing a `SKILL.md`, an agent, or any action, run `/reload-plugins` in th
 
 Claude Code then loads the plugins straight from your working tree: edit the framework, run `/reload-plugins`, and test the result in that project. The loop is edit - reload - try, with no publish step in between.
 
-**With Codex (or another non-Claude tool)** - the framework is authored in Claude Code syntax, so Codex needs a *built* distribution with codex-native plugin internals (`.codex-plugin/`, `codex-agents/`), not the working tree. Build it from your checkout (`--out` must sit outside `--source`), register the build with Codex's own CLI, then install the plugins:
+**With Codex (or another non-Claude tool)** - the framework is authored in Claude Code syntax, so Codex needs a *built* distribution with codex-native plugin internals (`.codex-plugin/`, `codex-agents/`), not the working tree. Build it from your checkout (`--out` must sit outside `--source`), register the build with Codex's own CLI, then install the plugins you are working on:
 
 ```bash
 # CLI version is pinned in .github/workflows/ci.yml (build-per-tool job)
 npx @ai-driven-dev/cli@4.6.1 framework build --source . --target codex --out /tmp/aidd-codex
 codex plugin marketplace add /tmp/aidd-codex
-
-# install + enable every plugin (same set as the Claude example above)
-for p in aidd-context aidd-dev aidd-vcs aidd-pm aidd-refine; do
-  codex plugin add "$p@aidd-framework"
-done
-codex plugin list      # STATUS -> installed, enabled
+codex plugin add aidd-dev@aidd-framework      # check status with `codex plugin list`
 ```
 
 Point Codex at the build, not the repo root: the root ships Claude-format internals, so Codex would list the plugins but fail to load their agents. No live reload - rebuild, then `codex plugin marketplace upgrade`, after each change. Swap `--target codex` for `cursor`, `copilot`, or `opencode` to target another tool.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,9 @@ Before opening a PR, exercise the skills you touched in a real session. Clone th
 git clone https://github.com/ai-driven-dev/aidd-framework ~/projects/aidd-framework
 ```
 
-**With Claude Code (recommended)** - register the checkout as a local marketplace, then install the plugins you are working on:
+#### Claude Code
+
+Register the checkout as a local marketplace, then install the plugins:
 
 ```text
 /plugin marketplace add ~/projects/aidd-framework
@@ -62,7 +64,7 @@ git clone https://github.com/ai-driven-dev/aidd-framework ~/projects/aidd-framew
 
 After editing a `SKILL.md`, an agent, or any action, run `/reload-plugins` in the same session to pick up the change - no reinstall needed.
 
-**Pin the checkout from a personal project** - to keep one of your own projects wired to your local framework while you develop, add a `directory` marketplace in that project's `.claude/settings.local.json` (the personal, machine-local settings file, not the team-shared `settings.json`):
+To load the plugins into a personal project, point its `.claude/settings.local.json` at the checkout:
 
 ```json
 {
@@ -85,9 +87,9 @@ After editing a `SKILL.md`, an agent, or any action, run `/reload-plugins` in th
 }
 ```
 
-Claude Code then loads the plugins straight from your working tree: edit the framework, run `/reload-plugins`, and test the result in that project. The loop is edit - reload - try, with no publish step in between.
+#### Codex
 
-**With Codex** - Codex reads the same marketplace manifest, so register the cloned checkout with Codex's own CLI (pass an absolute path; `./` is rejected), then install the plugins:
+Register the checkout (pass an absolute path; `./` is rejected), then install the plugins:
 
 ```bash
 codex plugin marketplace add ~/projects/aidd-framework


### PR DESCRIPTION
## 🎯 What & why

Three contributor-doc gaps, found while wiring a local checkout into a real project.

## 🛠️ How it works

- **Local testing guide** (`CONTRIBUTING.md` §1) - clone into `~/projects/aidd-framework`, link it from Claude Code or Codex, install the six plugins.
- **PR template** - dropped the CI-redundant checklist, refocused on a technical *How it works* + author certification.
- **Label guide** (§3) - `label -> when to use` table for the four manual labels.

## ⚠️ Heads-up

[`README.md:119`](README.md#L119) Codex install row likely outdated - `codex plugin marketplace add <repo>` registers the checkout directly. Separate `framework` PR.

## ✅ I certify

- [ ] Docs updated to match the new behaviour.
- [ ] I self-reviewed this PR.
- [ ] No cross-plugin references introduced.