### PR TITLE
ci(release-please): pin GitHub latest to umbrella marketplace tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,22 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: gh pr merge "${{ fromJSON(steps.release.outputs.pr).number }}" --squash --admin --repo "${{ github.repository }}"
 
+      # Pin GitHub's "Latest" badge to the umbrella marketplace release.
+      # release-please creates the umbrella + every plugin release in one run
+      # with no ordering guarantee, and GitHub marks whichever release is created
+      # last as "Latest" (the create API defaults make_latest to true). That
+      # lets a plugin release (e.g. aidd-dev-v2.3.0) outrank the marketplace
+      # version whenever a cycle ships plugins alongside the umbrella. Bare
+      # `tag_name` is the root "." package tag (the umbrella `v*`, the tag that
+      # carries the marketplace bundle); forcing it latest auto-unsets the plugin
+      # release that held the badge. The umbrella bumps every cycle, so a
+      # release run always has a root tag to pin.
+      - name: Pin umbrella release as latest
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: gh release edit "${{ steps.release.outputs.tag_name }}" --latest --repo "${{ github.repository }}"
+
   build-and-attach:
     name: Build and attach marketplace
     needs: [release-please]


### PR DESCRIPTION
## 🎯 What & why

GitHub's "Latest" release badge is not reliably the umbrella marketplace version (`v*`). On cycles that ship plugins alongside the umbrella, a plugin release (e.g. `aidd-dev-v2.3.0`) can be marked Latest over the marketplace version (e.g. `v5.3.0`), so users landing on the repo see a `2.x` plugin instead of the `5.x` marketplace.

## 🛠️ How it works

release-please creates the umbrella + every plugin release in one run with no ordering guarantee. GitHub's release-create API defaults `make_latest` to `true`, and Latest resolves by `created_at` (last created wins), not by semver — so whichever release is created last steals the badge.

The fix adds one step to the `release-please` job in [ci.yml](.github/workflows/ci.yml), right after the action, forcing the root `.` package tag (the umbrella `v*`) as Latest:

```
gh release edit "$TAG" --latest
```

Why this over alternatives:
- Bare `steps.release.outputs.tag_name` is the root `.` tag — verified it's the tag carrying `aidd-framework-marketplace-*.zip`, not a plugin.
- Setting one release latest auto-unsets whoever held the badge, so no need to touch the plugin releases.
- Guarded on root `release_created == 'true'`. Safe because the umbrella bumps every cycle (across 90 releases, no plugin-only cycle exists), so a release run always has a root tag to pin.

## 🧪 How to verify

- YAML valid; `actionlint .github/workflows/ci.yml` clean for the new step (pre-existing SC2086 warnings at other steps untouched).
- `gh release edit --latest` flag present (`gh release edit --help`).
- Post-merge: next batched release run should leave `gh api repos/ai-driven-dev/framework/releases/latest --jq .tag_name` on the `v*` umbrella tag, not a plugin.

## ⚠️ Heads-up

The new step only executes on the real release run (push to `main` after the Release PR merges); it can't be exercised from this PR. Logic + syntax verified here.