### PR TITLE
feat(framework): read action files before running, across all skills

### DIFF
--- a/aidd_docs/memory/vcs.md
+++ b/aidd_docs/memory/vcs.md
@@ -5,6 +5,7 @@
 - Platform: `github`
 - CLI: `gh`
 - Ticketing Tool: GitHub Issues
+- Pull request Template : `.github/PULL_REQUEST_TEMPLATE.md`
 
 ## Branch Naming Convention
 

--- a/plugins/aidd-context/skills/00-onboard/SKILL.md
+++ b/plugins/aidd-context/skills/00-onboard/SKILL.md
@@ -16,7 +16,7 @@ Scans the current project against the AIDD framework, reports what is present, d
 | 02  | `report` | Render the loud diagnostic plus one ordered command list, foundations then dev flow       | the 01 snapshot  |
 | 03  | `run`    | Run the user's pick per its tier, `OK` walks the whole list pausing at each GUIDED step, then re-scan | the user's reply |
 
-Run `01 → 02 → 03`, then loop back to `01` after each run until the user stops. Run each action's `## Test` before the next.
+Run `01 → 02 → 03`, then loop back to `01` after each run until the user stops. Run each action's `## Test` before the next. Before running an action, read its file in `actions/`, not only the table or assets.
 
 ## References
 

--- a/plugins/aidd-context/skills/01-bootstrap/SKILL.md
+++ b/plugins/aidd-context/skills/01-bootstrap/SKILL.md
@@ -19,6 +19,7 @@ Plays the role of technical architect for a new SaaS project. Walks the user thr
 | 05  | `write-install-md`    | Produce `aidd_docs/INSTALL.md`                                 | design + decisions |
 
 Run `01 → 02 → 03 → 04 → 05`. The audit (03) gates: if every candidate fails, loop back to 02 or 01.
+Before running an action, read its file in `actions/`, not only the table or assets.
 
 ## Transversal rules
 

--- a/plugins/aidd-context/skills/02-project-memory/SKILL.md
+++ b/plugins/aidd-context/skills/02-project-memory/SKILL.md
@@ -18,7 +18,7 @@ Bootstraps the project's context layer: the AI context files with a memory block
 | 04  | `review-memory`     | Review the memory files for consistency             | the memory dir    |
 | 05  | `sync-memory`       | Fill the memory block in every context file         | the context files |
 
-Run the actions in order, `01 → 05`, and run each action's `## Test` before the next.
+Run the actions in order, `01 → 05`, and run each action's `## Test` before the next. Before running an action, read its file in `actions/`, not only the table or assets.
 
 ## Memory rules
 

--- a/plugins/aidd-context/skills/04-skill-generate/SKILL.md
+++ b/plugins/aidd-context/skills/04-skill-generate/SKILL.md
@@ -19,6 +19,7 @@ Builds one canonical skill from intent and renders it per confirmed host tool, o
 | 05  | `validate`          | Run each action's Test, aggregate pass/fail    | the skill path    |
 
 Run the actions in order, `01 → 05`, and run each action's `## Test` before the next. In modify mode the tool is fixed by the existing skill's location, so the resolution gate is skipped.
+Before running an action, read its file in `actions/`, not only the table or assets.
 
 ## References
 

--- a/plugins/aidd-context/skills/04-skill-generate/assets/skill-template.md
+++ b/plugins/aidd-context/skills/04-skill-generate/assets/skill-template.md
@@ -17,6 +17,7 @@ argument-hint: <action-name-1 | action-name-2> # omit when the skill has only on
 | 01  | `<slug>` | <one-line role> | <input> |
 
 <Flow line, one concise sentence: a chain (`01 → 02 → 03`, test each before the next), or independent actions (the router runs the one matching the intent, or several together when asked).>
+Before running an action, read its file in `actions/`, not only the table or assets.
 <Optional, if it delegates: `Spawn the `<agent>` agent to run this skill.`>
 
 <!--

--- a/plugins/aidd-context/skills/05-rule-generate/SKILL.md
+++ b/plugins/aidd-context/skills/05-rule-generate/SKILL.md
@@ -17,6 +17,7 @@ Write one canonical rule from intent and render it per confirmed host tool that 
 | 03  | `validate`     | Check each rule file                      | the files    |
 
 Run the actions in order, `01 → 03`, and run each action's `## Test` before the next.
