### PR TITLE
refactor(skills): forbid colon and em dash in descriptions

### DIFF
--- a/plugins/aidd-context/CATALOG.md
+++ b/plugins/aidd-context/CATALOG.md
@@ -202,5 +202,5 @@ Auto-generated index of skills, agents, references and assets shipped by the `ai
 | `actions` | [02-upsert.md](skills/12-cook/actions/02-upsert.md) | - |
 | `assets` | [recipe-template.md](skills/12-cook/assets/recipe-template.md) | - |
 | `-` | [README.md](skills/12-cook/README.md) | - |
-| `-` | [SKILL.md](skills/12-cook/SKILL.md) | `Manage the project's recipes/ how-to sheets: list them as a table, or create and update one from the canonical template. Use for "list recipes", "new recipe", "update a recipe", "cook a recipe".` |
+| `-` | [SKILL.md](skills/12-cook/SKILL.md) | `Manage the project's recipes and how-to sheets. List them as a table, or create and update one from the canonical template. Use when the user wants to list, create, update, or cook a recipe.` |
 

--- a/plugins/aidd-context/skills/04-skill-generate/references/skill-authoring.md
+++ b/plugins/aidd-context/skills/04-skill-generate/references/skill-authoring.md
@@ -15,6 +15,7 @@ The contract every generated skill must satisfy. These rules govern the CLIENT s
   - Optionally one short `Not for <X>` clause to fend off a sibling that could mis-trigger, describing the overlap in plain words.
   - Never name another skill, and never include a `/command` token: slash commands are tool-native, the host generates them.
   - Parentheses for an inline definition, not dashes.
+  - Never use a colon or an em dash in the description. Split the thought into two sentences instead.
 - **R6.** Zero duplication. One fact, one home. Actions cite a shared file via `@<path>` instead of restating it.
 - **R7.** `references/` = documents to READ and apply in place. `assets/` = files to COPY, INJECT, or fill in per run. A template, checklist, or form is an asset, not a reference, because each run instantiates it.
 - **R8.** Every action follows the action anatomy (below) and carries a `## Test`.

--- a/plugins/aidd-context/skills/12-cook/SKILL.md
+++ b/plugins/aidd-context/skills/12-cook/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: 12-cook
-description: Manage the project's recipes/ how-to sheets: list them as a table, or create and update one from the canonical template. Use for "list recipes", "new recipe", "update a recipe", "cook a recipe".
+description: Manage the project's recipes and how-to sheets. List them as a table, or create and update one from the canonical template. Use when the user wants to list, create, update, or cook a recipe.
 argument-hint: list | upsert
 ---
 

--- a/plugins/aidd-dev/CATALOG.md
+++ b/plugins/aidd-dev/CATALOG.md
@@ -85,7 +85,7 @@ Auto-generated index of skills, agents, references and assets shipped by the `ai
 | `actions` | [03-assert-frontend.md](skills/03-assert/actions/03-assert-frontend.md) | - |
 | `assets` | [task-template.md](skills/03-assert/assets/task-template.md) | - |
 | `-` | [README.md](skills/03-assert/README.md) | - |
-| `-` | [SKILL.md](skills/03-assert/SKILL.md) | `Assert the work behaves: iterate the project's coding assertions until they pass, plus optional architecture and frontend facets. Use to validate an implementation. Do NOT use to review or write tests.` |
+| `-` | [SKILL.md](skills/03-assert/SKILL.md) | `Assert the work behaves by iterating the project's coding assertions until they pass, plus optional architecture and frontend facets. Use to validate an implementation. Not for reviewing or writing tests.` |
 
 #### `skills/04-audit`
 

--- a/plugins/aidd-dev/skills/03-assert/SKILL.md
+++ b/plugins/aidd-dev/skills/03-assert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: 03-assert
-description: Assert the work behaves: iterate the project's coding assertions until they pass, plus optional architecture and frontend facets. Use to validate an implementation. Do NOT use to review or write tests.
+description: Assert the work behaves by iterating the project's coding assertions until they pass, plus optional architecture and frontend facets. Use to validate an implementation. Not for reviewing or writing tests.
 argument-hint: assert | assert-architecture | assert-frontend
 model: sonnet
 ---

