### PR TITLE
feat(aidd-ui): scaffold alpha plugin (0.1.0-alpha.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -48,6 +48,13 @@
       "description": "Meta-cognition: refine input through brainstorming, refine output through challenge and condensed communication mode.",
       "strict": true,
       "recommended": true
+    },
+    {
+      "name": "aidd-ui",
+      "source": "./plugins/aidd-ui",
+      "description": "UI and UX concern: design, review, and improve frontend interfaces.",
+      "strict": true,
+      "recommended": false
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -52,7 +52,7 @@
     {
       "name": "aidd-ui",
       "source": "./plugins/aidd-ui",
-      "description": "UI and UX concern: design, review, and improve frontend interfaces.",
+      "description": "ALPHA, not ready for use. UI and UX concern: design, review, and improve frontend interfaces.",
       "strict": true,
       "recommended": false
     }

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -5,5 +5,6 @@
   "plugins/aidd-vcs": "2.0.0",
   "plugins/aidd-pm": "2.0.0",
   "plugins/aidd-orchestrator": "2.0.0",
-  "plugins/aidd-refine": "2.0.0"
+  "plugins/aidd-refine": "2.0.0",
+  "plugins/aidd-ui": "0.1.0-alpha.0"
 }

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ### Vibe Coding for professional developers — focused on 100% quality on AI-generated code.
 
 <p>
-  <!--counts:start--><kbd>6 plugins</kbd> · <kbd>38 skills</kbd> · <kbd>3 agents</kbd><!--counts:end--> · <kbd>MIT</kbd>
+  <!--counts:start--><kbd>7 plugins</kbd> · <kbd>39 skills</kbd> · <kbd>3 agents</kbd><!--counts:end--> · <kbd>MIT</kbd>
 </p>
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
@@ -139,7 +139,7 @@ flowchart TD
 
 ## 🧩 Plugins
 
-Six plugins covering the whole SDLC — **install all of them**; they're designed to work together.
+Seven plugins covering the whole SDLC — **install all of them**; they're designed to work together. (`aidd-ui` is experimental and off the curated install path.)
 
 <table>
 <tr>
@@ -197,6 +197,17 @@ Meta-cognition: brainstorm, challenge, condense, shadow-areas, fact-check.
 `1 skill` · stable (`async-dev`)
 
 Label an issue, get a PR; re-label, get the review applied.
+
+</td>
+</tr>
+<tr>
+<td width="33%" valign="top">
+
+### 🎨 [aidd-ui](plugins/aidd-ui/README.md)
+
+`1 skill` · experimental
+
+UI and UX: design, review, and improve frontend interfaces.
 
 </td>
 </tr>

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ flowchart TD
 
 ## 🧩 Plugins
 
-Seven plugins covering the whole SDLC — **install all of them**; they're designed to work together. (`aidd-ui` is experimental and off the curated install path.)
+Seven plugins covering the whole SDLC — **install all of them**; they're designed to work together. (`aidd-ui` is 🚧 **alpha — not ready for use**, off the curated install path.)
 
 <table>
 <tr>
@@ -203,11 +203,11 @@ Label an issue, get a PR; re-label, get the review applied.
 <tr>
 <td width="33%" valign="top">
 
-### 🎨 [aidd-ui](plugins/aidd-ui/README.md)
+### 🎨 [aidd-ui](plugins/aidd-ui/README.md) 🚧
 
-`1 skill` · experimental
+`1 skill` · **alpha — not ready**
 
-UI and UX: design, review, and improve frontend interfaces.
+UI and UX: design, review, and improve frontend interfaces. ⚠️ Alpha (`0.1.0-alpha.0`), smoke-test only — do not rely on it yet.
 
 </td>
 </tr>

