### PR TITLE
ci(back-merge): realign next onto main to kill drift

### DIFF
--- a/.github/workflows/back-merge.yml
+++ b/.github/workflows/back-merge.yml
@@ -1,9 +1,11 @@
 name: Back-merge
 
 # After a release on main, sync main back into next so its changelog, manifest,
-# and version bumps do not drift. No conflict -> push next directly (the App is
-# an "always" bypass actor on next). Conflict -> open a PR for a human.
-# Any other failure -> open a tracking issue so the drift is never silent.
+# and version bumps do not drift. When next holds no unreleased work, realign it
+# onto main's hashes (force-push, the App is an "always" bypass actor on next)
+# so the rebase-promote hash drift cannot accumulate. When next has real work,
+# keep the merge. Conflict -> open a PR for a human. Any other failure -> open a
+# tracking issue so the drift is never silent.
 
 on:
   release:
@@ -40,7 +42,17 @@ jobs:
           git config user.email "aidd-bot[bot]@users.noreply.github.com"
           git fetch origin main
           if git merge --no-edit origin/main; then
-            git push origin next
+            # Promotes to main are rebase-merged, so main carries new commit
+            # hashes and next drifts even though the content matches. When the
+            # merge result is content-identical to main (next held no unreleased
+            # work), realign next onto main's clean hashes so the drift cannot
+            # accumulate into a giant conflicting promote later. Otherwise next
+            # has real unreleased work, so keep the merge and push normally.
+            if git diff --quiet origin/main HEAD; then
+              git push --force origin "origin/main:refs/heads/next"
+            else
+              git push origin next
+            fi
           else
             git merge --abort
             BRANCH="back-merge/main-to-next-${{ github.run_id }}"

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -50,9 +50,11 @@ To force a package to a chosen version on the next cut, set `release-as` for it
 in `release-please-config.json` (deterministic, overrides any `Release-As:`
 commit footer). Remove the pin afterwards so automatic bumps resume.
 
-## Back-merge failures
+## Back-merge and drift
 
-If the back-merge cannot push `next`, it opens an issue labelled
-`back-merge-failed`. Resync by opening a `main -> next` PR. The root cause is the
-bot app needing an `always` bypass on the `next` ruleset; align that and the
-back-merge runs unattended.
+The back-merge runs unattended (the bot app has an `always` bypass on the `next`
+ruleset). After each release it either realigns `next` onto `main` (when `next`
+holds no unreleased work, the normal case) or keeps a merge (when it does), so
+the rebase-promote hash drift never accumulates. If it ever cannot push, it
+opens an issue labelled `back-merge-failed`; resync by opening a `main -> next`
+PR.


### PR DESCRIPTION
## 🎯 What & why

Stop the rebase-promote hash drift from accumulating. After each release the back-merge now realigns `next` onto `main` (when `next` holds no unreleased work), instead of only merging, so `next` never diverges into a giant conflicting promote again.

## 🛠️ How it works

After `git merge origin/main`: if the result is content-identical to `main` (next had nothing unreleased), force-push `next` to `main`'s hashes; else keep the merge and push normally (no work lost). The bot's `always` bypass on the `next` ruleset permits the force-push.

## 🧪 How to verify

Next release: the back-merge run leaves `next` at `main`'s exact HEAD (zero divergence), with no `back-merge-failed` issue.

## ✅ I certify

- [ ] **I DO CERTIFY I READ EACH LINE OF THE PULL REQUEST BECAUSE I AM A SOFTWARE ENGINEER, NOT A AI PUPPY.**