### PR TITLE
chore(framework): require review on next + sync release-flow docs

### DIFF
--- a/.github/rulesets/next.json
+++ b/.github/rulesets/next.json
@@ -16,7 +16,7 @@
     {
       "type": "pull_request",
       "parameters": {
-        "required_approving_review_count": 0,
+        "required_approving_review_count": 1,
         "dismiss_stale_reviews_on_push": false,
         "require_code_owner_review": false,
         "require_last_push_approval": false,

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -84,9 +84,9 @@ a PR with ≥1 Habilité (CODEOWNERS) approval, passing checks (`lefthook
 form: [`.github/rulesets/main.json`](.github/rulesets/main.json) (enforced once
 the repo is public / on a paid plan).
 
-`next` is the integration branch: PRs and passing checks, no direct push or
-deletion, but no required review so the week's work batches quickly. The release
-bot bypasses to push the automated back-merge. Machine-readable form:
+`next` is the integration branch: PRs with ≥1 review and passing checks, no
+direct push or deletion. The release bot bypasses to push the automated
+back-merge, and the `admin` team may merge without a second review. Machine-readable form:
 [`.github/rulesets/next.json`](.github/rulesets/next.json). The release flow is in
 [`RELEASE.md`](RELEASE.md).
 

--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -86,8 +86,8 @@ Dependabot labels its PRs `dependencies` only (ecosystem sub-labels were dropped
 
 release-please opens/updates a `chore: release main` PR on each push to `main`.
 
-1. Review the version bumps + changelog in the release PR (it is authored by the **aidd-bot** App, so its checks run normally).
-2. Merge it: `gh pr merge <n> --squash`. No admin needed - the App is a ruleset bypass actor, so its PRs merge once checks pass.
+1. (Optional) Review the version bumps + changelog. The PR is authored by the **aidd-bot** App, so its checks run normally.
+2. CI **auto-merges** it with the App token (`--squash --admin`); no human step is needed. `--admin` is required because a plain `gh pr merge` is refused even for the bypass App.
 3. CI tags each bumped package, creates the GitHub Releases, and attaches the bundles:
    - `aidd-framework-marketplace-X.Y.Z.zip` (`.claude-plugin/` + `plugins/`)
    - `<plugin>-vX.Y.Z.zip`
@@ -109,7 +109,9 @@ Two bypass actors (both `pull_request` mode, so neither can push directly to `ma
 
 The App: ID in secret `AIDD_BOT_APP_ID`, key in `AIDD_BOT_PRIVATE_KEY`. If the App is broken/uninstalled, release and Dependabot PRs stop merging - fix the App rather than re-adding an admin bypass.
 
-To change protection, edit `.github/rulesets/main.json`, then apply it live:
+Head branches are **not** auto-deleted on merge (`delete_branch_on_merge: false`): the promote PR merges `next` into `main` without deleting `next`, so the back-merge that realigns `next` afterwards never hits a missing branch. Do not re-enable the setting.
+
+To change protection, edit `.github/rulesets/main.json` (or `next.json`), then apply it live:
 ```bash
 gh api -X PUT repos/ai-driven-dev/framework/rulesets/<id> --input .github/rulesets/main.json
 ```

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -57,4 +57,5 @@ ruleset). After each release it either realigns `next` onto `main` (when `next`
 holds no unreleased work, the normal case) or keeps a merge (when it does), so
 the rebase-promote hash drift never accumulates. If it ever cannot push, it
 opens an issue labelled `back-merge-failed`; resync by opening a `main -> next`
-PR.
+PR. If `next` is missing entirely (it must not be — head branches are not
+auto-deleted), recreate it from `main` first: `git push origin main:next`.


### PR DESCRIPTION
Codifies the review requirement on `next`: `next.json` → 1 approval + GOVERNANCE.md updated (was "no required review"). The live ruleset already enforces 1; this resyncs the source file and doc with it, per the MAINTAINERS 'keep file and live ruleset in sync' rule.

Release bot (App, always-bypass) and admin team keep their bypass, so automation and lead-maintainer self-merge are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)