### PR TITLE
chore(framework): share Codex worktree setup

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -1,0 +1,20 @@
+version = 1
+name = "framework"
+
+[setup]
+script = """
+if [ "$(git rev-parse --abbrev-ref HEAD)" != "HEAD" ]; then
+  echo "Refusing to move a named branch during setup."
+  exit 1
+fi
+
+if [ -n "$(git status --porcelain)" ]; then
+  echo "Refusing to update setup base: worktree is not clean."
+  git status --short
+  exit 1
+fi
+
+git fetch --prune origin main
+git switch --detach origin/main
+make setup
+"""


### PR DESCRIPTION
## ✅ Type of PR

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## 🗒️ Description

Share the Codex local environment setup so managed worktrees start from the latest `origin/main` before running `make setup`.

## 🚶‍➡️ Behavior

- New Codex worktrees refuse to move setup if they are on a named branch.
- New Codex worktrees refuse to update their base if local changes are present.
- Clean detached worktrees fetch `origin/main`, switch to it, then run `make setup`.

## 🧪 Steps to test

- [x] Run the setup script commands in a detached clean worktree.