+Before running an action, read its file in `actions/`, not only the table or assets.
 
 ## References
 

--- a/plugins/aidd-context/skills/06-agent-generate/SKILL.md
+++ b/plugins/aidd-context/skills/06-agent-generate/SKILL.md
@@ -17,6 +17,7 @@ Write one canonical agent from intent and render it per confirmed host tool, or 
 | 03  | `validate`      | Check each agent file                          | the files    |
 
 Run the actions in order, `01 → 03`, and run each action's `## Test` before the next.
+Before running an action, read its file in `actions/`, not only the table or assets.
 
 ## References
 

--- a/plugins/aidd-context/skills/07-command-generate/SKILL.md
+++ b/plugins/aidd-context/skills/07-command-generate/SKILL.md
@@ -17,6 +17,7 @@ Write one canonical slash command from intent and render it per confirmed host t
 | 03  | `validate`        | Check each command file                   | the files    |
 
 Run the actions in order, `01 → 03`, and run each action's `## Test` before the next.
+Before running an action, read its file in `actions/`, not only the table or assets.
 
 ## References
 

--- a/plugins/aidd-context/skills/08-hook-generate/SKILL.md
+++ b/plugins/aidd-context/skills/08-hook-generate/SKILL.md
@@ -17,6 +17,7 @@ Builds one hook: an entry merged into the chosen scope for each supported tool, 
 | 03  | `validate`     | Check the file, the merge, and the moment fit      | files written     |
 
 Run the actions in order, `01 → 03`, and run each action's `## Test` before the next.
+Before running an action, read its file in `actions/`, not only the table or assets.
 
 ## References
 

--- a/plugins/aidd-context/skills/09-mermaid/SKILL.md
+++ b/plugins/aidd-context/skills/09-mermaid/SKILL.md
@@ -14,6 +14,7 @@ Produces a valid, structured Mermaid diagram from a written source by planning i
 | 01  | `mermaid` | Plan, confirm, generate, and review one diagram         | a written source |
 
 Run action `01` and run its `## Test` before trusting the result.
+Before running an action, read its file in `actions/`, not only the table or assets.
 
 ## Transversal rules
 

--- a/plugins/aidd-context/skills/10-learn/SKILL.md
+++ b/plugins/aidd-context/skills/10-learn/SKILL.md
@@ -18,6 +18,7 @@ Turns what a piece of work taught into the project's lasting context. It reads a
 | 04  | `sync`   | Refresh the memory block in every context file          | the written files |
 
 Order: `01 → 02 → 03 → 04`. Run each action's `## Test` before the next. When nothing is worth learning, `01` exits and the rest is skipped.
+Before running an action, read its file in `actions/`, not only the table or assets.
 
 ## Destinations
 

--- a/plugins/aidd-context/skills/11-explore/SKILL.md
+++ b/plugins/aidd-context/skills/11-explore/SKILL.md
@@ -22,6 +22,7 @@ Surveys the current project across three axes so the user sees what is there and
 | 02  | `drill`  | Descend one axis or all, level by level, match an intent if any   | a scope or a goal |
 
 Detect the project's AI tools first, from the signals in `references/ai-mapping.md`. Then route by what the user asked: no scope given runs `survey` for a compact map, a named axis or "all" runs `drill` straight away. Always propose the axes when the request is open, never assume one. Run each action's `## Test` before the next.
+Before running an action, read its file in `actions/`, not only the table or assets.
 
 ## Transversal rules
 

--- a/plugins/aidd-context/skills/12-cook/SKILL.md
+++ b/plugins/aidd-context/skills/12-cook/SKILL.md
@@ -16,6 +16,7 @@ Maintains the project's `recipes/` how-to sheets, the short runbooks that live a
 | 02  | `upsert` | Create or update one recipe from the template | recipe topic + fields |
 
 Run `list` to survey recipes, `upsert` to author one. Run `list` first when the user wants to update a recipe but hasn't named which.
