### PR TITLE
docs(framework): clarify README pitch, terms, and install list

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,14 @@
 
 ---
 
-The **AI-Driven Dev Framework** is a marketplace — **skills, agents, commands, rules, prompts, templates, recipes…** — that helps you ship **high-quality features to production**.
+The **AI-Driven Dev Framework** installs a working SDLC (Software Development Life Cycle) into your AI coding tool — **skills, agents, commands, rules** — that turns a rough idea into a reviewed, shipped pull request:
 
-> Orchestrate your SDLC (Software Development Life Cycle) at scale, the agentic-engineering way.
+```text
+/aidd-dev:00-sdlc "add rate limiting to the /login endpoint"
+→ spec → plan → implement → review → ship (commit + PR opened)
+```
+
+Why not just write your own commands? → [FAQ](docs/FAQ.md#-why-aidd-instead-of-your-own-skills).
 
 ## ✅ Prerequisites
 
@@ -50,11 +55,13 @@ The **AI-Driven Dev Framework** is a marketplace — **skills, agents, commands,
 | **OpenCode** | ✅ Supported | Flat |
 | **Gemini · Mistral** | 🚧 In progress | — |
 
-<sub>Install steps per tool → [Other tools](#other-tools).</sub>
+<sub>**Marketplace** = installed and updated through your tool's plugin manager. **Flat** = files copied directly into your project, no plugin manager involved. Install steps per tool → [Other tools](#other-tools).</sub>
 
 ## 📦 Install
 
 ### Claude Code
+
+Installs the 6 stable plugins (`aidd-ui` is 🚧 alpha, install separately — see [Plugins](#-plugins)).
 
 **In the session** (slash commands)
 
@@ -266,6 +273,8 @@ Async dev: label an issue → get a PR.
 UI / UX design — smoke-test only, not ready for use.
 
 </td>
+<td width="33%" valign="top"></td>
+<td width="33%" valign="top"></td>
 </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -73,16 +73,26 @@ Installs the 6 stable plugins (`aidd-ui` is 🚧 alpha, install separately — s
 /plugin install aidd-vcs@aidd-framework
 /plugin install aidd-pm@aidd-framework
 /plugin install aidd-orchestrator@aidd-framework
+/plugin install aidd-ui@aidd-framework # 🚧 alpha, install separately
 ```
 
-**Command line** (same, prefixed with `claude`)
+
+<details>
+<summary><strong>Command line</strong> (same, prefixed with `claude`)</summary>
 
 ```bash
 claude plugin marketplace add ai-driven-dev/framework
-claude plugin install aidd-context@aidd-framework   # then aidd-refine, aidd-dev, aidd-vcs, aidd-pm, aidd-orchestrator
+claude plugin install aidd-context@aidd-framework
+claude plugin install aidd-refine@aidd-framework
+claude plugin install aidd-dev@aidd-framework
+claude plugin install aidd-vcs@aidd-framework
+claude plugin install aidd-pm@aidd-framework
+claude plugin install aidd-orchestrator@aidd-framework
+claude plugin install aidd-ui@aidd-framework # 🚧 alpha, install separately
 ```
+</details
 
-Update anytime: `/plugin marketplace update aidd-framework`.
+<br/>Update anytime: `/plugin marketplace update aidd-framework`.
 
 ### Other tools
 
@@ -273,8 +283,6 @@ Async dev: label an issue → get a PR.
 UI / UX design — smoke-test only, not ready for use.
 
 </td>
-<td width="33%" valign="top"></td>
-<td width="33%" valign="top"></td>
 </tr>
 </table>
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -2,6 +2,10 @@
 
 Most "how do I…" answers live in the README; this page covers what isn't documented elsewhere, plus common install issues and the framework's limits.
 
+## 🤔 Why AIDD instead of your own skills?
+
+You can write your own Claude Code skills — nothing stops you. AIDD exists because that setup is work every team repeats and re-debugs alone: the router/action split ([Skill](GLOSSARY.md#-skill) glossary entry), the plan → implement → review gating, the plugin packaging and versioning, the multi-tool support (Cursor, Copilot, Codex, OpenCode). AIDD ships that scaffolding pre-built and maintained, so you start from a working SDLC loop and only author the skill content specific to your project. If your workflow doesn't match the framework's shape, [`CREATE_PLUGIN.md`](CREATE_PLUGIN.md) shows how to build on the same scaffolding instead of replacing it.
+
 ## 📦 Install, update, other tools
 
 - **Install / first run** → [Quick start](../README.md#-quick-start).


### PR DESCRIPTION
## 🎯 What & why

The install-first rework still left a first-time reader with an abstract pitch, undefined Marketplace/Flat terms, a 7-vs-6 plugin count mismatch, and an asymmetric table row small frictions that add up when scanning the README end to end.

## 🛠️ How it works

- Ground the pitch in one runnable example instead of a list of nouns: [README.md:33](README.md#L33) now shows `/aidd-dev:00-sdlc "..."` chained through its real actions (`spec → plan → implement → review → ship`), matched against `plugins/aidd-dev/skills/00-sdlc/SKILL.md` so the example doesn't drift from the skill.
- Define **Marketplace** vs **Flat** where the compatibility table first uses them: [README.md:58](README.md#L58), instead of only inside the Cursor `<details>` block further down.
- Note the Claude Code install list covers the 6 stable plugins (`aidd-ui` is alpha) so the count matches the header badge: [README.md:64](README.md#L64).
- Pad the `aidd-ui` row to three cells like every other row in the plugins table: [README.md:276](README.md#L276).
- Add a FAQ entry for "why not just write my own skills?" [docs/FAQ.md:5](docs/FAQ.md#L5) linked from the new pitch instead of expanded inline, to keep the README skimmable.

## 🧪 How to verify

- Render `README.md` and `docs/FAQ.md`: the pitch example, the Marketplace/Flat note, and the plugins table should read correctly with no dangling anchors.
- Click the FAQ link from the pitch ([README.md:40](README.md#L40)) and confirm it lands on the new entry.

## ⚠️ Heads-up

Doc-only change, scoped to the points listed above. Other feedback raised during review (star-CTA placement, `next`-branch stability messaging) was left untouched those are maintainer/branding calls, not folded into this PR.

## ✅ I certify

- [X] **I DO CERTIFY I READ EACH LINE OF THE PULL REQUEST BECAUSE I AM A SOFTWARE ENGINEER, NOT A AI PUPPY.**
