### PR TITLE
feat(aidd-dev): route deletions to refactor cleanup with orphan sweep

### DIFF
--- a/plugins/aidd-dev/CATALOG.md
+++ b/plugins/aidd-dev/CATALOG.md
@@ -131,7 +131,7 @@ Auto-generated index of skills, agents, references and assets shipped by the `ai
 | `actions` | [03-cleanup.md](skills/07-refactor/actions/03-cleanup.md) | - |
 | `actions` | [04-architecture.md](skills/07-refactor/actions/04-architecture.md) | - |
 | `-` | [README.md](skills/07-refactor/README.md) | - |
-| `-` | [SKILL.md](skills/07-refactor/SKILL.md) | `Improve code without breaking behavior across four axes - cleanup (clean-code + tech debt), performance, security, architecture. Scans and fixes, or fixes the findings of an audit report pushed in by the caller. Use when the user wants to refactor, clean up, optimize, harden, or restructure code. Do NOT use for read-only diagnosis (use 04-audit), adding tests (use 06-test), or UI redesign (use the impeccable skill).` |
+| `-` | [SKILL.md](skills/07-refactor/SKILL.md) | `Improve code without breaking behavior across four axes - cleanup (clean-code + tech debt), performance, security, architecture. Scans and fixes, or fixes the findings of an audit report pushed in by the caller. Use when the user wants to refactor, clean up, optimize, harden, restructure, or delete/remove code. Do NOT use for read-only diagnosis (use 04-audit), adding tests (use 06-test), or UI redesign (use the impeccable skill).` |
 
 #### `skills/08-debug`
 

--- a/plugins/aidd-dev/skills/07-refactor/SKILL.md
+++ b/plugins/aidd-dev/skills/07-refactor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: 07-refactor
-description: Improve code without breaking behavior across four axes - cleanup (clean-code + tech debt), performance, security, architecture. Scans and fixes, or fixes the findings of an audit report pushed in by the caller. Use when the user wants to refactor, clean up, optimize, harden, or restructure code. Do NOT use for read-only diagnosis (use 04-audit), adding tests (use 06-test), or UI redesign (use the impeccable skill).
+description: Improve code without breaking behavior across four axes - cleanup (clean-code + tech debt), performance, security, architecture. Scans and fixes, or fixes the findings of an audit report pushed in by the caller. Use when the user wants to refactor, clean up, optimize, harden, restructure, or delete/remove code. Do NOT use for read-only diagnosis (use 04-audit), adding tests (use 06-test), or UI redesign (use the impeccable skill).
 argument-hint: performance | security | cleanup | architecture
 ---
 
@@ -23,6 +23,7 @@ This skill is run-one-OR-run-all:
 
 - The user named an axis ("optimize this", "harden", "clean up", "restructure") -> run that ONE action.
 - Unscoped ("refactor this", "improve the code") -> ask ONE question: "all applicable axes, or a specific one (cleanup / performance / security / architecture)?" Then run the chosen one, or all applicable.
+- The user asked to delete or remove code ("delete X", "remove this", "drop this") -> run the `cleanup` action directly; do not ask which axis.
 - Never silently default to action 01.
 
 ## Audit handoff (push, never pull)

--- a/plugins/aidd-dev/skills/07-refactor/actions/03-cleanup.md
+++ b/plugins/aidd-dev/skills/07-refactor/actions/03-cleanup.md
@@ -33,7 +33,7 @@ verification: <summary of test and type-check results confirming no behavioral r
    - Replace magic numbers and inline strings with named constants.
    - Remove dead, misleading, or out-of-date comments; add a brief comment only where intent is genuinely non-obvious.
 3. **Apply tech-debt fixes** from the finding list:
-   - Delete dead code and unused exports.
+   - Delete dead code and unused exports, and sweep for the orphaned references a deletion leaves behind.
    - Reduce cyclomatic complexity by extracting early returns, guard clauses, and helper functions.
    - Shorten oversized files and functions to a single responsibility.
    - Flatten excessive nesting.


### PR DESCRIPTION
## ✅ Type of PR
- [x] Feature

## 🗒️ Description
Quand tu demandes de **supprimer du code**, le skill `aidd-dev:07-refactor` est
maintenant une cible de déclenchement et route directement vers l'action `cleanup`.
Le cleanup **balaie les références orphelines** qu'une suppression laisse derrière
elle (imports, tests, docs, config qui pointaient sur le symbole supprimé).

## 🚶‍➡️ Behavior
- « supprime X » / « remove this » → invoque refactor → action `cleanup` sans demander l'axe.
- Une suppression ne nettoie plus seulement la définition mais aussi ce qui la référençait.
- **Limite** : le routage dépend de la décision de l'IA hôte (par `description`), pas garanti à 100 % comme le serait un hook.

## 🧪 Steps to test
- [ ] Demander « supprime la fonction `foo` » (avec `foo` importée dans 2 fichiers + un test).
- [ ] Vérifier que le skill refactor / action `cleanup` est bien invoqué.
- [ ] Vérifier que la suppression retire `foo` ET balaie imports / test / docs qui la référençaient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