--- a/plugins/aidd-orchestrator/CATALOG.md
+++ b/plugins/aidd-orchestrator/CATALOG.md
@@ -26,5 +26,5 @@ Auto-generated index of skills, agents, references and assets shipped by the `ai
 |-------|------|---|
 | `-` | [README.md](skills/00-async-dev/README.md) | - |
 | `references` | [routing.md](skills/00-async-dev/references/routing.md) | - |
-| `-` | [SKILL.md](skills/00-async-dev/SKILL.md) | `Drive the async-dev pipeline from one entry point: setup, run, or review. Use when the user wants to install async dev, run a ready issue, or address PR review comments, or on a webhook trigger. Not for plain status checks.` |
+| `-` | [SKILL.md](skills/00-async-dev/SKILL.md) | `Drive the async-dev pipeline from one entry point, whether setup, run, or review. Use when the user wants to install async dev, run a ready issue, or address PR review comments, or on a webhook trigger. Not for plain status checks.` |
 

--- a/plugins/aidd-orchestrator/skills/00-async-dev/SKILL.md
+++ b/plugins/aidd-orchestrator/skills/00-async-dev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: 00-async-dev
-description: Drive the async-dev pipeline from one entry point: setup, run, or review. Use when the user wants to install async dev, run a ready issue, or address PR review comments, or on a webhook trigger. Not for plain status checks.
+description: Drive the async-dev pipeline from one entry point, whether setup, run, or review. Use when the user wants to install async dev, run a ready issue, or address PR review comments, or on a webhook trigger. Not for plain status checks.
 argument-hint: collect-comments | detect-stop | fix-iteration | finalize | poll-ready | resolve-deps | acquire-lock | check-sdlc | delegate-sdlc | write-audit | detect-context | ask-config | generate-workflow | generate-local-script | write-config | bootstrap-labels | install-user-scope-plugins | configure-remote-secrets | bootstrap-scheduling | commit-and-push | smoke-test
 ---
 

--- a/plugins/aidd-vcs/CATALOG.md
+++ b/plugins/aidd-vcs/CATALOG.md
@@ -32,7 +32,7 @@ Auto-generated index of skills, agents, references and assets shipped by the `ai
 | `actions` | [02-publish.md](skills/00-repo-init/actions/02-publish.md) | - |
 | `assets` | [CONTRIBUTING.md](skills/00-repo-init/assets/CONTRIBUTING.md) | - |
 | `-` | [README.md](skills/00-repo-init/README.md) | - |
-| `-` | [SKILL.md](skills/00-repo-init/SKILL.md) | `Initialize a project repository: git init, default branch, bootstrap commit, CONTRIBUTING.md, optionally the remote. Use when the user wants to init or set up a new repo, or publish to a remote. Not for committing, opening a PR, or tagging.` |
+| `-` | [SKILL.md](skills/00-repo-init/SKILL.md) | `Initialize a project repository with git init, a default branch, a bootstrap commit, CONTRIBUTING.md, and optionally the remote. Use when the user wants to init or set up a new repo, or publish to a remote. Not for committing, opening a PR, or tagging.` |
 
 #### `skills/01-commit`
 

--- a/plugins/aidd-vcs/skills/00-repo-init/SKILL.md
+++ b/plugins/aidd-vcs/skills/00-repo-init/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: 00-repo-init
-description: Initialize a project repository: git init, default branch, bootstrap commit, CONTRIBUTING.md, optionally the remote. Use when the user wants to init or set up a new repo, or publish to a remote. Not for committing, opening a PR, or tagging.
+description: Initialize a project repository with git init, a default branch, a bootstrap commit, CONTRIBUTING.md, and optionally the remote. Use when the user wants to init or set up a new repo, or publish to a remote. Not for committing, opening a PR, or tagging.
 argument-hint: init | publish
 ---
 


### PR DESCRIPTION
## 🎯 What & why

Four skill descriptions used a colon (`cook`, `assert`, `async-dev`, `repo-init`), which reads heavy in the router blurb. Forbid the colon and the em dash in descriptions, and codify the rule so it holds going forward.

## 🛠️ How it works

Rewrote the four descriptions into two plain sentences each, and added the rule to R5 in [skill-authoring.md:18](plugins/aidd-context/skills/04-skill-generate/references/skill-authoring.md#L18). `assert` also drops the shouty `Do NOT use to` for a plain `Not for`. Plugin CATALOGs regenerated by the pre-commit hook to match the new descriptions.

## 🧪 How to verify

```sh
for f in plugins/*/skills/*/SKILL.md; do v="$(grep -m1 '^description:' "$f")"; echo "${v#description:}" | grep -qE ':|—' && echo "VIOLATION $f"; done
```

Prints nothing (zero descriptions with a colon or em dash).

## ✅ I certify

- [ ] **I DO CERTIFY I READ EACH LINE OF THE PULL REQUEST BECAUSE I AM A SOFTWARE ENGINEER, NOT A AI PUPPY.**
