### PR TITLE
docs(framework): streamline README, add recipes, extract marketplace doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ coverage/
 
 # Claude Code session-local
 .claude/settings.local.json
+.claude/worktrees/
 
 # SpecStory captures (may contain transcripts / secrets)
 .specstory/

--- a/README.md
+++ b/README.md
@@ -4,60 +4,57 @@
 
 # AI-Driven Dev Framework
 
-### A community-maintained marketplace of skills, agents, and rules for Claude Code.
+### Skills, agents & rules that run the full SDLC inside Claude Code — under human supervision.
 
 <p>
   <!--counts:start--><kbd>6 plugins</kbd> · <kbd>37 skills</kbd> · <kbd>3 agents</kbd><!--counts:end--> · <kbd>MIT</kbd>
 </p>
 
 <p>
-  <a href="#quick-start"><strong>Quick start →</strong></a> ·
-  <a href="#plugins"><strong>Browse plugins →</strong></a> ·
-  <a href="docs/ARCHITECTURE.md"><strong>How it works →</strong></a> ·
-  <a href="https://discord.gg/ai-driven-dev"><strong>Join Discord →</strong></a>
+  <a href="#-quick-start"><strong>Quick start →</strong></a> ·
+  <a href="#-plugins"><strong>Plugins →</strong></a> ·
+  <a href="recipes/"><strong>Recipes →</strong></a> ·
+  <a href="https://discord.gg/ai-driven-dev"><strong>Discord 🇫🇷 →</strong></a>
 </p>
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
-[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://www.conventionalcommits.org/)
-[![Git hooks: lefthook](https://img.shields.io/badge/git%20hooks-lefthook-007ACC.svg)](https://lefthook.dev/)
 [![Built for Claude Code](https://img.shields.io/badge/built%20for-Claude%20Code-D97757.svg)](https://code.claude.com/docs/en/discover-plugins)
-[![Maintained](https://img.shields.io/badge/maintained-yes-success.svg)](https://github.com/ai-driven-dev/framework/commits/main)
-[![Made in France](https://img.shields.io/badge/made%20in-France-0055A4?labelColor=EF4135)](https://www.ai-driven-dev.fr/)
-
 [![Latest Release](https://img.shields.io/github/v/release/ai-driven-dev/framework?include_prereleases&sort=semver)](https://github.com/ai-driven-dev/framework/releases)
 [![CI](https://github.com/ai-driven-dev/framework/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/ai-driven-dev/framework/actions/workflows/ci.yml)
+[![Made in France](https://img.shields.io/badge/made%20in-France-0055A4?labelColor=EF4135)](https://www.ai-driven-dev.fr/)
 
 </div>
 
 ---
 
-## What is the AIDD Framework?
+The **AIDD Framework** is a marketplace of **skills, agents, and rules** that make the AI-Driven Development flow concrete inside your AI coding assistant — the full SDLC (plan → implement → review → ship) under rigorous human supervision. It is the open toolset of the [AI-Driven Dev](https://www.ai-driven-dev.fr/) community, authored for **Claude Code**.
 
-The **AIDD Framework** is a marketplace of **skills, agents, rules, and conventions** that make the AI-Driven Development flow concrete inside your AI coding assistant - the full SDLC (plan → implement → review → ship) under rigorous human supervision. It is the open toolset of the [AI-Driven Dev](https://www.ai-driven-dev.fr/) community.
+## 👋 Who we are
 
-The framework is **authored for Claude Code**, and this repository is its native marketplace. Every release **also attaches archives adapted to each tool we support** - Cursor, GitHub Copilot, Codex, OpenCode (marketplace or flat format per tool) - so you grab the build that matches your assistant. See [Another AI tool?](#another-ai-tool) for the per-tool download + install table.
+Built by the **[AI-Driven Dev](https://www.ai-driven-dev.fr/)** community, founded by **Alex Soyes**.
 
-Founded by Alex Soyes - [Blog](https://alexsoyes.com/) · [GitHub](https://github.com/alexsoyes) · [LinkedIn](https://www.linkedin.com/in/alexsoyes/) · [X](https://x.com/alexsoyes).
+- 💬 **[Discord 🇫🇷](https://discord.gg/ai-driven-dev)** — live sessions every **Thursday**
+- 🎓 **[Training & community](https://www.ai-driven-dev.fr/)** — the AIDD programme (training · coaching · community)
+- ▶️ **[YouTube](https://www.youtube.com/@aidd_off)** · 💼 **[LinkedIn](https://www.linkedin.com/company/ai-driven-dev)** · 🌐 **[Website](https://www.ai-driven-dev.fr/)**
+- 👤 Alex Soyes — [Blog](https://alexsoyes.com/) · [GitHub](https://github.com/alexsoyes) · [LinkedIn](https://www.linkedin.com/in/alexsoyes/) · [X](https://x.com/alexsoyes)
 
-Join the conversation: [Discord](https://discord.gg/ai-driven-dev) · [YouTube](https://www.youtube.com/@aidd_off) · [LinkedIn](https://www.linkedin.com/company/ai-driven-dev) · [Website](https://www.ai-driven-dev.fr/)
+## 🧰 Supported tools
 
----
+The marketplace is **Claude Code native**. Every [release](https://github.com/ai-driven-dev/framework/releases/latest) also attaches an archive adapted to each other tool — download the one for your assistant and install it.
 
-## Prerequisites
+| Tool | Support | Install |
+| --- | --- | --- |
+| **Claude Code** | ✅ **Recommended** · native | `/plugin marketplace add ai-driven-dev/framework` |
+| **Cursor** | Supported | Download `…-cursor-flat-<version>.zip`, unzip into your project |
+| **GitHub Copilot** | Supported | Download `…-copilot-marketplace-<version>.zip`, `aidd marketplace add` |
+| **Codex** | Supported | Download `…-codex-marketplace-<version>.zip`, `aidd marketplace add` |
+| **OpenCode** | Supported | Download `…-opencode-flat-<version>.zip`, unzip into your project |
 
-Just an **AI coding assistant**. Everything else is per-plugin and optional.
+> On a non-Claude tool, map each skill's model tier to your tool's nearest model — see the [LLM tier reference](docs/MARKETPLACE.md#llm-tier-reference).
 
-| To… | You need |
-| --- | -------- |
-| Register & run the marketplace | An AI assistant - **Claude Code** runs this marketplace natively; for another tool, grab the release archive the `aidd-cli` builds for it |
-| Use a plugin's extras | Only what *that* plugin's README lists - e.g. `gh` / `glab` for VCS, a ticketing tool for PM |
+## 🚀 Quick start
 
-Nothing beyond the AI tool is required just to register the marketplace.
-
-## Quick start
-
-Register the marketplace and install the core plugins (Claude Code slash commands, not shell):
+**1. Install** — register the marketplace and the plugins (Claude Code slash commands, not shell):
 
 ```text
 /plugin marketplace add ai-driven-dev/framework
@@ -65,71 +62,31 @@ Register the marketplace and install the core plugins (Claude Code slash command
 /plugin install aidd-refine@aidd-framework
 /plugin install aidd-dev@aidd-framework
 /plugin install aidd-vcs@aidd-framework
+/plugin install aidd-pm@aidd-framework
+/plugin install aidd-orchestrator@aidd-framework
 ```
 
-Then set up project context (guided **onboard**, or direct **project-init**) and run the dev flow:
+**2. Onboard** — one command inspects your project and guides you:
+
+```text
+/aidd-context:00-onboard
+```
+
+**3. Run the flow** — take a feature from idea to shipped PR:
 
 ```mermaid
----
-title: AIDD quick start
----
-flowchart TD
-    Install["Marketplace + plugins installed"]
-    Setup{"Set up context"}
-    Onboard["aidd-context:00-onboard - guided hub"]
-    Init["aidd-context:02-project-init - context engineering"]
-    Brainstorm["aidd-refine:01-brainstorm"]
-    Plan["aidd-dev:01-plan"]
-    Implement["aidd-dev:02-implement"]
-    Assert["aidd-dev:03-assert"]
-    Review["aidd-dev:05-review"]
-    Commit["aidd-vcs:01-commit"]
-    PR["aidd-vcs:02-pull-request"]
-    Learn["aidd-context:10-learn"]
-
-    Install --> Setup
-    Setup -->|guided| Onboard
-    Setup -->|direct| Init
-    Onboard --> Init
-    Init --> Brainstorm
-    Brainstorm --> Plan
-    Plan --> Implement
-    Implement --> Assert
-    Assert --> Review
-    Review --> Commit
-    Commit --> PR
-    PR --> Learn
+flowchart LR
+    Onboard["/aidd-context:00-onboard"] --> Brainstorm["/aidd-refine:01-brainstorm"]
+    Brainstorm --> Plan["/aidd-dev:01-plan"]
+    Plan --> Implement["/aidd-dev:02-implement"]
+    Implement --> Review["/aidd-dev:05-review"]
+    Review --> Commit["/aidd-vcs:01-commit"]
+    Commit --> PR["/aidd-vcs:02-pull-request"]
 ```
 
-- **New here?** Run `/aidd-context:00-onboard` - it inspects the project and guides you.
-- **Whole loop in one command?** `/aidd-dev:00-sdlc` runs plan → implement → review → ship.
-- **More plugins?** Browse the [catalog](#plugins) or the `/plugin` Discover tab.
+> Want the whole loop in a single command? `/aidd-dev:00-sdlc` runs plan → implement → review → ship.
 
-### Another AI tool?
-
-The marketplace is Claude Code native. For Cursor, GitHub Copilot, Codex, or OpenCode, each
-[release](https://github.com/ai-driven-dev/framework/releases/latest) attaches a target-native
-archive. Download the one for your tool, unzip it, and install per the table - then map each tier to
-that tool's model via the **LLM tier reference** below.
-
-| Tool | Download (release asset) | Install |
-| --- | --- | --- |
-| **Claude Code** | — (native) | `/plugin marketplace add ai-driven-dev/framework` (no download needed) |
-| **GitHub Copilot** | `aidd-framework-copilot-marketplace-<version>.zip` | unzip, then `aidd marketplace add aidd-framework ./aidd-framework-copilot-marketplace-<version>` |
-| **Codex** | `aidd-framework-codex-marketplace-<version>.zip` | unzip, then `aidd marketplace add aidd-framework ./aidd-framework-codex-marketplace-<version>` |
-| **Cursor** | `aidd-framework-cursor-flat-<version>.zip` | unzip into your project (materializes `.cursor/`) |
-| **OpenCode** | `aidd-framework-opencode-flat-<version>.zip` | unzip into your project (materializes `.opencode/`) |
-
-> Today this is **download → unzip → install** (no one-command remote fetch yet). Marketplace
-> archives (`-marketplace-`) register through `aidd marketplace add`; flat archives (`-flat-`)
-> materialize straight into a project workspace. A flat variant of every tool and a marketplace
-> variant for Claude/Copilot/Codex are attached too - pick the format that fits your workflow.
-
-> **Private repo?** `/plugin marketplace add` needs read access (`gh auth login` or a PAT) - see the Anthropic [install docs](https://code.claude.com/docs/en/discover-plugins).
-
----
-
-## Plugins
+## 🧩 Plugins
 
 <table>
 <tr>
@@ -186,150 +143,44 @@ Meta-cognition: brainstorm, challenge, condense, shadow-areas, fact-check.
 
 `1 skill` · stable (`async-dev`)
 
-Label an issue, get a PR; re-label, get the review applied. Router-based skill: one entry point, three sub-flows (setup, run, review).
+Label an issue, get a PR; re-label, get the review applied.
 
 </td>
 </tr>
 </table>
 
-Each plugin's README links to per-skill READMEs covering when to use, how to invoke, prerequisites, and outputs.
+## 📖 Recipes
 
----
+Task-oriented how-to sheets — install an MCP server, optimise your tokens, and more.
 
-## Recommended MCP servers
+➡️ **[Browse the recipes →](recipes/)**
 
-> **Prefer the CLI over MCP. It is more efficient.**
+## 🤝 Contributing
 
-An MCP server loads its full tool schema into every turn. That bloats the context window and is less optimized.
+- 🐛 **Open an [issue](https://github.com/ai-driven-dev/framework/issues)** or share an idea in [Discussions](https://github.com/ai-driven-dev/framework/discussions).
+- 💬 **Join the [Discord 🇫🇷](https://discord.gg/ai-driven-dev)** — live every **Thursday**.
+- 📦 Building a plugin or a recipe? See [`CONTRIBUTING.md`](./CONTRIBUTING.md) and [`docs/CREATE_PLUGIN.md`](docs/CREATE_PLUGIN.md).
 
-A CLI call costs a few tokens. It returns only what you ask for.
+Roles, rights, and how decisions get made → [`GOVERNANCE.md`](./GOVERNANCE.md). By participating you agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
 
-Reach for MCP only when no CLI covers the service.
+## 🔒 Trust & safety
 
-**Always verify your sources. Audit what you install before connecting any server.**
+Plugins can run commands, edit files, and call external services on your behalf. Before installing any plugin from any marketplace, including this one: read its `README` and `SKILL.md`, inspect its actions, and check the permissions in its hooks and MCP servers. Spot a vulnerability? Report it privately via [`SECURITY.md`](./SECURITY.md).
 
-| Service | Official MCP | CLI alternative | Recommended |
-| --- | --- | --- | --- |
-| **GitHub** | [`api.githubcopilot.com/mcp/`](https://github.com/github/github-mcp-server) | [`gh`](https://cli.github.com/) | **CLI** - `gh` covers issues, PRs, releases, API at a fraction of the context |
-| **Atlassian** (Jira / Confluence) | [`mcp.atlassian.com/v1/mcp`](https://www.atlassian.com/platform/remote-mcp-server) | [`acli`](https://developer.atlassian.com/cloud/acli/guides/introduction/) (Jira only at GA) | **CLI** for Jira · **MCP** for Confluence (no CLI yet) |
-| **Playwright** | [`@playwright/mcp`](https://github.com/microsoft/playwright-mcp) | [`npx playwright`](https://playwright.dev/docs/test-cli) + [official skill](https://claude.com/plugins/playwright) | **CLI** - the CLI drives a real browser (`playwright open`, `codegen`, `--headed`). The skill wraps it |
-| **Figma** | [`mcp.figma.com/mcp`](https://developers.figma.com/docs/figma-mcp-server/remote-server-installation/) | none for design data | **MCP** |
-| **Notion** | [`mcp.notion.com/mcp`](https://developers.notion.com/guides/mcp/get-started-with-mcp) | none official | **MCP** |
-
----
-
-## How marketplaces work in Claude Code
-
-A marketplace is a Git repository that publishes plugins. When you run `/plugin marketplace add <owner>/<repo>`, Claude Code clones the repo, reads its `.claude-plugin/marketplace.json`, and offers the plugins listed there for install.
-
-`aidd-framework` is a **community-maintained, methodology-driven complement** to Anthropic's [official marketplace](https://github.com/anthropics/claude-plugins-official). The official catalog covers broadly useful plugins curated by Anthropic; AIDD ships plugins that materialise a specific way of working (the AI-Driven Development flow) inside Claude Code. The two are designed to coexist; you can register both and install plugins from either.
-
-The official Anthropic documentation covers the full model:
-
-- [Discover and install plugins](https://code.claude.com/docs/en/discover-plugins) - the user-facing flow
-- [Plugin marketplaces](https://code.claude.com/docs/en/plugin-marketplaces) - host your own
-- [Plugins reference](https://code.claude.com/docs/en/plugins-reference) - manifest + marketplace.json schemas
-- [Anthropic's official marketplace](https://github.com/anthropics/claude-plugins-official) - canonical example
-
-### Scopes
-
-Plugins can be installed at three different scopes:
-
-| Scope     | Stored in                  | Lifetime         | Best for |
-| --------- | -------------------------- | ---------------- | -------- |
-| `user`    | `~/.claude/plugins/`       | All your projects| Personal toolbelt |
-| `project` | `.claude/settings.json` (`enabledPlugins`) in the repo | This repo only | Team-shared setup |
-| `local`   | A local directory          | This machine     | Plugin development |
-
-Set scope at install time with the `/plugin` UI, or by editing `enabledPlugins` directly in `.claude/settings.json`.
-
----
-
-## Versioning and updates
-
-- Each plugin versions independently via `release-please`. Tags look like `aidd-<plugin>-vX.Y.Z`.
-- The root marketplace (`marketplace.json`) versions independently as `vX.Y.Z`.
-- Pull updates inside Claude Code with `/plugin marketplace update aidd-framework`.
-
-See [`CHANGELOG.md`](./CHANGELOG.md) for the full history.
-
----
-
-## Trust and safety
-
-This is a community-maintained marketplace. Plugins can execute commands, edit files, and call external services on your behalf. Before installing any plugin from any third-party marketplace, including this one:
-
-- Read its README and SKILL.md files.
-- Inspect the action files under `actions/`.
-- Check what permissions it requests in its hooks (`hooks/hooks.json`) and MCP servers (`.mcp.json`).
-
-If you spot a vulnerability, please report it privately via [SECURITY.md](./SECURITY.md).
-
----
-
-## Documentation
+## 📚 Documentation
 
 | Resource | Where |
 | -------- | ----- |
-| Architecture overview | [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) |
-| Skills catalog | [Plugins](#plugins) (each links its own `CATALOG.md`) |
-| Glossary | [`docs/GLOSSARY.md`](docs/GLOSSARY.md) |
+| How it works (architecture) | [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) |
+| Marketplace, scopes & versioning · LLM tiers | [`docs/MARKETPLACE.md`](docs/MARKETPLACE.md) |
+| Skills catalog | [`docs/CATALOG.md`](docs/CATALOG.md) |
 | Build your own plugin | [`docs/CREATE_PLUGIN.md`](docs/CREATE_PLUGIN.md) |
-| Frequently asked questions | [`docs/FAQ.md`](docs/FAQ.md) |
-| Troubleshooting & limits | [`docs/TROUBLESHOOTING.md`](docs/TROUBLESHOOTING.md) |
-| Contribution guide | [`CONTRIBUTING.md`](./CONTRIBUTING.md) |
-| Maintainers guide | [`docs/MAINTAINERS.md`](docs/MAINTAINERS.md) |
-| Governance | [`GOVERNANCE.md`](./GOVERNANCE.md) |
-| Roadmap | [`ROADMAP.md`](./ROADMAP.md) |
-| Contributors | [`CONTRIBUTORS.md`](./CONTRIBUTORS.md) |
-| Code of Conduct | [`CODE_OF_CONDUCT.md`](./CODE_OF_CONDUCT.md) |
-| Support | [`.github/SUPPORT.md`](./.github/SUPPORT.md) |
-| Security policy | [`SECURITY.md`](./SECURITY.md) |
-| Third-party licenses | [`THIRD_PARTY_LICENSES.md`](./THIRD_PARTY_LICENSES.md) |
-| Changelog | [`CHANGELOG.md`](./CHANGELOG.md) (see also [GitHub Releases](https://github.com/ai-driven-dev/framework/releases)) |
-| Anthropic plugin docs | [code.claude.com/docs/en/plugins](https://code.claude.com/docs/en/plugins) |
-
-Note: `aidd_docs/` and similar directories generated by `aidd-context:02-project-init` belong to user projects, not to this marketplace. Do not link them from framework-level documentation.
-
----
-
-<details>
-<summary><strong>LLM tier reference</strong> (used by skills that target a specific model tier)</summary>
-
-Some skills target a model **tier** when they need a particular capability. The framework is authored against Claude; on another AI tool, map each tier to that tool's nearest model.
-
-| Tier | Best for | Claude | Other tools (examples) |
-| ---- | -------- | ------ | ---------------------- |
-| **T1 Fast** | Mechanical, deterministic tasks, templates, git ops | Haiku 4.5 | GPT-5.5 mini, Gemini Flash, Grok fast |
-| **T2 Balanced** | Implementation, validation, code generation | Sonnet 4.6 | GPT-5.5, Gemini Pro |
-| **T3 Thinking** | Deep reasoning, synthesis, planning, onboarding | Opus 4.8 | GPT-5.5 (thinking), Gemini Pro thinking |
-
-</details>
-
----
-
-## Troubleshooting
-
-Install issues, load problems, and the framework's current limits → [`docs/TROUBLESHOOTING.md`](docs/TROUBLESHOOTING.md).
-
----
-
-## Contributing
-
-Everyone can shape this project. **Anyone** can open issues, react, and upvote ideas in [Discussions](https://github.com/ai-driven-dev/framework/discussions) (a signal); a counted roadmap vote is a benefit of **Core Team** membership in the [AIDD](https://www.ai-driven-dev.fr/) programme (training/community/coaching) and up, and **pull-request rights** are held by [Certifié and Habilité contributors](./GOVERNANCE.md#roles) so the standard stays consistent. See [`CONTRIBUTING.md`](./CONTRIBUTING.md) for the contribution flow, the commit scope discipline, and the templates each surface (skill, agent, rule, command) follows, and [`GOVERNANCE.md`](./GOVERNANCE.md) for the roles and how decisions get made.
-
-To build and ship a brand-new plugin through this marketplace, see [`docs/CREATE_PLUGIN.md`](docs/CREATE_PLUGIN.md).
-
-By participating you agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
-
----
-
-## Acknowledgements
-
-- [Anthropic](https://www.anthropic.com/) for Claude Code, the plugin marketplace model, and the [`claude-code-action`](https://github.com/anthropics/claude-code-action) GitHub Action.
-- [SchemaStore](https://www.schemastore.org/) for the canonical JSON schemas the lefthook hooks validate against.
-- [lefthook](https://lefthook.dev/), [release-please](https://github.com/googleapis/release-please), and [Contributor Covenant](https://www.contributor-covenant.org/) for the OSS toolchain underneath.
-- Everyone in the AIDD community who shares prompts, skills, and feedback. Without you this catalog would be empty.
+| Recipes | [`recipes/`](recipes/) |
+| FAQ · Troubleshooting | [`docs/FAQ.md`](docs/FAQ.md) · [`docs/TROUBLESHOOTING.md`](docs/TROUBLESHOOTING.md) |
+| Glossary | [`docs/GLOSSARY.md`](docs/GLOSSARY.md) |
+| Contributing · Governance | [`CONTRIBUTING.md`](./CONTRIBUTING.md) · [`GOVERNANCE.md`](./GOVERNANCE.md) |
+| Changelog · Roadmap | [`CHANGELOG.md`](./CHANGELOG.md) · [`ROADMAP.md`](./ROADMAP.md) |
+| Security | [`SECURITY.md`](./SECURITY.md) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The **AI-Driven Dev Framework** is a marketplace — **skills, agents, commands,
 
 > Orchestrate your SDLC (Software Development Life Cycle) at scale, the agentic engineering way.
 
-**Who we are** — built by the [AI-Driven Dev](https://www.ai-driven-dev.fr/) community (in France 🇫🇷): 3 years of R&D, 500+ developers trained in English 🇬🇧 and French 🇫🇷, shipping production software with 100% AI-generated code.
+**Who we are** — built by the [AI-Driven Dev](https://www.ai-driven-dev.fr/) community: 3 years of R&D, 500+ developers trained in English 🇬🇧 and French 🇫🇷, shipping production software with 100% AI-generated code.
 
 - **[Join the Discord 🇫🇷](https://discord.gg/ai-driven-dev)** — public [roadmap](./ROADMAP.md) decisions every Thursday morning.
 - **Want to train your team?** [See the programme](https://www.ai-driven-dev.fr/entreprise).

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ The **AI-Driven Dev Framework** is a marketplace — **skills, agents, commands,
 
 ## ✅ Compatibility
 
+> Primarily built on **Claude Code** (they set the standards), but compatibility with the other tools is ensured.
+
 | Tool | Status |
 | --- | --- |
 | **Claude Code** | ✅ Native · **recommended** |
@@ -35,8 +37,6 @@ The **AI-Driven Dev Framework** is a marketplace — **skills, agents, commands,
 | **OpenCode** | ✅ Supported |
 | **Gemini** | 🚧 In progress |
 | **Mistral** | 🚧 In progress |
-
-> Primarily built on **Claude Code** (they set the standards), but compatibility with the other tools is ensured.
 
 ## 👥 Community
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # AI-Driven Dev Framework
 
-### Skills, agents & rules that run the full SDLC inside your AI coding assistant — under human supervision.
+### Vibe Coding for professional developers — focused on 100% quality on AI-generated code.
 
 <p>
   <!--counts:start--><kbd>6 plugins</kbd> · <kbd>37 skills</kbd> · <kbd>3 agents</kbd><!--counts:end--> · <kbd>MIT</kbd>
@@ -20,7 +20,9 @@
 
 ---
 
-The **AIDD Framework** is a marketplace of **skills, agents, and rules** that make the AI-Driven Development flow concrete inside your AI coding assistant — the full SDLC (plan → implement → review → ship) under rigorous human supervision. It is the open toolset of the [AI-Driven Dev](https://www.ai-driven-dev.fr/) community: authored for **Claude Code** and shipped for every major AI assistant.
+The **AI-Driven Dev Framework** is a marketplace — **skills, agents, commands, rules, prompts, templates, recipes…** — that helps you ship **high-quality features to production**.
+
+> Orchestrate your SDLC (Software Development Life Cycle) at scale, the agentic engineering way.
 
 ## ✅ Compatibility
 
@@ -34,6 +36,8 @@ The **AIDD Framework** is a marketplace of **skills, agents, and rules** that ma
 | **Gemini** | 🚧 In progress |
 | **Mistral** | 🚧 In progress |
 
+> Primarily built on **Claude Code** (they set the standards), but compatibility with the other tools is ensured.
+
 ## 👥 Community
 
 Three years of R&D and **500+ developers trained** — so we open-sourced the framework we use ourselves to ship production-grade software with **100% AI-generated code**.
@@ -41,7 +45,7 @@ Three years of R&D and **500+ developers trained** — so we open-sourced the fr
 > ### → [Join the Discord 🇫🇷](https://discord.gg/ai-driven-dev)
 > Live coding sessions every **Thursday**. Come build, ask, and share.
 
-> **Want to train your team?** [See the programme →](https://www.ai-driven-dev.fr/) or [join the ecosystem](https://discord.gg/ai-driven-dev).
+> **Want to train your team?** [See the programme →](https://www.ai-driven-dev.fr/entreprise) or [join the ecosystem](https://www.ai-driven-dev.fr/ecosysteme).
 
 ## 📦 Installation
 
@@ -64,29 +68,47 @@ All builds are attached to each [GitHub release](https://github.com/ai-driven-de
 /plugin install aidd-orchestrator@aidd-framework
 ```
 
-**Other tools** — every release attaches a per-tool archive. Download yours from the [latest release](https://github.com/ai-driven-dev/framework/releases/latest), then:
+**Other tools** — every release attaches a per-tool archive. Grab yours from the [latest release](https://github.com/ai-driven-dev/framework/releases/latest):
 
-**GitHub Copilot** *(marketplace)*
+<details>
+<summary><strong>GitHub Copilot</strong> — marketplace</summary>
 
-1. Download `aidd-framework-copilot-marketplace-<version>.zip` and unzip it.
-2. Register it: `aidd marketplace add aidd-framework ./aidd-framework-copilot-marketplace-<version>`
-3. Install the plugins from the registered marketplace.
+1. Download [`aidd-framework-copilot-marketplace-<version>.zip`](https://github.com/ai-driven-dev/framework/releases/latest) and unzip it.
+2. Register the marketplace:
+   ```bash
+   aidd marketplace add aidd-framework ./aidd-framework-copilot-marketplace-<version>
+   ```
+3. Install the plugins from the registered `aidd-framework` marketplace (same plugin names as Claude Code).
 
-**Codex** *(marketplace)*
+</details>
 
-1. Download `aidd-framework-codex-marketplace-<version>.zip` and unzip it.
-2. Register it: `aidd marketplace add aidd-framework ./aidd-framework-codex-marketplace-<version>`
-3. Install the plugins from the registered marketplace.
+<details>
+<summary><strong>Codex</strong> — marketplace</summary>
 
-**Cursor** *(flat)*
+1. Download [`aidd-framework-codex-marketplace-<version>.zip`](https://github.com/ai-driven-dev/framework/releases/latest) and unzip it.
+2. Register the marketplace:
+   ```bash
+   aidd marketplace add aidd-framework ./aidd-framework-codex-marketplace-<version>
+   ```
+3. Install the plugins from the registered `aidd-framework` marketplace (same plugin names as Claude Code).
 
-1. Download `aidd-framework-cursor-flat-<version>.zip`.
-2. Unzip it into your project root — it materializes `.cursor/`.
+</details>
 
-**OpenCode** *(flat)*
+<details>
+<summary><strong>Cursor</strong> — flat</summary>
 
-1. Download `aidd-framework-opencode-flat-<version>.zip`.
-2. Unzip it into your project root — it materializes `.opencode/`.
+1. Download [`aidd-framework-cursor-flat-<version>.zip`](https://github.com/ai-driven-dev/framework/releases/latest).
+2. Unzip it into your project root — it materializes `.cursor/`, ready to use.
+
+</details>
+
+<details>
+<summary><strong>OpenCode</strong> — flat</summary>
+
+1. Download [`aidd-framework-opencode-flat-<version>.zip`](https://github.com/ai-driven-dev/framework/releases/latest).
+2. Unzip it into your project root — it materializes `.opencode/`, ready to use.
+
+</details>
 
 ## 🚀 Quick start
 

--- a/README.md
+++ b/README.md
@@ -215,13 +215,16 @@ Task-oriented how-to sheets. **[Browse all recipes →](recipes/)**
 
 ## 🤝 Contributing
 
+> ### 🗺️ [See the roadmap →](./ROADMAP.md)
+> Actively maintained — see what's shipping next and help shape what comes after.
+
 Every contribution shapes the framework — ideas, issues, and plugins all move it forward.
 
 - **Got an idea or hit a bug?** [Open an issue](https://github.com/ai-driven-dev/framework/issues) or start a [Discussion](https://github.com/ai-driven-dev/framework/discussions).
 - **Want to go further?** [Join the Discord 🇫🇷](https://discord.gg/ai-driven-dev) — live every **Thursday**.
 - **Building a plugin or a recipe?** Start from [`CONTRIBUTING.md`](./CONTRIBUTING.md) and [`docs/CREATE_PLUGIN.md`](docs/CREATE_PLUGIN.md).
 
-> **Note** — code (pull-request) rights on this repo are reserved for **certified Core Team members** ([`GOVERNANCE.md`](./GOVERNANCE.md)). Everyone else can open issues, join discussions, and shape the [roadmap](./ROADMAP.md).
+> **Note** — code (pull-request) rights on this repo are reserved for **certified Core Team members** ([`GOVERNANCE.md`](./GOVERNANCE.md)). Everyone else can open issues, join discussions, and shape the roadmap.
 
 ## 🔒 Trust & safety
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ### Skills, agents & rules that run the full SDLC inside your AI coding assistant — under human supervision.
 
 <p>
-  <!--counts:start--><kbd>6 plugins</kbd> · <kbd>38 skills</kbd> · <kbd>3 agents</kbd><!--counts:end--> · <kbd>MIT</kbd>
+  <!--counts:start--><kbd>6 plugins</kbd> · <kbd>37 skills</kbd> · <kbd>3 agents</kbd><!--counts:end--> · <kbd>MIT</kbd>
 </p>
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
@@ -101,7 +101,7 @@ flowchart TD
 
 ### 🧭 [aidd-context](plugins/aidd-context/README.md)
 
-`13 skills` · stable
+`12 skills` · stable
 
 Project init, architecture, generation of Claude Code context artifacts (skills, agents, rules, commands, hooks), diagrams, learning, discovery.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The **AI-Driven Dev Framework** is a marketplace — **skills, agents, commands,
 
 > Orchestrate your SDLC (Software Development Life Cycle) at scale, the agentic engineering way.
 
-**Who we are** — built by the [AI-Driven Dev](https://www.ai-driven-dev.fr/) community: 3 years of R&D, 500+ developers trained, shipping production software with 100% AI-generated code.
+**Who we are** — built by the [AI-Driven Dev](https://www.ai-driven-dev.fr/) community (in France 🇫🇷): 3 years of R&D, 500+ developers trained in English 🇬🇧 and French 🇫🇷, shipping production software with 100% AI-generated code.
 
 - **[Join the Discord 🇫🇷](https://discord.gg/ai-driven-dev)** — public [roadmap](./ROADMAP.md) decisions every Thursday morning.
 - **Want to train your team?** [See the programme](https://www.ai-driven-dev.fr/entreprise).
@@ -206,7 +206,7 @@ Task-oriented how-to sheets. **[Browse all recipes →](recipes/)**
 
 | Recipe | What you'll do |
 | --- | --- |
-| [Install an MCP server](recipes/mcp-installation.md) | Choose between CLI and MCP, and wire up the recommended servers |
+| [MCP installations](recipes/mcp-installation.md) | Choose CLI vs MCP, and wire up the recommended servers (GitHub, Atlassian, Figma, Notion…) |
 
 ## 🤝 Contributing
 

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Task-oriented how-to sheets. **[Browse all recipes →](recipes/)**
 
 | Recipe | What you'll do |
 | --- | --- |
-| [Install an MCP server](recipes/mcp_installation.md) | Choose between CLI and MCP, and wire up the recommended servers |
+| [Install an MCP server](recipes/mcp-installation.md) | Choose between CLI and MCP, and wire up the recommended servers |
 | Optimise your tokens *(soon)* | Cut context cost on day-to-day development |
 
 > Manage recipes straight from your assistant with **`/cook`** — `list` what exists, `upsert` a new one from the template.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
 </p>
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Built for Claude Code](https://img.shields.io/badge/built%20for-Claude%20Code-D97757.svg)](https://code.claude.com/docs/en/discover-plugins)
 [![Latest Release](https://img.shields.io/github/v/release/ai-driven-dev/framework?include_prereleases&sort=semver)](https://github.com/ai-driven-dev/framework/releases)
 [![CI](https://github.com/ai-driven-dev/framework/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/ai-driven-dev/framework/actions/workflows/ci.yml)
 [![Made in France](https://img.shields.io/badge/made%20in-France-0055A4?labelColor=EF4135)](https://www.ai-driven-dev.fr/)
@@ -23,6 +22,8 @@
 The **AI-Driven Dev Framework** is a marketplace — **skills, agents, commands, rules, prompts, templates, recipes…** — that helps you ship **high-quality features to production**.
 
 > Orchestrate your SDLC (Software Development Life Cycle) at scale, the agentic engineering way.
+
+**Who we are** — built by the [AI-Driven Dev](https://www.ai-driven-dev.fr/) community: 3 years of R&D, 500+ developers trained, shipping production software with 100% AI-generated code.
 
 ## ✅ Compatibility
 
@@ -39,8 +40,6 @@ The **AI-Driven Dev Framework** is a marketplace — **skills, agents, commands,
 | **Mistral** | 🚧 In progress |
 
 ## 👥 Community
-
-Three years of R&D and **500+ developers trained** — so we open-sourced the framework we use ourselves to ship production-grade software with **100% AI-generated code**.
 
 > ### → [Join the Discord 🇫🇷](https://discord.gg/ai-driven-dev)
 > Live coding sessions every **Thursday**. Come build, ask, and share.
@@ -211,7 +210,6 @@ Task-oriented how-to sheets. **[Browse all recipes →](recipes/)**
 | Recipe | What you'll do |
 | --- | --- |
 | [Install an MCP server](recipes/mcp-installation.md) | Choose between CLI and MCP, and wire up the recommended servers |
-| Optimise your tokens *(soon)* | Cut context cost on day-to-day development |
 
 > Manage recipes straight from your assistant with **`/cook`** — `list` what exists, `upsert` a new one from the template.
 
@@ -223,7 +221,7 @@ Every contribution shapes the framework — ideas, issues, and plugins all move 
 - **Want to go further?** [Join the Discord 🇫🇷](https://discord.gg/ai-driven-dev) — live every **Thursday**.
 - **Building a plugin or a recipe?** Start from [`CONTRIBUTING.md`](./CONTRIBUTING.md) and [`docs/CREATE_PLUGIN.md`](docs/CREATE_PLUGIN.md).
 
-> **Note** — code (pull-request) rights on this repo are reserved for **certified Core Team members** ([`GOVERNANCE.md`](./GOVERNANCE.md)). Everyone else can open issues, join discussions, and shape the roadmap.
+> **Note** — code (pull-request) rights on this repo are reserved for **certified Core Team members** ([`GOVERNANCE.md`](./GOVERNANCE.md)). Everyone else can open issues, join discussions, and shape the [roadmap](./ROADMAP.md).
 
 ## 🔒 Trust & safety
 

--- a/README.md
+++ b/README.md
@@ -4,17 +4,10 @@
 
 # AI-Driven Dev Framework
 
-### Skills, agents & rules that run the full SDLC inside Claude Code — under human supervision.
+### Skills, agents & rules that run the full SDLC inside your AI coding assistant — under human supervision.
 
 <p>
-  <!--counts:start--><kbd>6 plugins</kbd> · <kbd>37 skills</kbd> · <kbd>3 agents</kbd><!--counts:end--> · <kbd>MIT</kbd>
-</p>
-
-<p>
-  <a href="#-quick-start"><strong>Quick start →</strong></a> ·
-  <a href="#-plugins"><strong>Plugins →</strong></a> ·
-  <a href="recipes/"><strong>Recipes →</strong></a> ·
-  <a href="https://discord.gg/ai-driven-dev"><strong>Discord 🇫🇷 →</strong></a>
+  <!--counts:start--><kbd>6 plugins</kbd> · <kbd>38 skills</kbd> · <kbd>3 agents</kbd><!--counts:end--> · <kbd>MIT</kbd>
 </p>
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
@@ -27,34 +20,27 @@
 
 ---
 
-The **AIDD Framework** is a marketplace of **skills, agents, and rules** that make the AI-Driven Development flow concrete inside your AI coding assistant — the full SDLC (plan → implement → review → ship) under rigorous human supervision. It is the open toolset of the [AI-Driven Dev](https://www.ai-driven-dev.fr/) community, authored for **Claude Code**.
+The **AIDD Framework** is a marketplace of **skills, agents, and rules** that make the AI-Driven Development flow concrete inside your AI coding assistant — the full SDLC (plan → implement → review → ship) under rigorous human supervision. It is the open toolset of the [AI-Driven Dev](https://www.ai-driven-dev.fr/) community: authored for **Claude Code** and shipped for every major AI assistant.
 
-## 👋 Who we are
+## Community
 
-Built by the **[AI-Driven Dev](https://www.ai-driven-dev.fr/)** community, founded by **Alex Soyes**.
+Built and maintained by the **[AI-Driven Dev](https://www.ai-driven-dev.fr/)** community.
 
-- 💬 **[Discord 🇫🇷](https://discord.gg/ai-driven-dev)** — live sessions every **Thursday**
-- 🎓 **[Training & community](https://www.ai-driven-dev.fr/)** — the AIDD programme (training · coaching · community)
-- ▶️ **[YouTube](https://www.youtube.com/@aidd_off)** · 💼 **[LinkedIn](https://www.linkedin.com/company/ai-driven-dev)** · 🌐 **[Website](https://www.ai-driven-dev.fr/)**
-- 👤 Alex Soyes — [Blog](https://alexsoyes.com/) · [GitHub](https://github.com/alexsoyes) · [LinkedIn](https://www.linkedin.com/in/alexsoyes/) · [X](https://x.com/alexsoyes)
+> ### → [Join the Discord 🇫🇷](https://discord.gg/ai-driven-dev)
+> Live coding sessions every **Thursday**. Come build, ask, and share.
 
-## 🧰 Supported tools
+**[Discover the AIDD programme →](https://www.ai-driven-dev.fr/)** — training, coaching, and community.
 
-The marketplace is **Claude Code native**. Every [release](https://github.com/ai-driven-dev/framework/releases/latest) also attaches an archive adapted to each other tool — download the one for your assistant and install it.
+[YouTube](https://www.youtube.com/@aidd_off) · [LinkedIn](https://www.linkedin.com/company/ai-driven-dev) · [Website](https://www.ai-driven-dev.fr/)
 
-| Tool | Support | Install |
-| --- | --- | --- |
-| **Claude Code** | ✅ **Recommended** · native | `/plugin marketplace add ai-driven-dev/framework` |
-| **Cursor** | Supported | Download `…-cursor-flat-<version>.zip`, unzip into your project |
-| **GitHub Copilot** | Supported | Download `…-copilot-marketplace-<version>.zip`, `aidd marketplace add` |
-| **Codex** | Supported | Download `…-codex-marketplace-<version>.zip`, `aidd marketplace add` |
-| **OpenCode** | Supported | Download `…-opencode-flat-<version>.zip`, unzip into your project |
+## Installation
 
-> On a non-Claude tool, map each skill's model tier to your tool's nearest model — see the [LLM tier reference](docs/MARKETPLACE.md#llm-tier-reference).
+There are two ways to install, depending on your tool:
 
-## 🚀 Quick start
+- **Marketplace** *(recommended)* — register the marketplace once, then install and update plugins on demand. Native in Claude Code; for Copilot and Codex, download the `-marketplace-` release archive and register it with `aidd marketplace add`.
+- **Flat** — unzip a `-flat-` release archive straight into your project (it materializes `.cursor/`, `.opencode/`, …). For tools without marketplace support.
 
-**1. Install** — register the marketplace and the plugins (Claude Code slash commands, not shell):
+**Claude Code** — register the marketplace and install the plugins (slash commands, not shell):
 
 ```text
 /plugin marketplace add ai-driven-dev/framework
@@ -66,27 +52,48 @@ The marketplace is **Claude Code native**. Every [release](https://github.com/ai
 /plugin install aidd-orchestrator@aidd-framework
 ```
 
-**2. Onboard** — one command inspects your project and guides you:
+**Other tools** — grab the archive for your assistant from the [latest release](https://github.com/ai-driven-dev/framework/releases/latest):
+
+| Tool | Format | Install |
+| --- | --- | --- |
+| **Claude Code** | Marketplace *(native)* ✅ **recommended** | `/plugin marketplace add ai-driven-dev/framework` |
+| **GitHub Copilot** | Marketplace archive | Download `…-copilot-marketplace-<version>.zip`, then `aidd marketplace add` |
+| **Codex** | Marketplace archive | Download `…-codex-marketplace-<version>.zip`, then `aidd marketplace add` |
+| **Cursor** | Flat archive | Download `…-cursor-flat-<version>.zip`, unzip into your project |
+| **OpenCode** | Flat archive | Download `…-opencode-flat-<version>.zip`, unzip into your project |
+
+> A flat variant is attached for every tool too — pick the format that fits your workflow. On a non-Claude tool, map each skill's model tier to your tool's nearest model ([LLM tier reference](docs/MARKETPLACE.md#llm-tier-reference)).
+
+## Quick start
+
+Once installed, let one command inspect your project and guide you:
 
 ```text
 /aidd-context:00-onboard
 ```
 
-**3. Run the flow** — take a feature from idea to shipped PR:
+Then run the flow — here's a feature going from idea to shipped PR:
 
 ```mermaid
-flowchart LR
-    Onboard["/aidd-context:00-onboard"] --> Brainstorm["/aidd-refine:01-brainstorm"]
-    Brainstorm --> Plan["/aidd-dev:01-plan"]
-    Plan --> Implement["/aidd-dev:02-implement"]
-    Implement --> Review["/aidd-dev:05-review"]
-    Review --> Commit["/aidd-vcs:01-commit"]
-    Commit --> PR["/aidd-vcs:02-pull-request"]
+flowchart TD
+    Idea(["💡 'Add a dark-mode toggle'"])
+    Onboard["/aidd-context:00-onboard<br/><i>understand the project</i>"]
+    Brainstorm["/aidd-refine:01-brainstorm<br/><i>clarify the request</i>"]
+    Plan["/aidd-dev:01-plan<br/><i>draft the technical plan</i>"]
+    Implement["/aidd-dev:02-implement<br/><i>write the code</i>"]
+    Review["/aidd-dev:05-review<br/><i>review the diff</i>"]
+    Commit["/aidd-vcs:01-commit<br/><i>atomic commit</i>"]
+    PR(["🚀 /aidd-vcs:02-pull-request"])
+
+    Idea --> Onboard --> Brainstorm --> Plan --> Implement --> Review --> Commit --> PR
+
+    classDef edge fill:#D97757,stroke:#9c4f37,color:#fff;
+    class Idea,PR edge;
 ```
 
-> Want the whole loop in a single command? `/aidd-dev:00-sdlc` runs plan → implement → review → ship.
+> Prefer one command for the whole loop? `/aidd-dev:00-sdlc` runs plan → implement → review → ship.
 
-## 🧩 Plugins
+## Plugins
 
 <table>
 <tr>
@@ -94,7 +101,7 @@ flowchart LR
 
 ### 🧭 [aidd-context](plugins/aidd-context/README.md)
 
-`12 skills` · stable
+`13 skills` · stable
 
 Project init, architecture, generation of Claude Code context artifacts (skills, agents, rules, commands, hooks), diagrams, learning, discovery.
 
@@ -149,44 +156,40 @@ Label an issue, get a PR; re-label, get the review applied.
 </tr>
 </table>
 
-## 📖 Recipes
+## Recipes
 
 Task-oriented how-to sheets — install an MCP server, optimise your tokens, and more.
 
-➡️ **[Browse the recipes →](recipes/)**
+**[Browse the recipes →](recipes/)**
 
-## 🤝 Contributing
+## Contributing
 
-- 🐛 **Open an [issue](https://github.com/ai-driven-dev/framework/issues)** or share an idea in [Discussions](https://github.com/ai-driven-dev/framework/discussions).
-- 💬 **Join the [Discord 🇫🇷](https://discord.gg/ai-driven-dev)** — live every **Thursday**.
-- 📦 Building a plugin or a recipe? See [`CONTRIBUTING.md`](./CONTRIBUTING.md) and [`docs/CREATE_PLUGIN.md`](docs/CREATE_PLUGIN.md).
+- Open an [issue](https://github.com/ai-driven-dev/framework/issues) or share an idea in [Discussions](https://github.com/ai-driven-dev/framework/discussions).
+- Join the [Discord 🇫🇷](https://discord.gg/ai-driven-dev) — live every **Thursday**.
+- Building a plugin or a recipe? See [`CONTRIBUTING.md`](./CONTRIBUTING.md) and [`docs/CREATE_PLUGIN.md`](docs/CREATE_PLUGIN.md).
 
-Roles, rights, and how decisions get made → [`GOVERNANCE.md`](./GOVERNANCE.md). By participating you agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
-
-## 🔒 Trust & safety
+## Trust & safety
 
 Plugins can run commands, edit files, and call external services on your behalf. Before installing any plugin from any marketplace, including this one: read its `README` and `SKILL.md`, inspect its actions, and check the permissions in its hooks and MCP servers. Spot a vulnerability? Report it privately via [`SECURITY.md`](./SECURITY.md).
 
-## 📚 Documentation
+## Documentation
 
-| Resource | Where |
-| -------- | ----- |
-| How it works (architecture) | [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) |
-| Marketplace, scopes & versioning · LLM tiers | [`docs/MARKETPLACE.md`](docs/MARKETPLACE.md) |
-| Skills catalog | [`docs/CATALOG.md`](docs/CATALOG.md) |
-| Build your own plugin | [`docs/CREATE_PLUGIN.md`](docs/CREATE_PLUGIN.md) |
-| Recipes | [`recipes/`](recipes/) |
-| FAQ · Troubleshooting | [`docs/FAQ.md`](docs/FAQ.md) · [`docs/TROUBLESHOOTING.md`](docs/TROUBLESHOOTING.md) |
-| Glossary | [`docs/GLOSSARY.md`](docs/GLOSSARY.md) |
-| Contributing · Governance | [`CONTRIBUTING.md`](./CONTRIBUTING.md) · [`GOVERNANCE.md`](./GOVERNANCE.md) |
-| Changelog · Roadmap | [`CHANGELOG.md`](./CHANGELOG.md) · [`ROADMAP.md`](./ROADMAP.md) |
-| Security | [`SECURITY.md`](./SECURITY.md) |
+| Doc | What's inside |
+| --- | --- |
+| [`ARCHITECTURE.md`](docs/ARCHITECTURE.md) | How the framework is structured |
+| [`MARKETPLACE.md`](docs/MARKETPLACE.md) | Marketplaces, install scopes, versioning, LLM tiers |
+| [`CATALOG.md`](docs/CATALOG.md) | Full skills catalog |
+| [`CREATE_PLUGIN.md`](docs/CREATE_PLUGIN.md) | Build your own plugin |
+| [`FAQ.md`](docs/FAQ.md) | Frequently asked questions |
+| [`TROUBLESHOOTING.md`](docs/TROUBLESHOOTING.md) | Install issues, load problems, limits |
+| [`GLOSSARY.md`](docs/GLOSSARY.md) | Terms used across the framework |
+| [`MAINTAINERS.md`](docs/MAINTAINERS.md) | Maintainer guide |
 
 ---
 
 <div align="center">
 
-🇫🇷 🥖 🐓 · Made with care in France by the AIDD community · 🐓 🥖 🇫🇷
+Made with care in France 🇫🇷 by the AIDD community
 
 ← [Back to the AIDD organisation](https://github.com/ai-driven-dev)
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ The **AI-Driven Dev Framework** is a marketplace — **skills, agents, commands,
 
 **Who we are** — built by the [AI-Driven Dev](https://www.ai-driven-dev.fr/) community: 3 years of R&D, 500+ developers trained, shipping production software with 100% AI-generated code.
 
+- **[Join the Discord 🇫🇷](https://discord.gg/ai-driven-dev)** — public [roadmap](./ROADMAP.md) decisions every Thursday morning.
+- **Want to train your team?** [See the programme](https://www.ai-driven-dev.fr/entreprise).
+- **AI is important to you?** [Join the ecosystem](https://www.ai-driven-dev.fr/ecosysteme).
+
 ## ✅ Compatibility
 
 > Primarily built on **Claude Code** (they set the standards), but compatibility with the other tools is ensured.
@@ -38,13 +42,6 @@ The **AI-Driven Dev Framework** is a marketplace — **skills, agents, commands,
 | **OpenCode** | ✅ Supported |
 | **Gemini** | 🚧 In progress |
 | **Mistral** | 🚧 In progress |
-
-## 👥 Community
-
-> ### → [Join the Discord 🇫🇷](https://discord.gg/ai-driven-dev)
-> Live coding sessions every **Thursday**. Come build, ask, and share.
-
-> **Want to train your team?** [See the programme →](https://www.ai-driven-dev.fr/entreprise) or [join the ecosystem](https://www.ai-driven-dev.fr/ecosysteme).
 
 ## 📦 Installation
 
@@ -211,18 +208,12 @@ Task-oriented how-to sheets. **[Browse all recipes →](recipes/)**
 | --- | --- |
 | [Install an MCP server](recipes/mcp-installation.md) | Choose between CLI and MCP, and wire up the recommended servers |
 
-> Manage recipes straight from your assistant with **`/cook`** — `list` what exists, `upsert` a new one from the template.
-
 ## 🤝 Contributing
 
 > ### 🗺️ [See the roadmap →](./ROADMAP.md)
 > Actively maintained — see what's shipping next and help shape what comes after.
 
-Every contribution shapes the framework — ideas, issues, and plugins all move it forward.
-
-- **Got an idea or hit a bug?** [Open an issue](https://github.com/ai-driven-dev/framework/issues) or start a [Discussion](https://github.com/ai-driven-dev/framework/discussions).
-- **Want to go further?** [Join the Discord 🇫🇷](https://discord.gg/ai-driven-dev) — live every **Thursday**.
-- **Building a plugin or a recipe?** Start from [`CONTRIBUTING.md`](./CONTRIBUTING.md) and [`docs/CREATE_PLUGIN.md`](docs/CREATE_PLUGIN.md).
+Got an idea or hit a bug? **[Open an issue](https://github.com/ai-driven-dev/framework/issues)** or **[start a discussion](https://github.com/ai-driven-dev/framework/discussions)**. For everything else, **[join the Discord 🇫🇷](https://discord.gg/ai-driven-dev)**.
 
 > **Note** — code (pull-request) rights on this repo are reserved for **certified Core Team members** ([`GOVERNANCE.md`](./GOVERNANCE.md)). Everyone else can open issues, join discussions, and shape the roadmap.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 The **AIDD Framework** is a marketplace of **skills, agents, and rules** that make the AI-Driven Development flow concrete inside your AI coding assistant — the full SDLC (plan → implement → review → ship) under rigorous human supervision. It is the open toolset of the [AI-Driven Dev](https://www.ai-driven-dev.fr/) community: authored for **Claude Code** and shipped for every major AI assistant.
 
-## Community
+## 👥 Community
 
 Built and maintained by the **[AI-Driven Dev](https://www.ai-driven-dev.fr/)** community.
 
@@ -33,12 +33,14 @@ Built and maintained by the **[AI-Driven Dev](https://www.ai-driven-dev.fr/)** c
 
 [YouTube](https://www.youtube.com/@aidd_off) · [LinkedIn](https://www.linkedin.com/company/ai-driven-dev) · [Website](https://www.ai-driven-dev.fr/)
 
-## Installation
+## 📦 Installation
 
-There are two ways to install, depending on your tool:
+Two install formats, depending on your tool:
 
-- **Marketplace** *(recommended)* — register the marketplace once, then install and update plugins on demand. Native in Claude Code; for Copilot and Codex, download the `-marketplace-` release archive and register it with `aidd marketplace add`.
-- **Flat** — unzip a `-flat-` release archive straight into your project (it materializes `.cursor/`, `.opencode/`, …). For tools without marketplace support.
+1. **Marketplace** *(recommended)* — register once, then install and update plugins on demand. Native in Claude Code; for Copilot and Codex, grab the `-marketplace-` archive and run `aidd marketplace add`.
+2. **Flat** — unzip a `-flat-` archive straight into your project (it materializes `.cursor/`, `.opencode/`, …). For tools without marketplace support.
+
+All builds are attached to each [GitHub release](https://github.com/ai-driven-dev/framework/releases) → [latest release](https://github.com/ai-driven-dev/framework/releases/latest).
 
 **Claude Code** — register the marketplace and install the plugins (slash commands, not shell):
 
@@ -64,36 +66,36 @@ There are two ways to install, depending on your tool:
 
 > A flat variant is attached for every tool too — pick the format that fits your workflow. On a non-Claude tool, map each skill's model tier to your tool's nearest model ([LLM tier reference](docs/MARKETPLACE.md#llm-tier-reference)).
 
-## Quick start
+## 🚀 Quick start
 
-Once installed, let one command inspect your project and guide you:
-
-```text
-/aidd-context:00-onboard
-```
-
-Then run the flow — here's a feature going from idea to shipped PR:
+1. **Onboard** — one command inspects your project and guides you:
+   ```text
+   /aidd-context:00-onboard
+   ```
+2. **Run the flow** — take a feature from idea to a tested, shipped PR:
 
 ```mermaid
 flowchart TD
-    Idea(["💡 'Add a dark-mode toggle'"])
-    Onboard["/aidd-context:00-onboard<br/><i>understand the project</i>"]
-    Brainstorm["/aidd-refine:01-brainstorm<br/><i>clarify the request</i>"]
-    Plan["/aidd-dev:01-plan<br/><i>draft the technical plan</i>"]
-    Implement["/aidd-dev:02-implement<br/><i>write the code</i>"]
-    Review["/aidd-dev:05-review<br/><i>review the diff</i>"]
-    Commit["/aidd-vcs:01-commit<br/><i>atomic commit</i>"]
-    PR(["🚀 /aidd-vcs:02-pull-request"])
+    Idea(["💡 <i>'Add a dark-mode toggle'</i>"])
+    Onboard["<b>/aidd-context:00-onboard</b><br/><i>understand the project</i>"]
+    Brainstorm["<b>/aidd-refine:01-brainstorm</b><br/><i>clarify the request</i>"]
+    Plan["<b>/aidd-dev:01-plan</b><br/><i>draft the technical plan</i>"]
+    Implement["<b>/aidd-dev:02-implement</b><br/><i>write the code</i>"]
+    Review["<b>/aidd-dev:05-review</b><br/><i>review the diff</i>"]
+    Commit["<b>/aidd-vcs:01-commit</b><br/><i>atomic commit</i>"]
+    PR(["✅ <b>/aidd-vcs:02-pull-request</b><br/><i>tested · shipped</i>"])
 
     Idea --> Onboard --> Brainstorm --> Plan --> Implement --> Review --> Commit --> PR
 
-    classDef edge fill:#D97757,stroke:#9c4f37,color:#fff;
-    class Idea,PR edge;
+    classDef start fill:#D97757,stroke:#9c4f37,color:#fff;
+    classDef done fill:#2ea043,stroke:#1a7f37,color:#fff;
+    class Idea start;
+    class PR done;
 ```
 
 > Prefer one command for the whole loop? `/aidd-dev:00-sdlc` runs plan → implement → review → ship.
 
-## Plugins
+## 🧩 Plugins
 
 <table>
 <tr>
@@ -156,23 +158,26 @@ Label an issue, get a PR; re-label, get the review applied.
 </tr>
 </table>
 
-## Recipes
+## 📖 Recipes
 
-Task-oriented how-to sheets — install an MCP server, optimise your tokens, and more.
+Task-oriented how-to sheets. **[Browse all recipes →](recipes/)**
 
-**[Browse the recipes →](recipes/)**
+| Recipe | What you'll do |
+| --- | --- |
+| [Install an MCP server](recipes/mcp_installation.md) | Choose between CLI and MCP, and wire up the recommended servers |
+| Optimise your tokens *(soon)* | Cut context cost on day-to-day development |
 
-## Contributing
+## 🤝 Contributing
 
 - Open an [issue](https://github.com/ai-driven-dev/framework/issues) or share an idea in [Discussions](https://github.com/ai-driven-dev/framework/discussions).
 - Join the [Discord 🇫🇷](https://discord.gg/ai-driven-dev) — live every **Thursday**.
 - Building a plugin or a recipe? See [`CONTRIBUTING.md`](./CONTRIBUTING.md) and [`docs/CREATE_PLUGIN.md`](docs/CREATE_PLUGIN.md).
 
-## Trust & safety
+## 🔒 Trust & safety
 
 Plugins can run commands, edit files, and call external services on your behalf. Before installing any plugin from any marketplace, including this one: read its `README` and `SKILL.md`, inspect its actions, and check the permissions in its hooks and MCP servers. Spot a vulnerability? Report it privately via [`SECURITY.md`](./SECURITY.md).
 
-## Documentation
+## 📚 Documentation
 
 | Doc | What's inside |
 | --- | --- |

--- a/README.md
+++ b/README.md
@@ -22,16 +22,26 @@
 
 The **AIDD Framework** is a marketplace of **skills, agents, and rules** that make the AI-Driven Development flow concrete inside your AI coding assistant — the full SDLC (plan → implement → review → ship) under rigorous human supervision. It is the open toolset of the [AI-Driven Dev](https://www.ai-driven-dev.fr/) community: authored for **Claude Code** and shipped for every major AI assistant.
 
+## ✅ Compatibility
+
+| Tool | Status |
+| --- | --- |
+| **Claude Code** | ✅ Native · **recommended** |
+| **GitHub Copilot** | ✅ Supported |
+| **Codex** | ✅ Supported |
+| **Cursor** | ✅ Supported |
+| **OpenCode** | ✅ Supported |
+| **Gemini** | 🚧 In progress |
+| **Mistral** | 🚧 In progress |
+
 ## 👥 Community
 
-Built and maintained by the **[AI-Driven Dev](https://www.ai-driven-dev.fr/)** community.
+Three years of R&D and **500+ developers trained** — so we open-sourced the framework we use ourselves to ship production-grade software with **100% AI-generated code**.
 
 > ### → [Join the Discord 🇫🇷](https://discord.gg/ai-driven-dev)
 > Live coding sessions every **Thursday**. Come build, ask, and share.
 
-**[Discover the AIDD programme →](https://www.ai-driven-dev.fr/)** — training, coaching, and community.
-
-[YouTube](https://www.youtube.com/@aidd_off) · [LinkedIn](https://www.linkedin.com/company/ai-driven-dev) · [Website](https://www.ai-driven-dev.fr/)
+> **Want to train your team?** [See the programme →](https://www.ai-driven-dev.fr/) or [join the ecosystem](https://discord.gg/ai-driven-dev).
 
 ## 📦 Installation
 
@@ -54,17 +64,29 @@ All builds are attached to each [GitHub release](https://github.com/ai-driven-de
 /plugin install aidd-orchestrator@aidd-framework
 ```
 
-**Other tools** — grab the archive for your assistant from the [latest release](https://github.com/ai-driven-dev/framework/releases/latest):
+**Other tools** — every release attaches a per-tool archive. Download yours from the [latest release](https://github.com/ai-driven-dev/framework/releases/latest), then:
 
-| Tool | Format | Install |
-| --- | --- | --- |
-| **Claude Code** | Marketplace *(native)* ✅ **recommended** | `/plugin marketplace add ai-driven-dev/framework` |
-| **GitHub Copilot** | Marketplace archive | Download `…-copilot-marketplace-<version>.zip`, then `aidd marketplace add` |
-| **Codex** | Marketplace archive | Download `…-codex-marketplace-<version>.zip`, then `aidd marketplace add` |
-| **Cursor** | Flat archive | Download `…-cursor-flat-<version>.zip`, unzip into your project |
-| **OpenCode** | Flat archive | Download `…-opencode-flat-<version>.zip`, unzip into your project |
+**GitHub Copilot** *(marketplace)*
 
-> A flat variant is attached for every tool too — pick the format that fits your workflow. On a non-Claude tool, map each skill's model tier to your tool's nearest model ([LLM tier reference](docs/MARKETPLACE.md#llm-tier-reference)).
+1. Download `aidd-framework-copilot-marketplace-<version>.zip` and unzip it.
+2. Register it: `aidd marketplace add aidd-framework ./aidd-framework-copilot-marketplace-<version>`
+3. Install the plugins from the registered marketplace.
+
+**Codex** *(marketplace)*
+
+1. Download `aidd-framework-codex-marketplace-<version>.zip` and unzip it.
+2. Register it: `aidd marketplace add aidd-framework ./aidd-framework-codex-marketplace-<version>`
+3. Install the plugins from the registered marketplace.
+
+**Cursor** *(flat)*
+
+1. Download `aidd-framework-cursor-flat-<version>.zip`.
+2. Unzip it into your project root — it materializes `.cursor/`.
+
+**OpenCode** *(flat)*
+
+1. Download `aidd-framework-opencode-flat-<version>.zip`.
+2. Unzip it into your project root — it materializes `.opencode/`.
 
 ## 🚀 Quick start
 
@@ -96,6 +118,8 @@ flowchart TD
 > Prefer one command for the whole loop? `/aidd-dev:00-sdlc` runs plan → implement → review → ship.
 
 ## 🧩 Plugins
+
+Six plugins covering the whole SDLC — **install all of them**; they're designed to work together.
 
 <table>
 <tr>
@@ -167,11 +191,17 @@ Task-oriented how-to sheets. **[Browse all recipes →](recipes/)**
 | [Install an MCP server](recipes/mcp_installation.md) | Choose between CLI and MCP, and wire up the recommended servers |
 | Optimise your tokens *(soon)* | Cut context cost on day-to-day development |
 
+> Manage recipes straight from your assistant with **`/cook`** — `list` what exists, `upsert` a new one from the template.
+
 ## 🤝 Contributing
 
-- Open an [issue](https://github.com/ai-driven-dev/framework/issues) or share an idea in [Discussions](https://github.com/ai-driven-dev/framework/discussions).
-- Join the [Discord 🇫🇷](https://discord.gg/ai-driven-dev) — live every **Thursday**.
-- Building a plugin or a recipe? See [`CONTRIBUTING.md`](./CONTRIBUTING.md) and [`docs/CREATE_PLUGIN.md`](docs/CREATE_PLUGIN.md).
+Every contribution shapes the framework — ideas, issues, and plugins all move it forward.
+
+- **Got an idea or hit a bug?** [Open an issue](https://github.com/ai-driven-dev/framework/issues) or start a [Discussion](https://github.com/ai-driven-dev/framework/discussions).
+- **Want to go further?** [Join the Discord 🇫🇷](https://discord.gg/ai-driven-dev) — live every **Thursday**.
+- **Building a plugin or a recipe?** Start from [`CONTRIBUTING.md`](./CONTRIBUTING.md) and [`docs/CREATE_PLUGIN.md`](docs/CREATE_PLUGIN.md).
+
+> **Note** — code (pull-request) rights on this repo are reserved for **certified Core Team members** ([`GOVERNANCE.md`](./GOVERNANCE.md)). Everyone else can open issues, join discussions, and shape the roadmap.
 
 ## 🔒 Trust & safety
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ The **AI-Driven Dev Framework** is a marketplace — **skills, agents, commands,
 
 > Orchestrate your SDLC (Software Development Life Cycle) at scale, the agentic engineering way.
 
-**Who we are** — built by the [AI-Driven Dev](https://www.ai-driven-dev.fr/) community: 3 years of R&D, 500+ developers trained in English 🇬🇧 and French 🇫🇷, shipping production software with 100% AI-generated code.
+## 👥 Who we are
+
+Built by the [AI-Driven Dev](https://www.ai-driven-dev.fr/) community: 3 years of R&D, 500+ developers trained in English 🇬🇧 and French 🇫🇷, shipping production software with 100% AI-generated code.
 
 - **[Join the Discord 🇫🇷](https://discord.gg/ai-driven-dev)** — public [roadmap](./ROADMAP.md) decisions every Thursday morning.
 - **Want to train your team?** [See the programme](https://www.ai-driven-dev.fr/entreprise).

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The **AI-Driven Dev Framework** is a marketplace — **skills, agents, commands,
 
 > Orchestrate your SDLC (Software Development Life Cycle) at scale, the agentic engineering way.
 
-## 👥 Who we are
+## 🧑‍💻 The AI-Driven Dev
 
 Built by the [AI-Driven Dev](https://www.ai-driven-dev.fr/) community: 3 years of R&D, 500+ developers trained in English 🇬🇧 and French 🇫🇷, shipping production software with 100% AI-generated code.
 

--- a/docs/MARKETPLACE.md
+++ b/docs/MARKETPLACE.md
@@ -1,0 +1,47 @@
+# Marketplace, scopes & versioning
+
+Reference for how the `aidd-framework` marketplace is registered, scoped, and versioned, plus the LLM tier mapping used by skills.
+
+## How marketplaces work
+
+A marketplace is a Git repo that publishes plugins. When you run `/plugin marketplace add <owner>/<repo>`, Claude Code clones the repo, reads its `.claude-plugin/marketplace.json`, and offers the listed plugins for install.
+
+`aidd-framework` is a **community-maintained, methodology-driven complement** to Anthropic's [official marketplace](https://github.com/anthropics/claude-plugins-official). The official catalog covers broadly useful plugins curated by Anthropic; AIDD ships plugins that materialise a specific way of working (the AI-Driven Development flow). The two are designed to coexist — register both and install from either.
+
+Official Anthropic docs:
+
+- [Discover and install plugins](https://code.claude.com/docs/en/discover-plugins) — the user-facing flow
+- [Plugin marketplaces](https://code.claude.com/docs/en/plugin-marketplaces) — host your own
+- [Plugins reference](https://code.claude.com/docs/en/plugins-reference) — manifest + marketplace.json schemas
+
+> **Private repo?** `/plugin marketplace add` needs read access (`gh auth login` or a PAT) — see the [install docs](https://code.claude.com/docs/en/discover-plugins).
+
+## Install scopes
+
+Plugins can be installed at three scopes:
+
+| Scope | Stored in | Lifetime | Best for |
+| --- | --- | --- | --- |
+| `user` | `~/.claude/plugins/` | All your projects | Personal toolbelt |
+| `project` | `.claude/settings.json` (`enabledPlugins`) in the repo | This repo only | Team-shared setup |
+| `local` | A local directory | This machine | Plugin development |
+
+Set scope at install time with the `/plugin` UI, or by editing `enabledPlugins` directly in `.claude/settings.json`.
+
+## Versioning & updates
+
+- Each plugin versions independently via `release-please`. Tags look like `aidd-<plugin>-vX.Y.Z`.
+- The root marketplace (`marketplace.json`) versions independently as `vX.Y.Z`.
+- Pull updates inside Claude Code with `/plugin marketplace update aidd-framework`.
+
+See [`CHANGELOG.md`](../CHANGELOG.md) for the full history.
+
+## LLM tier reference
+
+Some skills target a model **tier** when they need a particular capability. The framework is authored against Claude; on another AI tool, map each tier to that tool's nearest model.
+
+| Tier | Best for | Claude | Other tools (examples) |
+| ---- | -------- | ------ | ---------------------- |
+| **T1 Fast** | Mechanical, deterministic tasks, templates, git ops | Haiku 4.5 | GPT-5.5 mini, Gemini Flash, Grok fast |
+| **T2 Balanced** | Implementation, validation, code generation | Sonnet 4.6 | GPT-5.5, Gemini Pro |
+| **T3 Thinking** | Deep reasoning, synthesis, planning, onboarding | Opus 4.8 | GPT-5.5 (thinking), Gemini Pro thinking |

--- a/plugins/aidd-dev/CATALOG.md
+++ b/plugins/aidd-dev/CATALOG.md
@@ -152,7 +152,6 @@ Auto-generated index of skills, agents, references and assets shipped by the `ai
 | `actions` | [02-auto-accept.md](skills/09-for-sure/actions/02-auto-accept.md) | - | - |
 | `actions` | [03-autonomous-loop.md](skills/09-for-sure/actions/03-autonomous-loop.md) | - | - |
 | `assets` | [plan-template.md](skills/09-for-sure/assets/plan-template.md) | `For Sure autonomous-loop tracking file. Extends the 01-plan format with `success_condition` and `iteration` (For-Sure-only), which the loop runs and increments.` | - |
-| `evals` | [scenarios.json](skills/09-for-sure/evals/scenarios.json) | - | - |
 | `-` | [README.md](skills/09-for-sure/README.md) | - | - |
 | `-` | [SKILL.md](skills/09-for-sure/SKILL.md) | `Iterative agent loop that tracks attempts and retries until a success condition is met. Use when the user says "for sure", "make sure", "keep trying until", "loop until done", "don't stop until", or needs guaranteed completion of a task with explicit success criteria.` | - |
 

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -1,0 +1,13 @@
+# Recipes
+
+Task-oriented how-to sheets for the AIDD Framework. Each recipe is a self-contained tutorial: a clear goal, prerequisites, and steps you can follow end to end.
+
+| Recipe | What you'll do | Level |
+| --- | --- | --- |
+| [Install an MCP server](mcp_installation.md) | Choose between CLI and MCP, and wire up the recommended servers | Beginner |
+
+> More coming — token optimisation, custom plugins, and others.
+
+## Contributing a recipe
+
+Recipes follow a shared template (title · goal · level · time · prerequisites · steps · verify · related). A `/cook` skill to `list` and `upsert` recipes from a canonical template is on the way; until then, copy the shape of [`mcp_installation.md`](mcp_installation.md) and open a PR. See [`CONTRIBUTING.md`](../CONTRIBUTING.md).

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -4,7 +4,7 @@ Task-oriented how-to sheets for the AIDD Framework. Each recipe is a self-contai
 
 | Recipe | Goal | Level |
 | --- | --- | --- |
-| [Install an MCP server](mcp-installation.md) | Decide when to use an MCP server vs a CLI, and wire up the recommended ones | Beginner |
+| [MCP installations](mcp-installation.md) | Decide when to use an MCP server vs a CLI, and wire up the recommended ones | Beginner |
 
 > More coming — token optimisation, custom plugins, and others.
 

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -2,9 +2,9 @@
 
 Task-oriented how-to sheets for the AIDD Framework. Each recipe is a self-contained tutorial: a clear goal, prerequisites, and steps you can follow end to end.
 
-| Recipe | What you'll do | Level |
+| Recipe | Goal | Level |
 | --- | --- | --- |
-| [Install an MCP server](mcp-installation.md) | Choose between CLI and MCP, and wire up the recommended servers | Beginner |
+| [Install an MCP server](mcp-installation.md) | Decide when to use an MCP server vs a CLI, and wire up the recommended ones | Beginner |
 
 > More coming — token optimisation, custom plugins, and others.
 

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -4,10 +4,10 @@ Task-oriented how-to sheets for the AIDD Framework. Each recipe is a self-contai
 
 | Recipe | What you'll do | Level |
 | --- | --- | --- |
-| [Install an MCP server](mcp_installation.md) | Choose between CLI and MCP, and wire up the recommended servers | Beginner |
+| [Install an MCP server](mcp-installation.md) | Choose between CLI and MCP, and wire up the recommended servers | Beginner |
 
 > More coming — token optimisation, custom plugins, and others.
 
 ## Contributing a recipe
 
-Recipes follow a shared template (title · goal · level · time · prerequisites · steps · verify · related). A `/cook` skill to `list` and `upsert` recipes from a canonical template is on the way; until then, copy the shape of [`mcp_installation.md`](mcp_installation.md) and open a PR. See [`CONTRIBUTING.md`](../CONTRIBUTING.md).
+Recipes follow a shared template (title · goal · level · time · prerequisites · steps · verify · related). A `/cook` skill to `list` and `upsert` recipes from a canonical template is on the way; until then, copy the shape of [`mcp-installation.md`](mcp-installation.md) and open a PR. See [`CONTRIBUTING.md`](../CONTRIBUTING.md).

--- a/recipes/mcp-installation.md
+++ b/recipes/mcp-installation.md
@@ -1,4 +1,4 @@
-# Install an MCP server
+# MCP installations
 
 > **Goal:** Decide when to use an MCP server vs a CLI, and wire up the recommended ones.
 

--- a/recipes/mcp-installation.md
+++ b/recipes/mcp-installation.md
@@ -1,6 +1,6 @@
 # Install an MCP server
 
-> **Goal:** decide when to use an MCP server vs a CLI, and wire up the recommended ones.
+> **Goal:** Decide when to use an MCP server vs a CLI, and wire up the recommended ones.
 
 | | |
 | --- | --- |

--- a/recipes/mcp-installation.md
+++ b/recipes/mcp-installation.md
@@ -30,8 +30,8 @@ An MCP server loads its full tool schema into **every** turn — that bloats the
 
 ## Steps
 
-1. **Check for a CLI first.** If the service has one (GitHub → `gh`, Jira → `acli`), install and authenticate it instead of an MCP server.
-2. **If MCP is the only option**, add the server to your `.mcp.json`:
+1. 🔎 **Check for a CLI first** — if the service has one (GitHub → `gh`, Jira → `acli`), install and authenticate it instead of an MCP server.
+2. 🔌 **If MCP is the only option**, add the server to your `.mcp.json`:
    ```json
    {
      "mcpServers": {
@@ -39,8 +39,8 @@ An MCP server loads its full tool schema into **every** turn — that bloats the
      }
    }
    ```
-3. **Audit the server** before connecting — read its docs and the permissions it requests.
-4. **Restart** your assistant so it picks up the new configuration.
+3. 🛡️ **Audit the server** before connecting — read its docs and the permissions it requests.
+4. ✅ **Restart** your assistant so it picks up the new configuration.
 
 ## Verify
 

--- a/recipes/mcp_installation.md
+++ b/recipes/mcp_installation.md
@@ -1,0 +1,53 @@
+# Install an MCP server
+
+> **Goal:** decide when to use an MCP server vs a CLI, and wire up the recommended ones.
+
+| | |
+| --- | --- |
+| **Level** | Beginner |
+| **Time** | ~10 min |
+| **Prerequisites** | An AI assistant (Claude Code); the CLI for the service when one exists (`gh`, `acli`, …) |
+
+## Why
+
+> **Prefer the CLI over MCP. It is more efficient.**
+
+An MCP server loads its full tool schema into **every** turn — that bloats the context window and is less optimised. A CLI call costs a few tokens and returns only what you ask for.
+
+**Reach for MCP only when no CLI covers the service.**
+
+⚠️ **Always verify your sources. Audit what you install before connecting any server.**
+
+## Recommended servers
+
+| Service | Official MCP | CLI alternative | Recommended |
+| --- | --- | --- | --- |
+| **GitHub** | [`api.githubcopilot.com/mcp/`](https://github.com/github/github-mcp-server) | [`gh`](https://cli.github.com/) | **CLI** — `gh` covers issues, PRs, releases, API at a fraction of the context |
+| **Atlassian** (Jira / Confluence) | [`mcp.atlassian.com/v1/mcp`](https://www.atlassian.com/platform/remote-mcp-server) | [`acli`](https://developer.atlassian.com/cloud/acli/guides/introduction/) (Jira only at GA) | **CLI** for Jira · **MCP** for Confluence (no CLI yet) |
+| **Playwright** | [`@playwright/mcp`](https://github.com/microsoft/playwright-mcp) | [`npx playwright`](https://playwright.dev/docs/test-cli) + [official skill](https://claude.com/plugins/playwright) | **CLI** — drives a real browser (`playwright open`, `codegen`, `--headed`). The skill wraps it |
+| **Figma** | [`mcp.figma.com/mcp`](https://developers.figma.com/docs/figma-mcp-server/remote-server-installation/) | none for design data | **MCP** |
+| **Notion** | [`mcp.notion.com/mcp`](https://developers.notion.com/guides/mcp/get-started-with-mcp) | none official | **MCP** |
+
+## Steps
+
+1. **Check for a CLI first.** If the service has one (GitHub → `gh`, Jira → `acli`), install and authenticate it instead of an MCP server.
+2. **If MCP is the only option**, add the server to your `.mcp.json`:
+   ```json
+   {
+     "mcpServers": {
+       "figma": { "url": "https://mcp.figma.com/mcp" }
+     }
+   }
+   ```
+3. **Audit the server** before connecting — read its docs and the permissions it requests.
+4. **Restart** your assistant so it picks up the new configuration.
+
+## Verify
+
+- The MCP tools appear in your assistant (e.g. `/mcp` in Claude Code lists connected servers).
+- For a CLI, run a read-only command (`gh auth status`, `acli jira me`) and confirm it returns.
+
+## Related
+
+- [`docs/ARCHITECTURE.md`](../docs/ARCHITECTURE.md) — how the framework is structured
+- [Anthropic — discover plugins](https://code.claude.com/docs/en/discover-plugins)


### PR DESCRIPTION
## What

Rework the README into a lean landing page and introduce a `recipes/` cookbook.

### README
- New tagline + marketplace-focused intro with an SDLC-orchestration line
- **The AI-Driven Dev** section — who we are (3y R&D, 500+ devs trained EN/FR, 100% AI-generated code) + Discord / training / ecosystem CTAs, roadmap decisions every Thursday
- **Compatibility** matrix — Claude Code native/recommended; Copilot, Codex, Cursor, OpenCode supported; Gemini & Mistral in progress
- **Installation** — Claude Code shown in full; Copilot/Codex (marketplace) and Cursor/OpenCode (flat) in collapsible blocks, each linking the release asset
- **Quick start** — `/aidd-context:00-onboard` + a top-down flow diagram (idea → tested, shipped PR)
- **Plugins** table, **Recipes** table, slim **Contributing** (issues/discussions + Discord) with a prominent roadmap CTA and the Core Team note, **Trust & safety**, and a `docs/`-only documentation table

### Moved out (no duplication)
- `docs/MARKETPLACE.md` — marketplaces, install scopes, versioning, LLM tier reference (was inline in the README)

### Recipes (new)
- `recipes/README.md` — index
- `recipes/mcp-installation.md` — "MCP installations" (migrated from the README MCP section); its shape doubles as the de-facto recipe template

## Companion PR
- #281 — the `/cook` skill (`list` / `upsert` recipes) + canonical recipe template. **Merge together** with this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
