### PR TITLE
chore(framework): allow full access in worktrees

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,2 @@
+sandbox_mode = "danger-full-access"
+approval_policy = "never"


### PR DESCRIPTION
# chore(framework): allow full access in worktrees

## ✅ Type of PR

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## 🗒️ Description

Configure Codex project permissions so trusted worktrees can run without approval prompts.

## 🚶‍➡️ Behavior

- Codex uses full local access when this trusted project config is loaded.
- Codex no longer pauses for command approval prompts in trusted worktrees.

## 🧪 Steps to test

- [ ] Open a trusted Codex worktree for this repo.
- [ ] Confirm Codex loads `.codex/config.toml`.
- [ ] Run a local command and confirm no approval prompt is shown.
