### PR TITLE
ci(framework): trigger Validate on next branch

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,9 +6,9 @@ name: Validate
 
 on:
   push:
-    branches: [main]
+    branches: [main, next]
   pull_request:
-    branches: [main]
+    branches: [main, next]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Why

The required status check **`lefthook (framework-local checks)`** (required by `.github/rulesets/next.json`) is published only by `validate.yml`. Its `push`/`pull_request` filter was `[main]`, so PRs targeting `next` never triggered it. The required status stayed *"Expected — Waiting for status…"* indefinitely, deadlocking merges (e.g. #307).

## Fix

Add `next` to both `push` and `pull_request` branch filters in `validate.yml`.

## Effect

- PRs into `next` now run the lefthook validation job → required status reports → merges unblock.
- After this lands on `next`, rebase/update #307 (or any PR based on `next`) so the new trigger applies on its head branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)