### PR TITLE
docs(aidd-context): add explicit-scoped-includes rule (R13) to skill-generate

### DIFF
--- a/plugins/aidd-context/skills/04-skill-generate/assets/action-template.md
+++ b/plugins/aidd-context/skills/04-skill-generate/assets/action-template.md
@@ -18,3 +18,11 @@
 ## Test
 
 <One deterministic check: a command to run, a concrete check on the produced artifact, or an observable side-effect. State the pass condition plainly.>
+
+<!--
+Cite an include the action needs as its `@<path>` ALONE inside a fenced block, never inline in a sentence (R13). Name an include used only by this action with this action's slug prefix; cite a global include (used skill-wide) from SKILL.md instead of here.
+
+```md
+@references/<action-slug>-<file>.md
+```
+-->

--- a/plugins/aidd-context/skills/04-skill-generate/assets/skill-template.md
+++ b/plugins/aidd-context/skills/04-skill-generate/assets/skill-template.md
@@ -22,9 +22,11 @@ description: <What the skill does, third person, one clause>. Use when <explicit
 OPTIONAL sections below. Include a section ONLY when it has content (R9); never write an empty section or a "None." placeholder. Delete this comment and any section you do not use.
 
 ## References    documents the actions READ (conventions, schemas). Plain paths, no `@`.
+List ONLY global includes (used skill-wide). An action-specific include lives with its action and carries that action's slug prefix (R13).
 - `references/<file>.md`: <what it covers>
 
 ## Assets       files the actions COPY or INJECT (templates, fixed snippets).
+List ONLY global includes (used skill-wide). An action-specific include lives with its action and carries that action's slug prefix (R13).
 - `assets/<file>`: <what it provides>
 
 ## Transversal rules   rules applying to every action that are NOT already owned by a reference.

--- a/plugins/aidd-context/skills/04-skill-generate/references/skill-authoring.md
+++ b/plugins/aidd-context/skills/04-skill-generate/references/skill-authoring.md
@@ -13,12 +13,14 @@ The contract every generated skill must satisfy. These rules govern the CLIENT s
   - Triggers explicit and slightly pushy. The model under-triggers, so over-list.
   - Lead with the plain artifact name. Parentheses for an inline definition, not dashes.
   - Optionally a short `Not for <X>` clause, only when a sibling skill could mis-trigger.
-- **R6.** Zero duplication. One fact, one home. Templates live in `assets/`. Actions cite them via `@<path>`.
-- **R7.** `references/` = documents to READ. `assets/` = files to COPY or INJECT.
+- **R6.** Zero duplication. One fact, one home. Actions cite a shared file via `@<path>` instead of restating it.
+- **R7.** `references/` = documents to READ and apply in place. `assets/` = files to COPY, INJECT, or fill in per run. A template, checklist, or form is an asset, not a reference, because each run instantiates it.
 - **R8.** Every action follows the action anatomy (below) and carries a `## Test`.
 - **R9.** Omit any optional section that would be empty. Never write a placeholder like `## External data` + `None.`.
 - **R10.** Generated skills are English only (frontmatter, body, actions, references, assets), regardless of conversation language.
 - **R11.** One idea per sentence. Split a sentence that runs past one line. Exceptions: the single-line `description` and table rows.
+- **R12.** One file = one artifact. A reference or asset holds a single coherent thing: one checklist, one template, one criteria set. When a file accumulates several independently reusable artifacts, split them so each is cited and reused alone. Prefer this split over bundling, even when the combined file is short.
+- **R13.** Includes are explicit and scoped. Cite an include with its `@<path>` alone inside a fenced ```<lang> block, never inline in prose. Naming: a global include (imported from SKILL.md, used skill-wide) takes no prefix; an include used by only one action is prefixed with that action's slug (e.g. `research-checklist.md`). SKILL.md lists only the global includes; an action-specific include is cited only from its own action.
 
 ## Action anatomy
 


### PR DESCRIPTION
## What

Adds rule **R13 (explicit, scoped includes)** to the `04-skill-generate` skill's authoring contract, plus the supporting changes to R6, R7, and new R12. Updates the action and SKILL.md scaffolds so generated skills follow R13 by construction.

### Rule changes (`references/skill-authoring.md`, now R1–R13)
- **R6** — actions cite a shared file via `@<path>` instead of restating it (drops the templates-only framing).
- **R7** — `references/` = READ and apply in place; `assets/` = COPY, INJECT, or fill in per run. A template, checklist, or form is an asset, not a reference, because each run instantiates it.
- **R12** (new) — one file = one artifact; split independently reusable artifacts so each is cited and reused alone.
- **R13** (new) — cite an include as its `@<path>` alone inside a fenced ` ```<lang> ` block, never inline in prose. A global include (imported from SKILL.md, used skill-wide) takes no prefix; an include used by only one action carries that action's slug prefix and is cited only from that action. SKILL.md lists only the global includes.

### Scaffold changes
- `assets/action-template.md` — demonstrates a fenced, slug-prefixed `@<path>` include and notes that global includes are cited from SKILL.md instead.
- `assets/skill-template.md` — References/Assets sections now note they list ONLY global includes; action-specific includes live with their action and carry that action's slug prefix.

## Why

The `@include` mechanism only front-loads context reliably when imported from SKILL.md; action-specific files load on demand. Without a convention, authors inline includes in prose (which the loader ignores) or restate content (duplication). Making the `@<path>` fenced and alone keeps the citation machine-loadable, and the no-prefix vs. slug-prefix naming makes each include's scope explicit — global vs. action-only — so SKILL.md stays a pure router and nothing is loaded out of scope.

The skill-generate skill is its own reference implementation, so encoding R13 here makes every generated skill inherit the convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)