+Before running an action, read its file in `actions/`, not only the table or assets.
 
 ## Assets
 

--- a/plugins/aidd-dev/skills/00-sdlc/SKILL.md
+++ b/plugins/aidd-dev/skills/00-sdlc/SKILL.md
@@ -19,6 +19,7 @@ Take a request from idea to shipped code, delegating every step. Interactive by 
 | 05  | `ship`      | Open the change request               | a commit and change-request capability  |
 
 Run `01 → 02 → 03 → 04 → 05`. On `04 = iterate`, loop to `03` then re-run `04`.
+Before running an action, read its file in `actions/`, not only the table or assets.
 
 ## Transversal rules
 

--- a/plugins/aidd-dev/skills/01-plan/SKILL.md
+++ b/plugins/aidd-dev/skills/01-plan/SKILL.md
@@ -18,6 +18,7 @@ Turn a gathered source into an implementation plan and its phase files. Never wr
 | 04  | `plan`      | Break into phases, write the plan and phase files    | explore output + wireframe |
 
 Run them in order, `01 → 04`. The plan is the culmination. Skip `03` when there is no UI.
+Before running an action, read its file in `actions/`, not only the table or assets.
 
 ## References
 

--- a/plugins/aidd-dev/skills/02-implement/SKILL.md
+++ b/plugins/aidd-dev/skills/02-implement/SKILL.md
@@ -17,6 +17,7 @@ Run an existing plan to write its code, one phase at a time, until every accepta
 | 03  | `finalize` | Verify and mark the plan implemented            | coded phases  |
 
 Run them in order, `01 → 03`.
+Before running an action, read its file in `actions/`, not only the table or assets.
 
 ## Transversal rules
 

--- a/plugins/aidd-dev/skills/03-assert/SKILL.md
+++ b/plugins/aidd-dev/skills/03-assert/SKILL.md
@@ -18,6 +18,7 @@ Validate that the work behaves as intended: run the project's assertions, iterat
 | 03  | `assert-frontend`     | Inspect the running UI, fixing until the behavior is right   |
 
 Run every applicable facet by default, or one when named. Coding (`01`) always applies; add `03` when the work has a UI and a frontend is running, the facet resolving the URL itself; run `02` only when architecture conformance is asked for. Skip a facet whose precondition is absent, with a noted reason. Ask only when the intent is genuinely ambiguous.
+Before running an action, read its file in `actions/`, not only the table or assets.
 
 ## Transversal rules
 

--- a/plugins/aidd-dev/skills/04-audit/SKILL.md
+++ b/plugins/aidd-dev/skills/04-audit/SKILL.md
@@ -22,6 +22,7 @@ Diagnose a codebase against quality pillars and emit one ranked findings report.
 | 07  | `ui`           | ui           | Loading/error/empty states, visual hierarchy, design-system drift, responsive, a11y |
 
 Run the one pillar named, or offer all seven when the request is unscoped.
+Before running an action, read its file in `actions/`, not only the table or assets.
 
 ## Transversal rules
 

--- a/plugins/aidd-dev/skills/05-review/SKILL.md
+++ b/plugins/aidd-dev/skills/05-review/SKILL.md
@@ -17,7 +17,7 @@ Read-only review of a diff along three axes, code quality, feature behavior, and
 | 02  | `review-functional` | The diff against the plan's phases and their acceptance criteria |
 | 03  | `review-relevancy`  | Does the change belong: fit to the need, rule conformance, no rot |
 
-Run all three by default, composing one report. Run a single axis only when the caller names it; if it is unclear whether they want all or one, ask.
+Run all three by default, composing one report. Run a single axis only when the caller names it; if it is unclear whether they want all or one, ask. Before running an action, read its file in `actions/`, not only the table or assets.
 
 ## Transversal rules
 

--- a/plugins/aidd-dev/skills/06-test/SKILL.md
+++ b/plugins/aidd-dev/skills/06-test/SKILL.md
@@ -17,6 +17,7 @@ Find untested behavior and iterate tests until they pass, or drive a full user j
 | 02  | `test-journey` | Validate a full user journey end-to-end in the browser         |
 
 Pick the one action matching the intent; never default to `01`. Triggers like "write tests" or "what's untested" route to `01`, "test the user journey" or "end-to-end" to `02`. Ask one question when the intent is ambiguous.
