### PR TITLE
chore(deps): target next instead of main for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,10 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
+    # Target `next`, not `main`. `main` only takes the weekly promotion PR and
+    # the Release PR (see RELEASE.md); dep updates batch on `next` and ship in
+    # the weekly release instead of cutting off-cycle releases.
+    target-branch: "next"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -15,6 +19,7 @@ updates:
 
   - package-ecosystem: "npm"
     directory: "/"
+    target-branch: "next"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
## Problem

Dependabot had no `target-branch`, so its PRs defaulted to `main`. Per `RELEASE.md`, `main` only takes the weekly promotion PR from `next` and the auto-merged Release PR — any other merge cuts a release. The js-yaml bump (#322) landing on `main` triggered an off-cycle **v5.0.3**.

## Fix

Set `target-branch: "next"` on both ecosystems (github-actions, npm). Dependabot PRs now land on `next`, auto-merge (non-major) batches them there, and they ship in the weekly `next`→`main` promotion — on-cycle, one release.

Auto-merge workflow still fires (`pull_request_target`, any base).

## Follow-up (not in this PR)

`RELEASE.md` says `chore` should only ride along a `feat`/`fix`, yet v5.0.3 was cut from a lone `chore(deps-dev)`. Worth checking release-please config separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)