### PR TITLE
chore(framework): enable local AIDD plugins for repo dogfooding

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "extraKnownMarketplaces": {
+    "aidd-framework": {
+      "source": { "source": "directory", "path": "." }
+    }
+  },
+  "enabledPlugins": {
+    "aidd-context@aidd-framework": true,
+    "aidd-dev@aidd-framework": true,
+    "aidd-vcs@aidd-framework": true,
+    "aidd-pm@aidd-framework": true,
+    "aidd-orchestrator@aidd-framework": true,
+    "aidd-refine@aidd-framework": true
+  }
+}


### PR DESCRIPTION
## 🎯 What & why

Enable the repo's own six AIDD plugins from the local working tree so contributors load the framework's own skills (dogfooding) instead of having to run a manual `/plugin marketplace add`.

## 🛠️ How it works

New committed `.claude/settings.json`:

- `extraKnownMarketplaces` registers the working tree as the `aidd-framework` marketplace via a `directory` source (`path: "."`).
- `enabledPlugins` turns on the six plugins as `<plugin>@aidd-framework`.

Chosen over the one-time `/plugin marketplace add .` command because committed settings apply for every contributor automatically. Personal `settings.local.json` (gitignored) is untouched.

## 🧪 How to verify

- Open the repo in Claude Code and confirm the aidd-* skills are listed (e.g. `aidd-context:03-context-generate`) without running `/plugin marketplace add` first.
- `jq . .claude/settings.json` is valid JSON; `git check-ignore .claude/settings.json` prints nothing (the file is tracked).

## ⚠️ Heads-up

Claude Code does not hot-reload a `settings.json` created mid-session; contributors already in a session need a restart (or opening `/hooks`) to pick up the plugins.

## ✅ I certify

- [ ] Docs updated to match the new behaviour.
- [ ] I self-reviewed this PR.
- [ ] No cross-plugin references introduced.