--- a/plugins/aidd-ui/.claude-plugin/plugin.json
+++ b/plugins/aidd-ui/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "aidd-ui",
+  "version": "0.1.0-alpha.0",
+  "description": "UI and UX concern for the AI-Driven Development framework. Use when the user wants to design, review, or improve a frontend interface. Do NOT use for backend-only or non-UI tasks.",
+  "author": { "name": "AI-Driven Dev", "url": "https://github.com/ai-driven-dev" },
+  "skills": ["./skills/01-hello"],
+  "keywords": ["ui", "ux", "design", "frontend"],
+  "repository": "https://github.com/ai-driven-dev/framework",
+  "homepage": "https://ai-driven.dev",
+  "license": "MIT"
+}

--- a/plugins/aidd-ui/.claude-plugin/plugin.json
+++ b/plugins/aidd-ui/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "aidd-ui",
   "version": "0.1.0-alpha.0",
-  "description": "UI and UX concern for the AI-Driven Development framework. Use when the user wants to design, review, or improve a frontend interface. Do NOT use for backend-only or non-UI tasks.",
+  "description": "ALPHA, not ready for use. UI and UX concern for the AI-Driven Development framework. Use when the user wants to design, review, or improve a frontend interface. Do NOT use for backend-only or non-UI tasks.",
   "author": { "name": "AI-Driven Dev", "url": "https://github.com/ai-driven-dev" },
   "skills": ["./skills/01-hello"],
   "keywords": ["ui", "ux", "design", "frontend"],