+Before running an action, read its file in `actions/`, not only the table or assets.
 
 ## Transversal rules
 

--- a/plugins/aidd-dev/skills/07-refactor/SKILL.md
+++ b/plugins/aidd-dev/skills/07-refactor/SKILL.md
@@ -18,6 +18,7 @@ The act-side of code improvement: it changes code to make it better. Behavior-pr
 | 04  | `architecture` | architecture | extract layers, fix coupling, enforce boundaries            |
 
 Run the one axis named, or offer all applicable when the request is unscoped.
+Before running an action, read its file in `actions/`, not only the table or assets.
 
 ## Transversal rules
 

--- a/plugins/aidd-dev/skills/08-debug/SKILL.md
+++ b/plugins/aidd-dev/skills/08-debug/SKILL.md
@@ -17,7 +17,7 @@ Diagnose and fix issues through structured hypothesis validation, root-cause ana
 | 02  | `debug`         | Root cause unknown: enumerate hypotheses, validate each, confirm the cause     |
 | 03  | `reflect-issue` | Stuck or prior fixes failed: reopen the search space, instrument logs first    |
 
-Pick the one action matching the intent; never default to `01`. Triggers like "reproduce and fix" route to `01`, "why does this happen" to `02`, "I'm stuck" or "previous fixes didn't work" to `03`. Ask one question when the intent is ambiguous.
+Pick the one action matching the intent; never default to `01`. Triggers like "reproduce and fix" route to `01`, "why does this happen" to `02`, "I'm stuck" or "previous fixes didn't work" to `03`. Ask one question when the intent is ambiguous. Before running an action, read its file in `actions/`, not only the table or assets.
 
 ## Transversal rules
 

--- a/plugins/aidd-dev/skills/09-for-sure/SKILL.md
+++ b/plugins/aidd-dev/skills/09-for-sure/SKILL.md
@@ -17,6 +17,7 @@ Run an autonomous loop until a success condition is verified. An interactive pre
 | 03  | `autonomous-loop` | autonomous             | spawn one worker per step, verify, retry, evaluate the success condition   |
 
 Run `01` interactively; it spawns `03`, which runs unattended under the `02` auto-accept rules until the success condition passes.
+Before running an action, read its file in `actions/`, not only the table or assets.
 
 ## Transversal rules
 

--- a/plugins/aidd-dev/skills/10-todo/SKILL.md
+++ b/plugins/aidd-dev/skills/10-todo/SKILL.md
@@ -12,3 +12,5 @@ Turn one prompt into N independent todos, implement them in parallel, report a t
 ```markdown
 actions/01-todo.md
 ```
+
+Before running an action, read its file in `actions/`, not only the table or assets.

--- a/plugins/aidd-pm/skills/01-ticket-info/SKILL.md
+++ b/plugins/aidd-pm/skills/01-ticket-info/SKILL.md
@@ -13,6 +13,8 @@ Reads ticket details from the configured ticketing tool. Read-only and tool-agno
 | --- | -------------- | ------------------------------------------------------------- | ---------------------------------- |
 | 01  | `ticket-info`  | Resolve ticket id, query the configured tool, display fields   | ticket_id (optional)               |
 
+Before running an action, read its file in `actions/`, not only the table or assets.
+
 ## Transversal rules
 
 - Read the configured ticketing tool from project memory first; otherwise inspect repo configuration or environment.

--- a/plugins/aidd-pm/skills/02-user-stories/SKILL.md
+++ b/plugins/aidd-pm/skills/02-user-stories/SKILL.md
@@ -20,6 +20,7 @@ Produces a prioritized backlog of INVEST-compliant user stories, each estimated 
 | 06  | `sync-tracker`    | Gate on Definition of Ready, get explicit approval, save to the tracker | ranked backlog from 05                 |
 
 Run `01 → 02 → 03 → 04 → 05 → 06`, passing each `## Test` first. A single story skips the epic split.
+Before running an action, read its file in `actions/`, not only the table or assets.
 
 ## Transversal rules
 

