### PR TITLE
docs(framework): add a human self-review attestation to the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -38,8 +38,4 @@ Closes #
 
 <!-- The author ticks these on GitHub before merge. Not for the AI to fill or delete - these are the checks no CI job can make. -->
 
-**I DO CERTIFY I READ EACH LINE OF THE PULL REQUEST BECAUSE I AM A SOFTWARE ENGINEER, NOT A AI PUPPY.**
-
-- [ ] Docs updated to match the new behaviour.
-- [ ] I self-reviewed this PR.
-- [ ] No cross-plugin references introduced.
+- [ ] **I DO CERTIFY I READ EACH LINE OF THE PULL REQUEST BECAUSE I AM A SOFTWARE ENGINEER, NOT A AI PUPPY.**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -38,6 +38,8 @@ Closes #
 
 <!-- The author ticks these on GitHub before merge. Not for the AI to fill or delete - these are the checks no CI job can make. -->
 
+**I DO CERTIFY I READ EACH LINE OF THE PULL REQUEST BECAUSE I AM A SOFTWARE ENGINEER, NOT A AI PUPPY.**
+
 - [ ] Docs updated to match the new behaviour.
 - [ ] I self-reviewed this PR.
 - [ ] No cross-plugin references introduced.


### PR DESCRIPTION
## 🎯 What & why

Reduces the "I certify" section of the PR template to a single, bold human attestation - reviewing the diff line by line is an owned commitment, not a rubber-stamp. The two mechanical boxes it replaces are tracked for machine enforcement in #250.

## 🛠️ How it works

- [.github/PULL_REQUEST_TEMPLATE.md:41](.github/PULL_REQUEST_TEMPLATE.md#L41) - the certify checklist becomes one bold checkbox; the "docs updated" and "no cross-plugin references" boxes are removed (they move to CI/hook enforcement, see #250).

## 🧪 How to verify

- Open a new PR and confirm the certify section shows the single bold checkbox.

## ✅ I certify

<!-- The author ticks these on GitHub before merge. Not for the AI to fill or delete - these are the checks no CI job can make. -->

- [ ] **I DO CERTIFY I READ EACH LINE OF THE PULL REQUEST BECAUSE I AM A SOFTWARE ENGINEER, NOT A AI PUPPY.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)