### PR TITLE
docs(vcs): add commit cycle guidelines for AI auto commits

### DIFF
--- a/plugins/aidd-context/skills/02-project-memory/assets/templates/memory/core/vcs.md
+++ b/plugins/aidd-context/skills/02-project-memory/assets/templates/memory/core/vcs.md
@@ -19,6 +19,10 @@ The version-control conventions this project follows: branches, commits, and the
 - Format: `<type(scope): description>`
 - Rules: `<imperative mood, lowercase, max length>`
 
+## Commit Strategy
+
+AI should auto commit: `never|after phase|after feature|after task done|post-tests`
+
 <!--
 Capture: the project's actual VCS choices. If they follow a standard, name it and point to the doc.
 Skip: re-explaining a standard in full. Capture the specifics and deviations.


### PR DESCRIPTION
Because AI should auto commit on branches when implementing.