--- a/plugins/aidd-pm/skills/03-prd/SKILL.md
+++ b/plugins/aidd-pm/skills/03-prd/SKILL.md
@@ -13,6 +13,8 @@ Drafts a structured Product Requirements Document covering scope, goals, and acc
 | --- | ------- | ---------------------------------------------------- | ----------------------------------------------- |
 | 01  | `prd`   | Parse input, draft per template, validate, save      | feature_description, user_stories (optional)    |
 
+Before running an action, read its file in `actions/`, not only the table or assets.
+
 ## Transversal rules
 
 - Focus on what and why; never include technical implementation detail.

--- a/plugins/aidd-pm/skills/04-spec/SKILL.md
+++ b/plugins/aidd-pm/skills/04-spec/SKILL.md
@@ -16,6 +16,7 @@ Generate or refine the immutable contract for a feature: its target, hard constr
 | 02  | `refine` | Rewrite an existing spec to address review findings  | a spec path and the findings |
 
 Dispatch by input: a spec path with findings runs `refine`; a request or PRD path runs `build`.
+Before running an action, read its file in `actions/`, not only the table or assets.
 
 ## Transversal rules
 

--- a/plugins/aidd-refine/skills/01-brainstorm/SKILL.md
+++ b/plugins/aidd-refine/skills/01-brainstorm/SKILL.md
@@ -17,7 +17,7 @@ Turns a vague idea into a precise one through a deep, natural conversation. Each
 | 03  | `integrate` | Fold answers in, judge if real ambiguity remains           | answers + the idea  |
 | 04  | `finalize`  | Consolidate, flag open assumptions, offer to persist       | the clarified idea  |
 
-Run `capture`, loop `probe → integrate` until the idea is clear, then `finalize`.
+Run `capture`, loop `probe → integrate` until the idea is clear, then `finalize`. Before running an action, read its file in `actions/`, not only the table or assets.
 
 ## Transversal rules
 

--- a/plugins/aidd-refine/skills/01-brainstorm/actions/04-finalize.md
+++ b/plugins/aidd-refine/skills/01-brainstorm/actions/04-finalize.md
@@ -15,16 +15,11 @@ The approved refined idea with its flagged open assumptions and risks, a pointer
 1. **Consolidate.** Write the refined idea as one coherent, intent-level description built from the bullets. No solution, no plan.
 2. **Flag the open.** List the assumptions left unanswered and the risks to confirm at design time, so the next step knows them. Never present a guess as settled.
 3. **Get approval.** Show the refined idea and the open list, and ask the user to confirm or correct. Wait for the answer.
-4. **Point to the next move.** Say in plain words what the refined idea is now ready for, planning it, specifying it, or building it, so the user's next request reaches the right tool on its own. Describe the move, never name a plugin or skill, and never run it.
-5. **Offer to persist.** Once approved, present all three destinations and act on the pick. Name all three, persist nothing without the user's choice.
-   - **File.** Write the document to the feature folder as `aidd_docs/tasks/<yyyy_mm>/<yyyy_mm_dd>_<slug>/brainstorm.md`, where `<yyyy_mm_dd>` is today's date and `<slug>` is the idea in kebab-case. Reuse the feature folder when one already exists for this idea, otherwise create it. The format is fixed, never another name.
-
-     | Idea, saved on | File written |
-     | --- | --- |
-     | aidd-craft plugin, 2026-03-09 | `aidd_docs/tasks/2026_03/2026_03_09_aidd-craft-plugin/brainstorm.md` |
-     | dark mode toggle, 2026-11-20 | `aidd_docs/tasks/2026_11/2026_11_20_dark-mode-toggle/brainstorm.md` |
+4. **Offer to persist.** Once approved, name all three destinations as equals and act on the pick. Persist nothing without the user's choice.
+   - **File.** Write to `aidd_docs/tasks/<yyyy_mm>/<yyyy_mm_dd>_<slug>/brainstorm.md`, where `<yyyy_mm_dd>` is today's date and `<slug>` is the idea in kebab-case (e.g. `aidd_docs/tasks/2026_03/2026_03_09_aidd-craft-plugin/brainstorm.md`). Reuse the feature folder if one exists for this idea, else create it. The path format is fixed.
    - **Ticket.** Open or append a ticket drawn from the memory and VCS context.
    - **Session.** Keep it in the conversation only, write nothing.
