### PR TITLE
feat(aidd-vcs): add repo-init skill (init + publish a repository)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 <p><b>🇫🇷 The first French open-source framework for AI-driven development.</b></p>
 
 <p>
-  <!--counts:start--><kbd>7 plugins</kbd> · <kbd>39 skills</kbd> · <kbd>3 agents</kbd><!--counts:end--> · <kbd>MIT</kbd>
+  <!--counts:start--><kbd>7 plugins</kbd> · <kbd>40 skills</kbd> · <kbd>3 agents</kbd><!--counts:end--> · <kbd>MIT</kbd>
 </p>
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
@@ -178,7 +178,7 @@ SDLC loop: sdlc, plan, implement, assert, audit, review, test, refactor, debug, 
 
 ### 🌿 [aidd-vcs](plugins/aidd-vcs/README.md)
 
-`4 skills` · stable
+`5 skills` · stable
 
 Commits, pull / merge requests, release tags, issue creation.
 

--- a/plugins/aidd-vcs/.claude-plugin/plugin.json
+++ b/plugins/aidd-vcs/.claude-plugin/plugin.json
@@ -2,12 +2,13 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "aidd-vcs",
   "version": "2.0.0",
-  "description": "External artifacts: commit, pull-request, release-tag, issue-create",
+  "description": "External artifacts: repo-init, commit, pull-request, release-tag, issue-create",
   "author": {
     "name": "AI-Driven Dev",
     "url": "https://github.com/ai-driven-dev"
   },
   "skills": [
+    "./skills/00-repo-init",
     "./skills/01-commit",
     "./skills/02-pull-request",
     "./skills/03-release-tag",
@@ -15,6 +16,7 @@
   ],
   "keywords": [
     "git",
+    "repo-init",
     "commit",
     "pull-request",
     "release",

--- a/plugins/aidd-vcs/CATALOG.md
+++ b/plugins/aidd-vcs/CATALOG.md
@@ -8,6 +8,7 @@ Auto-generated index of skills, agents, references and assets shipped by the `ai
 
 - [`.claude-plugin`](#claude-plugin)
 - [`skills`](#skills)
+  - [`skills/00-repo-init`](#skills00-repo-init)
   - [`skills/01-commit`](#skills01-commit)
   - [`skills/02-pull-request`](#skills02-pull-request)
   - [`skills/03-release-tag`](#skills03-release-tag)
@@ -22,6 +23,16 @@ Auto-generated index of skills, agents, references and assets shipped by the `ai
 | [plugin.json](.claude-plugin/plugin.json) |
 
 ### `skills`
+
+#### `skills/00-repo-init`
+
+| Group | File | Description |
+|-------|------|---|
+| `actions` | [01-init.md](skills/00-repo-init/actions/01-init.md) | - |
+| `actions` | [02-publish.md](skills/00-repo-init/actions/02-publish.md) | - |
+| `assets` | [CONTRIBUTING.md](skills/00-repo-init/assets/CONTRIBUTING.md) | - |
+| `-` | [README.md](skills/00-repo-init/README.md) | - |
+| `-` | [SKILL.md](skills/00-repo-init/SKILL.md) | `Initialize a project's repository - resolve the default branch and VCS provider, run git init with a bootstrap commit, write CONTRIBUTING.md, and on request create the remote repository and push. Use when the user says "init a repo", "git init", "initialize version control", "set up a new repo", "start a project", "create the remote and push", or "publish this repo". Do NOT use for committing changes (use 01-commit), opening pull requests (use 02-pull-request), tagging releases (use 03-release-tag), or cloning an existing remote.` |
 
 #### `skills/01-commit`
 
@@ -42,7 +53,7 @@ Auto-generated index of skills, agents, references and assets shipped by the `ai
 | `assets` | [pull_request.md](skills/02-pull-request/assets/pull_request.md) | `VCS pull/merge request template` |
 | `assets` | [README.md](skills/02-pull-request/assets/README.md) | `Project README template` |
 | `-` | [README.md](skills/02-pull-request/README.md) | - |
-| `-` | [SKILL.md](skills/02-pull-request/SKILL.md) | `Create a draft pull or merge request from the current branch. Use when the user says "open a pr", "open a pull request", "create a pr", "create a merge request", "open mr", "draft a pr for this branch", or invokes `/pull-request`. Do NOT use for committing changes, pushing a branch directly, tagging releases, merging an existing request, or amending commits.` |
+| `-` | [SKILL.md](skills/02-pull-request/SKILL.md) | `Create a draft pull or merge request from the current branch. Use when the user ask to create a PR or invokes `/pull-request`.` |
 
 #### `skills/03-release-tag`
 

--- a/plugins/aidd-vcs/skills/00-repo-init/README.md
+++ b/plugins/aidd-vcs/skills/00-repo-init/README.md
@@ -1,0 +1,34 @@
+← [aidd-vcs](../../README.md)
+
+# 00-repo-init
+
+Initializes a project's repository locally and, on request, on the remote host: `git init`, sets the default branch, resolves the provider, and can create the remote repository and push, returning its URL.
+
+> Status: experimental.
+
+## When to use
+
+- Starting version control on a new project (e.g. right after scaffolding it).
+- Creating the remote repository and pushing the initial state.
+
+## When NOT to use
+
+- Cloning an existing remote, opening pull requests, or tagging releases.
+- Re-initializing a directory that is already a repository (the local step no-ops there).
+
+## How to invoke
+
+`aidd-vcs:00-repo-init`, or say "initialize a git repository here" / "create the remote and publish".
+
+## Outputs
+
+- `init`: an initialized `.git`, the default branch set, the resolved provider, and `origin` added when a remote URL is given.
+- `publish`: the created remote repository and a push, returning its URL.
+
+## Prerequisites
+
+- `git` on the PATH. For `publish`, the resolved host's tooling (CLI, MCP, or API) available and authenticated.
+
+## Technical details
+
+Two actions: `init` (local) and `publish` (remote, outward-facing, confirms first). See [SKILL.md](SKILL.md).

--- a/plugins/aidd-vcs/skills/00-repo-init/SKILL.md
+++ b/plugins/aidd-vcs/skills/00-repo-init/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: 00-repo-init
+description: Initialize a project's repository - resolve the default branch and VCS provider, run git init with a bootstrap commit, write CONTRIBUTING.md, and on request create the remote repository and push. Use when the user says "init a repo", "git init", "initialize version control", "set up a new repo", "start a project", "create the remote and push", or "publish this repo". Do NOT use for committing changes (use 01-commit), opening pull requests (use 02-pull-request), tagging releases (use 03-release-tag), or cloning an existing remote.
+argument-hint: init | publish
+---
+
+# Repo Init
+
+Initializes a project's repository locally and, on request, on the remote host, then returns the remote URL.
+
+## Available actions
+
+| #   | Action    | Role                                                                                              | Input                           |
+| --- | --------- | ------------------------------------------------------------------------------------------------- | ------------------------------- |
+| 01  | `init`    | Resolve VCS config, `git init`, set the default branch, write `CONTRIBUTING.md`, bootstrap commit | cwd, default_branch, remote_url |
+| 02  | `publish` | Create the remote repo on the resolved host and push, return its URL                              | cwd, non_interactive            |
+
+## Default flow
+
+Chain `01 → 02`, testing each before the next. The router runs `init` alone for a local-only request, and runs `publish` after an `init` when asked to create the remote.
+
+## Transversal rules
+
+- The local step is idempotent. If the target is already a git work tree, `init` does nothing and reports.
+- `init` makes one bootstrap commit (`--allow-empty`) so `HEAD` exists and is pushable. The project's real first commit stays the commit skill's job.
+- `publish` is outward-facing. It confirms before creating the remote unless `non_interactive` is set.
+- The provider is open. Resolve the host and how to reach it (CLI, MCP, or API) from the VCS memory when present, else from the VCS tooling available in the environment. Never restrict to a fixed list or a fixed mechanism. `main` is the default-branch fallback.
+
+## Assets
+
+- `assets/CONTRIBUTING.md`: the project-root `CONTRIBUTING.md` template.
+
+## External data
+
+- `aidd_docs/memory/vcs.md`: the project's VCS config (default branch, provider), read by both actions when present and pointed to, never copied.

--- a/plugins/aidd-vcs/skills/00-repo-init/actions/01-init.md
+++ b/plugins/aidd-vcs/skills/00-repo-init/actions/01-init.md
@@ -1,0 +1,34 @@
+# 01 - Init
+
+Initialize a fresh local git repository on the resolved default branch.
+
+## Input
+
+- `cwd` (optional): directory to initialize. Defaults to the current directory.
+- `default_branch` (optional): overrides the resolved branch.
+- `remote_url` (optional): added as `origin` when given.
+
+## Output
+
+A report of the repo root, the resolved default branch and provider, and whether `origin` was added. Reports `created: false` and stops when the target is already a git work tree.
+
+## Process
+
+1. **Guard.** If `cwd` is already a git work tree, skip and report `created: false`.
+2. **Resolve.** Read the default branch and provider from the project's VCS memory. If absent, infer the provider from the environment (an installed VCS CLI, a configured MCP, or an existing remote URL). Fall back to `main` when nothing resolves. An explicit `default_branch` wins.
+3. **Init.** Run `git init -b <default_branch> <cwd>`.
+4. **Contribute.** Write `CONTRIBUTING.md` at the repo root from the template, filling `{{PROJECT_NAME}}`. Leave no raw `{{...}}`.
+
+   ```markdown
+   @../assets/CONTRIBUTING.md
+   ```
+
+5. **Bootstrap.** Commit once so `HEAD` exists and is pushable: `git -C <cwd> commit --allow-empty -m "chore: initialize repository"`.
+6. **Remote.** If `remote_url` is given, run `git -C <cwd> remote add origin <remote_url>`.
+
+## Test
+
+- `git -C <cwd> rev-parse --is-inside-work-tree` prints `true`.
+- `git -C <cwd> symbolic-ref --short HEAD` equals the resolved default branch.
+- `CONTRIBUTING.md` exists at the repo root and contains no `{{`.
+- `git -C <cwd> rev-parse HEAD` resolves to a commit.

--- a/plugins/aidd-vcs/skills/00-repo-init/actions/02-publish.md
+++ b/plugins/aidd-vcs/skills/00-repo-init/actions/02-publish.md
@@ -1,0 +1,24 @@
+# 02 - Publish
+
+Create the project's remote repository on the resolved host and push to it. Outward-facing; runs after `01-init`.
+
+## Input
+
+- `cwd` (optional): the initialized local repository. Defaults to the current directory.
+- `non_interactive` (optional, default `false`): skip the confirmation prompt for scaffolder or auto runs.
+
+## Output
+
+A report of the created remote URL, the resolved provider, and the pushed default branch.
+
+## Process
+
+1. **Resolve.** Read the host and how to reach it (CLI, MCP, or API) from the project's VCS memory. If absent, detect it from the VCS tooling available in the environment. Use no fixed provider list or fixed mechanism.
+2. **Confirm.** Unless `non_interactive`, confirm before creating the remote. The remote may be public, so create it private by default.
+3. **Create.** Create the remote repository and push through the resolved host tooling. `01-init` already left a pushable `HEAD`. If no host tooling is available, stop and report.
+4. **Return.** Report the remote URL to the user.
+
+## Test
+
+- The action prints a non-empty remote URL.
+- `git -C <cwd> remote get-url origin` resolves to that URL.

--- a/plugins/aidd-vcs/skills/00-repo-init/assets/CONTRIBUTING.md
+++ b/plugins/aidd-vcs/skills/00-repo-init/assets/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+# Contributing to {{PROJECT_NAME}}
+
+## Setup
+
+See `INSTALL.md`.
+
+## Workflow
+
+1. Branch off the default branch.
+2. Implement against the wired route stubs - keep architecture boundaries (see `INSTALL.md`).
+3. Add or extend tests alongside the code (see `INSTALL.md` for how to run them).
+4. Run the suite before opening a request.
+
+## Conventions
+
+- Commits: conventional commits (`<type>(<scope>): description`).
+- The CI pipeline runs the test suite on every push; keep it green.
+- Do not put business logic in route stubs until you replace them with real handlers.

--- a/plugins/aidd-vcs/skills/02-pull-request/SKILL.md
+++ b/plugins/aidd-vcs/skills/02-pull-request/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: 02-pull-request
-description: Create a draft pull or merge request from the current branch. Use when the user says "open a pr", "open a pull request", "create a pr", "create a merge request", "open mr", "draft a pr for this branch", or invokes `/pull-request`. Do NOT use for committing changes, pushing a branch directly, tagging releases, merging an existing request, or amending commits.
+description: Create a draft pull or merge request from the current branch. Use when the user ask to create a PR or invokes `/pull-request`.
 ---
 
 # Pull Request


### PR DESCRIPTION
## Quoi

Nouvelle skill **`aidd-vcs:00-repo-init`** : initialise un dépôt projet (git init, commit initial, `CONTRIBUTING.md`) et, sur demande, crée le remote + push.

- `actions/01-init.md` — résout branche par défaut + provider, git init, commit initial, écrit CONTRIBUTING.
- `actions/02-publish.md` — crée le dépôt distant et pousse.
- Enregistrée dans `aidd-vcs/.claude-plugin/plugin.json`.
- Tweak mineur de description sur `02-pull-request`.

Lot autonome extrait de `feat/scafolding` (cf. PR #268), porté propre sur `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)