### PR TITLE
ci(framework): bump framework-build CLI pin to 5.0.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
           # path contains the other. Stage under RUNNER_TEMP, not the repo tree.
           OUT="${RUNNER_TEMP}/dist/${{ matrix.tool }}/${{ matrix.mode }}"
           mkdir -p "$OUT"
-          npx --yes @ai-driven-dev/cli@4.6.1 framework build \
+          npx --yes @ai-driven-dev/cli@5.0.2 framework build \
             --source . --target ${{ matrix.tool }} --out "$OUT" ${{ matrix.flag }}
           STAGE="$(mktemp -d)/${NAME}"
           mkdir -p "$STAGE"


### PR DESCRIPTION
The per-tool release zips were built with a pinned `@ai-driven-dev/cli@4.6.1`, a major behind the published 5.0.2.

**Verified** all 9 matrix cells build with 5.0.2. Only output change: marketplace mode (claude/cursor/copilot) — 4.6.1 collapsed aidd-dev's `plugin.json` `agents` to a bare `./agents`, while the source lists explicit files (`./agents/executor.md`, `./agents/checker.md`); 5.0.2 preserves them (a fix). Flat + codex byte-identical.

v5 needs `--out` to pre-exist; the step already `mkdir -p`s it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)