+5. **Point to the next move.** After persisting, say in plain words what the refined idea is now ready for, planning it, specifying it, or building it, so the user's next request reaches the right tool on its own. Describe the move, never name a plugin or skill, and never run it.
 
 ## Test
 

--- a/plugins/aidd-refine/skills/02-challenge/SKILL.md
+++ b/plugins/aidd-refine/skills/02-challenge/SKILL.md
@@ -13,6 +13,8 @@ Rethink prior work and surface what is wrong, missing, or duplicated. Output a s
 | --- | ----------- | ------------------------------------------------------------- | ------------------------------ |
 | 01  | `challenge` | Rethink prior work, classify findings, score confidence       | the work + agreed reference    |
 
+Before running an action, read its file in `actions/`, not only the table or assets.
+
 ## Transversal rules
 
 - Reason from first principles, no logical gaps.

--- a/plugins/aidd-refine/skills/03-condense/SKILL.md
+++ b/plugins/aidd-refine/skills/03-condense/SKILL.md
@@ -16,6 +16,7 @@ Toggles a terse output mode with three intensity levels (lite, full, ultra). Str
 | 02  | `stats`    | Report real token usage and estimated savings for the current session | session messages + level timeline    |
 
 Dispatch by intent: a toggle phrase → `condense`, a savings query → `stats`.
+Before running an action, read its file in `actions/`, not only the table or assets.
 
 ## Transversal rules
 

--- a/plugins/aidd-refine/skills/04-shadow-areas/SKILL.md
+++ b/plugins/aidd-refine/skills/04-shadow-areas/SKILL.md
@@ -17,6 +17,7 @@ Analytically scans a written artifact for gaps the author has not addressed. Unl
 | 03  | `diff`           | Load prior report, classify gaps as closed / still-open / newly-introduced | gap list from detect + prior report path |
 
 Dispatch by context: with no prior report run `detect` then `render-report`; with one, run `detect` then `diff`.
+Before running an action, read its file in `actions/`, not only the table or assets.
 
 ## Transversal rules
 

--- a/plugins/aidd-refine/skills/05-fact-check/SKILL.md
+++ b/plugins/aidd-refine/skills/05-fact-check/SKILL.md
@@ -17,6 +17,7 @@ Verifies the factual claims inside a target text and rewrites it grounded in evi
 | 03  | `report`          | Rewrite the text with footnote citations, hedge unverified, surface conflicts | verdict list from 02        |
 
 Run `01 → 02 → 03`; pass each `## Test` before the next.
+Before running an action, read its file in `actions/`, not only the table or assets.
 
 ## Transversal rules
 

--- a/plugins/aidd-ui/skills/01-hello/SKILL.md
+++ b/plugins/aidd-ui/skills/01-hello/SKILL.md
@@ -14,3 +14,4 @@ Confirm the aidd-ui plugin loads and is reachable.
 | 01  | `greet` | Greet the user and confirm the skill works  |
 
 Single action skill: run `greet` and return its message.
+Before running an action, read its file in `actions/`, not only the table or assets.

--- a/plugins/aidd-vcs/skills/00-repo-init/SKILL.md
+++ b/plugins/aidd-vcs/skills/00-repo-init/SKILL.md
@@ -16,6 +16,7 @@ Initializes a project's repository locally and, on request, on the remote host, 
 | 02  | `publish` | Create the remote repo on the resolved host and push, return its URL                              | cwd, non_interactive            |
 
 Run `01 → 02`. `init` alone for local-only; `publish` after it to create the remote.
+Before running an action, read its file in `actions/`, not only the table or assets.
 
 ## Transversal rules
 

--- a/plugins/aidd-vcs/skills/01-commit/SKILL.md
+++ b/plugins/aidd-vcs/skills/01-commit/SKILL.md
@@ -17,6 +17,7 @@ Stage the right changes, write the message, commit. `01 → 02 → 03`.
 | 03  | `commit`  | Commit, and push when asked                            |
 
 Several concerns means several commits: repeat the chain, one concern at a time.
