### PR TITLE
fix(framework): guarantee and report Claude agent copy on reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,7 @@
 
 # AI-Driven Dev Framework
 
-### Vibe Coding for professional developers — focused on 100% quality on AI-generated code.
-
-<p><b>🇫🇷 The first French open-source framework for AI-driven development.</b></p>
+### A French framework for AI-Driven Developer to produce high code quality.
 
 <p>
   <!--counts:start--><kbd>7 plugins</kbd> · <kbd>40 skills</kbd> · <kbd>2 agents</kbd><!--counts:end--> · <kbd>MIT</kbd>

--- a/scripts/dev-sync.sh
+++ b/scripts/dev-sync.sh
@@ -76,7 +76,30 @@ sync_one() {
   fi
   if [ "$HAVE_CLAUDE" = 1 ]; then
     rm -rf "$CLAUDE_CACHE/$MKT/$name"
-    claude plugin install "$name@$MKT" --scope user >/dev/null 2>&1 && printf ' claude:ok' || printf ' claude:FAIL'
+    if claude plugin install "$name@$MKT" --scope user >/dev/null 2>&1; then
+      printf ' claude:ok'
+      # Claude loads agents ONLY from the installed installPath, and `claude plugin install`
+      # copies them there implicitly - which fails silently (still prints ok) if the copy is
+      # skipped, dropping executor/checker. Pin it like the Codex net above: force-sync every
+      # declared agent into the freshly installed version dir and report the count so a miss
+      # is never silent. Drop this once the install is a trusted source of bundled agents.
+      if [ -d "$FW/plugins/$name/agents" ]; then
+        local dest src n=0 fixed=0
+        dest="$(ls -d "$CLAUDE_CACHE/$MKT/$name"/*/ 2>/dev/null | head -1)"
+        if [ -n "$dest" ]; then
+          mkdir -p "${dest}agents"
+          for src in "$FW/plugins/$name/agents/"*.md; do
+            n=$((n + 1))
+            cmp -s "$src" "${dest}agents/$(basename "$src")" 2>/dev/null || { cp -f "$src" "${dest}agents/"; fixed=$((fixed + 1)); }
+          done
+          [ "$fixed" -gt 0 ] && printf '(+%d agents, repaired %d)' "$n" "$fixed" || printf '(+%d agents)' "$n"
+        else
+          printf '(agents:NO-INSTALLPATH)'
+        fi
+      fi
+    else
+      printf ' claude:FAIL'
+    fi
   fi
   echo
 }


### PR DESCRIPTION
## Why

`make reload` (`dev-sync.sh`) runs `claude plugin install`, which copies a plugin's bundled agents into the installed `installPath` implicitly. The script printed `claude:ok` whether or not that copy happened, so a skipped copy silently dropped `executor` / `checker` with **zero signal** — matching the reported "agents no longer copied on reload".

## What

Force-sync every declared agent into the freshly installed version dir and print the count, mirroring the existing Codex agent net:

- `claude:ok(+2 agents)` — present and verified
- `claude:ok(+2 agents, repaired N)` — install skipped N, script recovered them
- `claude:ok(agents:NO-INSTALLPATH)` — hard failure, now visible instead of silent

A miss is repaired and reported instead of vanishing.

## Test

```
aidd-dev               codex:ok(+2 agents) claude:ok(+2 agents)
```
Agents confirmed at `cache/aidd-framework/aidd-dev/2.1.0/agents/{executor,checker}.md`.

## Note

This branch also carries `196fbce Refine README positioning for AI-driven development`, a pre-existing local commit on `next`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)