--- a/plugins/aidd-ui/CATALOG.md
+++ b/plugins/aidd-ui/CATALOG.md
@@ -1,0 +1,30 @@
+# aidd-ui catalog
+
+Auto-generated index of skills, agents, references and assets shipped by the `aidd-ui` plugin.
+
+> This file is automatically updated by the `scripts/summarize-markdown.js` script.
+
+## Table of Contents
+
+- [`.claude-plugin`](#claude-plugin)
+- [`skills`](#skills)
+  - [`skills/01-hello`](#skills01-hello)
+
+---
+
+### `.claude-plugin`
+
+| File |
+|------|
+| [plugin.json](.claude-plugin/plugin.json) |
+
+### `skills`
+
+#### `skills/01-hello`
+
+| Group | File | Description |
+|-------|------|---|
+| `actions` | [01-greet.md](skills/01-hello/actions/01-greet.md) | - |
+| `-` | [README.md](skills/01-hello/README.md) | - |
+| `-` | [SKILL.md](skills/01-hello/SKILL.md) | `Smoke-test skill that confirms the aidd-ui plugin loads. Use when the user wants to verify the alpha aidd-ui plugin is installed and reachable. Do NOT use for real UI or UX design work.` |
+

--- a/plugins/aidd-ui/README.md
+++ b/plugins/aidd-ui/README.md
@@ -1,0 +1,26 @@
+← [aidd-framework](../../README.md)
+
+# aidd-ui
+
+UI and UX concern for the AI-Driven Development framework.
+
+> Status: experimental.
+
+This plugin is in alpha (`0.1.0-alpha.0`). It lives on a dedicated branch off `next` and is registered with `recommended: false`, so it stays off the curated install path until it stabilises and graduates to `main`. While it is not in the published marketplace yet, test it from a local checkout of this branch:
+
+```
+claude --plugin-dir plugins/aidd-ui          # zero-marketplace, session-scoped
+# or, persistent:
+/plugin marketplace add .                      # register this checkout as a local marketplace
+/plugin install aidd-ui@aidd-framework
+```
+
+Then run `aidd-ui:01-hello` to confirm it loads.
+
+One starter skill today; real UI and UX skills land as the concern stabilises.
+
+## Skills
+
+| Bracket ID | Skill | Description |
+| ---------- | ----- | ----------- |
+| [7.1] | [hello](skills/01-hello/README.md) | Smoke-test skill that confirms the plugin loads. |

--- a/plugins/aidd-ui/README.md
+++ b/plugins/aidd-ui/README.md
@@ -1,10 +1,12 @@
 ← [aidd-framework](../../README.md)
 
-# aidd-ui
+# aidd-ui 🚧 alpha
 
 UI and UX concern for the AI-Driven Development framework.
 
-> Status: experimental.
+> ⚠️ **ALPHA — NOT READY FOR USE.** `0.1.0-alpha.0`. This plugin ships a single smoke-test skill and no real UI/UX capability yet. Do not install it expecting to use it; it exists only to validate the scaffold. APIs, skills, and naming may change or be removed without notice.
+
+> Status: alpha (experimental).
 
 This plugin is in alpha (`0.1.0-alpha.0`). It lives on a dedicated branch off `next` and is registered with `recommended: false`, so it stays off the curated install path until it stabilises and graduates to `main`. While it is not in the published marketplace yet, test it from a local checkout of this branch:
 

--- a/plugins/aidd-ui/skills/01-hello/README.md
+++ b/plugins/aidd-ui/skills/01-hello/README.md
@@ -1,0 +1,29 @@
+← [aidd-ui](../../README.md)
+
+# hello
+
+Smoke-test skill for the alpha `aidd-ui` plugin. It greets the caller and confirms the plugin loaded.
+
+## When to use
+
+- To verify the alpha `aidd-ui` plugin is installed and reachable after a local install or reload.
+
+## When NOT to use
+
+- For real UI or UX design, review, or improvement work. Those skills do not exist yet.
+
+## How to invoke
+
+`aidd-ui:01-hello`
+
+## Outputs
+
+- A short greeting printed in the chat.
+
+## Prerequisites
+
+- The plugin loaded locally (`claude --plugin-dir plugins/aidd-ui`, or installed from the marketplace).
+
+## Technical details
+
+See [SKILL.md](SKILL.md).

--- a/plugins/aidd-ui/skills/01-hello/SKILL.md
+++ b/plugins/aidd-ui/skills/01-hello/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: 01-hello
+description: Smoke-test skill that confirms the aidd-ui plugin loads. Use when the user wants to verify the alpha aidd-ui plugin is installed and reachable. Do NOT use for real UI or UX design work.
+---
+
+## Available actions
+
+| ID  | Name  | Purpose                                       |
+| --- | ----- | --------------------------------------------- |
+| 01  | greet | Greet the user and confirm the skill works.   |
+
+## Default flow
+
+Run action `01-greet` and return its message.

--- a/plugins/aidd-ui/skills/01-hello/actions/01-greet.md
+++ b/plugins/aidd-ui/skills/01-hello/actions/01-greet.md
@@ -1,0 +1,15 @@
+# 01 - greet
+
+Greets the caller.
+
+## Inputs
+
+- none
+
+## Outputs
+
+- a short greeting printed in the chat
+
+## Process
+
+1. Print "Hello from aidd-ui (alpha)."

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -82,6 +82,16 @@
           "jsonpath": "$.version"
         }
       ]
+    },
+    "plugins/aidd-ui": {
+      "package-name": "aidd-ui",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": ".claude-plugin/plugin.json",
+          "jsonpath": "$.version"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
## What

Scaffolds a new **`aidd-ui`** plugin (UI/UX concern) with a single smoke-test skill (`01-hello`).

## Alpha status

- Version `0.1.0-alpha.0` in `plugin.json` is the alpha marker.
- `recommended: false` in `marketplace.json` (off the curated install path, like `aidd-orchestrator`).
- Targets **`next`**, not `main` — so it is not published (CI/marketplace archives/homepage all build from `main`). The `next → main` merge is the graduation gate.

## Contents

- `plugins/aidd-ui/` — manifest, README (`Status: experimental`), `01-hello` skill (SKILL + README + action), auto-generated CATALOG.
- Registered in `marketplace.json`, `release-please-config.json`, `.release-please-manifest.json`.
- Homepage README: count badge + plugins table row marked `experimental`.

## Local testing

```
claude --plugin-dir plugins/aidd-ui
# or: /plugin marketplace add . && /plugin install aidd-ui@aidd-framework
```
Then run `aidd-ui:01-hello`.

## Follow-ups

- Define the real UI/UX skills; confirm the concern boundary vs `aidd-context/12-design-system` (the design-system work on `feat/design-system`).
- At graduation: bump `0.1.0-alpha.0` → `0.1.0`, optionally `recommended: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)