### PR TITLE
feat(hooks): base new worktrees on next

### DIFF
--- a/.claude/hooks/worktree-create.js
+++ b/.claude/hooks/worktree-create.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+// WorktreeCreate hook — base every new worktree on `next`, falling back to
+// `main` when the `next` branch does not exist.
+//
+// Docs: https://code.claude.com/docs/en/hooks#worktreecreate
+//   stdin : JSON { name } — the worktree name
+//   stdout: the created worktree path, and nothing else
+// This replaces Claude's default `git worktree add`.
+
+const { execFileSync } = require("node:child_process");
+const { readFileSync } = require("node:fs");
+const { join } = require("node:path");
+
+// Run a git command and return its trimmed stdout. git's own progress text is
+// forwarded to our stderr so this process's stdout stays reserved for the path.
+function git(...args) {
+  return execFileSync("git", args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "inherit"],
+  }).trim();
+}
+
+function branchExists(branch) {
+  try {
+    git("rev-parse", "--verify", "--quiet", `refs/heads/${branch}`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function readWorktreeName() {
+  const payload = JSON.parse(readFileSync(0, "utf8"));
+  return payload.name;
+}
+
+function createWorktree() {
+  const worktreeName = readWorktreeName();
+  const baseBranch = branchExists("next") ? "next" : "main";
+
+  const repoRoot = git("rev-parse", "--show-toplevel");
+  const worktreePath = join(repoRoot, ".claude", "worktrees", worktreeName);
+  const newBranch = `worktree-${worktreeName}`;
+
+  git("worktree", "add", worktreePath, "-b", newBranch, baseBranch);
+
+  process.stdout.write(worktreePath + "\n");
+}
+
+createWorktree();

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,5 +12,17 @@
     "aidd-pm@aidd-framework": true,
     "aidd-orchestrator@aidd-framework": true,
     "aidd-refine@aidd-framework": true
+  },
+  "hooks": {
+    "WorktreeCreate": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/worktree-create.js\""
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
## 🎯 What & why

New worktrees created by Claude Code branched from the repo default (`origin/HEAD` = `main`). Day-to-day work targets `next`, so worktrees should start there. This adds a `WorktreeCreate` hook that bases every new worktree on `next`, falling back to `main` when `next` is absent.

## 🛠️ How it works

Claude Code's `WorktreeCreate` hook [replaces](https://code.claude.com/docs/en/hooks#worktreecreate) the default `git worktree add`: it reads `{ name }` on stdin and must print the created worktree path on stdout.

[.claude/hooks/worktree-create.js](.claude/hooks/worktree-create.js) does exactly that — picks `next` (else `main`), then `git worktree add <root>/.claude/worktrees/<name> -b worktree-<name> <base>`, and prints the path. git's own output goes to stderr so stdout stays the path only. [.claude/settings.json](.claude/settings.json) registers it.

Kept deliberately minimal: only `.name` is documented as hook input, so no speculative field parsing. Base is the local `next` branch (not `origin/next`) to keep it simple; call out if fresh-from-origin is wanted.

## 🧪 How to verify

- `claude --worktree probe` from repo root
- `git -C .claude/worktrees/probe log --oneline -1` → matches `next` tip
- `git -C .claude/worktrees/probe branch --show-current` → `worktree-probe`

## ⚠️ Heads-up

Not yet exercised by a real `claude --worktree` run — logic tested only in throwaway repos. The `.name` input key is from docs, not observed live; if the worktree lands empty, the payload key differs and the script needs adjusting.

## ✅ I certify

- [x] **I DO CERTIFY I READ EACH LINE OF THE PULL REQUEST BECAUSE I AM A SOFTWARE ENGINEER, NOT A AI PUPPY.**