### PR TITLE
fix(aidd-vcs): sync pull-request skill contract with prefix routing

### DIFF
--- a/plugins/aidd-vcs/skills/02-pull-request/SKILL.md
+++ b/plugins/aidd-vcs/skills/02-pull-request/SKILL.md
@@ -19,9 +19,10 @@ Single action skill. The router dispatches to `pull-request` whenever a PR/MR ph
 
 ## Transversal rules
 
-- Detect the base branch from repo state. Do NOT assume `main` or `master` (common alternatives: `develop`, `staging`).
+- Resolve the base branch from the head branch's prefix via the project's branch-naming convention (project memory); fall back to repo state when no prefix mapping exists. Never assume `main` or `master` (common alternatives: `next`, `develop`, `staging`).
 - Always ask the user to validate the title, body, and base branch before creating the request.
 - Open the request as a draft. The user promotes it manually when ready.
+- After opening, apply the triage label the branch prefix maps to, when that label exists; labels triage only, they never change the resolved base.
 - Never commit, never push the working branch, never create new branches inside this skill.
 - Tool-agnostic: read the VCS tool from project memory; fall back to inspecting the remote URL.
 


### PR DESCRIPTION
## 🎯 What & why

PR #325 added prefix-based base resolution + auto-labelling to the `02-pull-request` action, but that change merged under a `docs(framework)` squash, so `aidd-vcs` never got its patch bump or changelog line. This lands the same behavioural fix at the `aidd-vcs` scope and closes a real contract gap.

## 🛠️ How it works

`SKILL.md`'s transversal rules still described base detection from repo state only. Updated to match the action: base resolves from the branch prefix via project memory (fallback to repo state, never assume `main`), and the matching triage label is applied after opening. Single-scope so release-please bumps `aidd-vcs`.

## 🧪 How to verify

- `SKILL.md` transversal rules mention prefix-based base + auto-label, consistent with `actions/01-pull-request.md`.

## ⚠️ Heads-up

Follow-up to the squash-merge of #325 — keeps per-plugin release attribution correct.