### PR TITLE
ci(framework): drop the aidd-ui release-as pin, keep it consistent

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -82,6 +82,16 @@
           "jsonpath": "$.version"
         }
       ]
+    },
+    "plugins/aidd-ui": {
+      "package-name": "aidd-ui",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": ".claude-plugin/plugin.json",
+          "jsonpath": "$.version"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Context

#394 fixed the release-please duplicate-tag failure by removing aidd-ui from the config entirely — but that left aidd-ui as the only plugin without a package block, inconsistent with the other seven.

## This PR

Restore the aidd-ui block so it matches its siblings (`package-name` + `extra-files` syncing `plugin.json`), but **without** the `release-as: "0.1.0-alpha.0"` pin that caused the failure. Net over #394 + this PR: only the `release-as` pin is dropped; the package block is preserved.

## Verified (release-please dry-run on this branch)

```
## [0.2.0-alpha.0](compare/aidd-ui-v0.1.0-alpha.0...aidd-ui-v0.2.0-alpha.0)
```

- aidd-ui bumps `0.1.0-alpha.0` → **`0.2.0-alpha.0`**: a new tag, so **no duplicate-tag collision** — the failure is gone.
- It **stays on the alpha track** (does not graduate to a `0.1.0` stable release).
- No errors in the dry-run.

aidd-ui is back to being release-managed and consistent with the rest of the plugins.