+Before running an action, read its file in `actions/`, not only the table or assets.
 
 ## Transversal rules
 

--- a/plugins/aidd-vcs/skills/02-pull-request/SKILL.md
+++ b/plugins/aidd-vcs/skills/02-pull-request/SKILL.md
@@ -16,6 +16,8 @@ Collect the change, draft the request, create it as a draft. `01 → 02 → 03`.
 | 02  | `draft`   | Write the title and body from the template                   |
 | 03  | `create`  | Open the draft request, label it, return the URL             |
 
+Before running an action, read its file in `actions/`, not only the table or assets.
+
 ## Transversal rules
 
 - Follow the project's request practices in `aidd_docs/memory/vcs.md` and the repo's own request template when set, else the bundled `assets/pull_request.md`.

--- a/plugins/aidd-vcs/skills/03-release-tag/SKILL.md
+++ b/plugins/aidd-vcs/skills/03-release-tag/SKILL.md
@@ -13,6 +13,8 @@ Cuts annotated semver releases with notes derived from recent commits.
 | --- | -------------- | -------------------------------------------------------------------------- | ---------------------------------- |
 | 01  | `release-tag`  | Compute version, draft notes, validate, bump, tag, push                    | version (optional), notes_overrides|
 
+Before running an action, read its file in `actions/`, not only the table or assets.
+
 ## Transversal rules
 
 - Versions follow semver `major.minor.patch` strictly. No suffixes unless explicitly requested.

--- a/plugins/aidd-vcs/skills/04-issue-create/SKILL.md
+++ b/plugins/aidd-vcs/skills/04-issue-create/SKILL.md
@@ -13,6 +13,8 @@ Files well-formed issues in the configured tracker after gathering enough contex
 | --- | --------------- | -------------------------------------------------------------------------- | -------------------------------------- |
 | 01  | `issue-create`  | Detect tool, fill template, validate, open the issue                        | problem_description, labels, type      |
 
+Before running an action, read its file in `actions/`, not only the table or assets.
+
 ## Transversal rules
 
 - Detect the ticketing tool from project memory first, then fall back to inferring it from the remote URL.


### PR DESCRIPTION
## What

Every router skill now tells the host to read an action's file before running it, and the brainstorm finalize step is reordered so it persists before pointing to the next move.

## Why

On hosts that don't follow the `SKILL.md` router into the `actions/` files (codex, copilot), skills were improvising steps from `SKILL.md` alone. The clearest symptom: brainstorm `finalize` never offered to persist (file/ticket/session) because that detail lives only in `actions/04-finalize.md`, which those hosts never opened. Two fixes:

1. **Read the action file** — a uniform routing line added to all 38 router skills' `SKILL.md` and the skill-generate template:
   > Before running an action, read its file in `actions/`, not only the table or assets.
2. **Persist before next move** — brainstorm `finalize` reordered so the persist offer runs before the next-move pointer, making the truncatable closing beat the guidance, never the durable artifact.

## Testing (headless, codex + Claude)

- **Codex**: rebuilt + installed the native tree, drove each skill with a realistic intent. ~32/38 skills now open their action file(s), including every multi-action flow (bootstrap, plan, user-stories, pull-request, sdlc, audit 7/7, review 3/3, generate family). Validated flow, step-entry, fallback, menu-all, and menu-subset paths.
- **Claude**: `plan` and `brainstorm` read their action files *and* their assets (plan-template, phase-template) — the `not only the table or assets` wording does not make Claude skip assets. No regression.

## Known limits (out of scope here)

- ~6 single-shot / interactive skills (commit, spec, fact-check, skill-generate, challenge, brainstorm) still improvise on trivial one-shot tasks on codex: the host answers directly without framing it as "running action X", so the trigger doesn't arm. A stronger wording fixed some but broke precise subset control, so it was reverted. The important multi-action flows all follow.
- `aidd-orchestrator/00-async-dev` uses nested `actions/setup/` + `actions/run/` dirs; the generic line was not applied there.

## Future skills

The line is baked into `skill-generate`'s template, so newly generated skills carry it automatically.
