### PR TITLE
ci(framework): stop release-please re-tagging aidd-ui

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -82,17 +82,6 @@
           "jsonpath": "$.version"
         }
       ]
-    },
-    "plugins/aidd-ui": {
-      "package-name": "aidd-ui",
-      "release-as": "0.1.0-alpha.0",
-      "extra-files": [
-        {
-          "type": "json",
-          "path": ".claude-plugin/plugin.json",
-          "jsonpath": "$.version"
-        }
-      ]
     }
   }
 }


### PR DESCRIPTION
## Problem

release-please fails on every `main` push that touches aidd-ui:

```
⚠ Duplicate release tag: aidd-ui-v0.1.0-alpha.0
##[error] release-please failed: Validation Failed: {"code":"already_exists","field":"tag_name"}
```

`release-please-config.json` pinned aidd-ui with `release-as: "0.1.0-alpha.0"`. `release-as` is a one-shot override: it forces that exact version on **every** run. The tag `aidd-ui-v0.1.0-alpha.0` was created once, so every later change touching aidd-ui makes release-please retry the existing tag and fail (this is what broke the release CI after #392).

## Fix

Remove the aidd-ui package from `release-please-config.json`, freezing it at `0.1.0-alpha.0` (its `plugin.json` version and existing tag are untouched) while it is still an alpha scaffold. No more duplicate-tag failures, and no risk of release-please graduating it to `0.1.0` stable prematurely (there is no prerelease config to keep it in alpha).

The manifest entry is left in place as a version record.

## When aidd-ui is ready to version

Re-add its package block with proper prerelease handling (e.g. `prerelease: true` / a prerelease type) instead of a `release-as` pin.

## Alternative considered

Removing only `release-as` (keeping the package): rejected — with no prerelease config, the next `feat` touching aidd-ui would graduate it from `0.1.0-alpha.0` to `0.1.0` stable, shipping the scaffold as a real release.
