### PR TITLE
fix(framework): make setup work in worktrees

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ help: ## List targets
 	@grep -hE '^[a-z-]+:.*##' $(MAKEFILE_LIST) | sed 's/:.*## /\t/' | sort
 
 setup: ## Install deps, git hooks, and register+install the plugins in Claude/Codex
-	pnpm install
-	pnpm exec lefthook install
+	pnpm install --ignore-scripts
+	pnpm exec lefthook install --force
 	scripts/dev-setup.sh
 
 doctor: ## Check the local toolchain


### PR DESCRIPTION
# fix(framework): make setup work in worktrees

## ✅ Type of PR

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## 🗒️ Description

Make `make setup` reliable from a fresh worktree by avoiding pnpm lifecycle hook execution during dependency install and installing Lefthook explicitly.

## 🚶‍➡️ Behavior

- `make setup` no longer fails when a worktree inherits an existing `core.hooksPath`.
- Dependency installation no longer triggers the `prepare` lifecycle before setup can control hook installation.
- Lefthook still gets installed for the checkout through the explicit setup step.

## 🧪 Steps to test

- [x] Run `make setup` from the worktree.
- [x] Run `make doctor`.
