### PR TITLE
ci(dependabot): approve non-major updates to unblock auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -25,6 +25,15 @@ jobs:
         id: meta
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
 
+      - name: Approve non-major updates
+        # Required-review rulesets (e.g. on `next`) block auto-merge until a
+        # review approves. Dependabot never gets one, so the app approves here.
+        # The app identity differs from the PR author, so the approval counts.
+        if: steps.meta.outputs.update-type != 'version-update:semver-major'
+        run: gh pr review --approve "${{ github.event.pull_request.html_url }}"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
       - name: Enable auto-merge for non-major updates
         if: steps.meta.outputs.update-type != 'version-update:semver-major'
         run: gh pr merge --auto --squash "${{ github.event.pull_request.html_url }}"


### PR DESCRIPTION
## Problem

Non-major dependabot PRs on `next` had auto-merge enabled but sat `BLOCKED` forever. The `next protection` ruleset requires `required_approving_review_count: 1`; dependabot PRs never receive a review, so auto-merge never fires.

## Fix

Add an approve step (app token) for non-major (patch + minor) updates before enabling auto-merge. The app identity (`aidd-bot`) differs from the PR author (`dependabot[bot]`), so the approval counts toward the required review.

Targets `next` because `pull_request_target` runs the workflow from the PR's base branch.

## Notes
- Major bumps still require a human.
- Backlog (#398-401) already cleared manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)