### PR TITLE
docs(aidd-context): refresh plugin README for the reworked skills

### DIFF
--- a/plugins/aidd-context/README.md
+++ b/plugins/aidd-context/README.md
@@ -8,27 +8,27 @@ Knowledge production plugin for the AI-Driven Development framework.
 
 First time? Install with `/plugin install aidd-context@aidd-framework`, then run `aidd-context:00-onboard`.
 
-Covers project bootstrap, project initialisation, generation of Claude Code context artifacts (skills, agents, rules, commands, hooks), Mermaid diagrams, learning, discovery, and a state-aware onboarding loop.
+Covers project bootstrap, the project memory bank, generation of context artifacts (skills, agents, rules, commands, hooks), Mermaid diagrams, learning, discovery, recipes, and a plain-language onboarding guide.
 
 ## Skills
 
 | Bracket ID | Skill          | Description                                                                                                                                                     |
 | ---------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [1.0]      | [onboard](skills/00-onboard/README.md)                 | Detect the project's aidd-context state and guide the user to ONE next aidd-context action through a state -> recommend -> execute loop.                       |
+| [1.0]      | [onboard](skills/00-onboard/README.md)                 | Guide the user through the AIDD flow on the current project, in plain language, and suggest the next logical step, adapted to the installed plugins.            |
 | [1.1]      | [bootstrap](skills/01-bootstrap/README.md)             | Imagine and validate the technical architecture of a new SaaS through interactive Q&A, candidate-stack comparison, multi-agent audit, and an INSTALL.md output. |
-| [1.2]      | [project-memory](skills/02-project-memory/README.md)       | Initialize the project memory bank (rule directories are created lazily by `03-context-generate`).                                                              |
-| [1.3]      | [context-generate](skills/03-context-generate/README.md) | Generate Claude Code context artifacts - router-based skills, agents, rules, slash commands, hooks, plugin scaffolds, and plugin marketplaces.                  |
+| [1.2]      | [project-memory](skills/02-project-memory/README.md)       | Initialize or refresh the project memory bank from a capability-based model, and carry the memory block into the AI context files.                              |
+| [1.3]      | [context-generate](skills/03-context-generate/README.md) | Generate context artifacts: router-based skills, agents, rules, slash commands, hooks, plugin scaffolds, and plugin marketplaces.                               |
 | [1.4]      | [mermaid](skills/09-mermaid/README.md)                 | Generate high-quality Mermaid diagrams from markdown content using a structured plan-validate workflow.                                                         |
-| [1.5]      | [learn](skills/10-learn/README.md)                     | Capture and store learnings from recently implemented features into memory bank, decisions, or coding rules.                                                    |
+| [1.5]      | [learn](skills/10-learn/README.md)                     | Capture durable learnings from the conversation or git history, score each, and route the worthwhile ones to memory, a decision record, a rule, or a new skill. |
 | [1.6]      | [discovery](skills/11-discovery/README.md)             | Help users discover installed skills and find the right one for their use case.                                                                                 |
 | [1.7]      | [cook](skills/12-cook/README.md)                       | Maintain the project's `recipes/` how-to sheets: list every recipe, or create and update one from the canonical recipe template.                              |
 
 ## Onboarding
 
-New to aidd-context, or unsure what to run next? Invoke `aidd-context:00-onboard`. The skill:
+New to AIDD, or unsure what to run next? Invoke `aidd-context:00-onboard`. The skill:
 
-1. Probes the filesystem (no questions) to snapshot what already exists - `aidd_docs/`, memory bank, rules skeleton, the `<aidd_project_memory>` block in your AI context file.
-2. Picks ONE next aidd-context skill from the state matrix and presents a 5-option numbered menu (run / explain / handoff / swap / stop).
-3. Loops back to detection after each execution so the recommendation always reflects current state.
+1. Reads the project silently: the memory bank, the code and stack, any spec or plan, and which AIDD plugins are installed.
+2. Explains in plain language where the project sits in the AIDD flow and suggests the next logical step, resolved to a skill that is actually installed, then offers a short numbered menu.
+3. Loops back to reading the project after each step so the guidance always reflects the current state.
 
-The onboard skill is scoped to aidd-context only. Cross-plugin global walkthroughs live elsewhere in the framework.
+Onboard adapts to whatever plugins are installed: it suggests by function and discovers the skills that fill each step, so a skill added later shows up on its own.


### PR DESCRIPTION
## 🎯 What & why

The `aidd-context` plugin README still described `onboard`, `learn`, and `project-memory` with their pre-rework behavior (state matrix, five-option menu, capture into rules). PRs #279, #282, #284 reworked the skills but not this hand-written summary table, leaving it drifted on main.

## 🛠️ How it works

Align three rows and the Onboarding section with the reworked skills: onboard is a plain-language guide that suggests the next step adapted to the installed plugins; learn scores candidates and routes to memory, a decision record, a rule, or a new skill; project-memory uses the capability-based model. Regenerate the catalog.

## 🧪 How to verify

- `grep -niE 'state matrix|5-option|scoped to aidd-context only' plugins/aidd-context/README.md` returns nothing.
- The onboard/learn/project-memory rows match each skill's `SKILL.md` description.

## ✅ I certify

- [ ] **I DO CERTIFY I READ EACH LINE OF THE PULL REQUEST BECAUSE I AM A SOFTWARE ENGINEER, NOT A AI PUPPY.**
