### PR TITLE
chore(framework): type issues instead of labelling them

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: 🐛 Bug Report
 description: Report a bug or unexpected behaviour in the framework
-title: "fix: "
-labels: ["bug"]
+title: "fix(<scope>): "
+type: Bug
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: ✨ Feature Request
 description: Propose new content or an improvement to the framework
-title: "feat: "
-labels: ["enhancement"]
+title: "feat(<scope>): "
+type: Feature
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/roadmap.yml
+++ b/.github/ISSUE_TEMPLATE/roadmap.yml
@@ -1,0 +1,47 @@
+name: 🗺️ Roadmap item
+description: "Maintainer-authored work: a skill, a refactor, a rule to enforce"
+title: "<type>(<scope>): "
+type: Task
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For maintainers planning framework work. Reporting a bug or asking for a feature as a user?
+        Use the **Bug Report** or **Feature Request** form instead.
+
+        The title carries its own scope, matching `commitlint.config.cjs`: `feat(aidd-pm):`, `fix(framework):`, `refactor(aidd-context):`.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What is wrong or missing today. State the current behaviour, not the fix.
+      placeholder: The router of `10-learn` is 40 lines of its 153, denser than the four actions it routes to.
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: What this change does. One bullet per deliverable.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Checkboxes a reviewer can verify without asking the author. Each one observable.
+      value: |
+        - [ ]
+        - [ ]
+    validations:
+      required: true
+  - type: textarea
+    id: prior-art
+    attributes:
+      label: Prior art in this repo
+      description: What already exists that this builds on or duplicates. Cite the file and line. Leave empty if you checked and found none.
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: Out of scope
+      description: What a reader would expect here and will not find, with where it lives instead.

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,8 +1,12 @@
 # Canonical issue and PR label list for ai-driven-dev/framework.
 #
-# Labels are TRIAGE ONLY: they categorize an issue or PR. They never decide
-# where a PR targets — routing is by branch prefix (see aidd_docs/memory/vcs.md).
-# Keep one triage label per change.
+# Labels do NOT categorize an issue. Issue types (Bug, Feature, Task) and the
+# org issue fields (Priority, Effort) do that, and the issue forms set the type.
+# A label here exists only when a bot or a human reads it, and nothing else can
+# carry the signal.
+#
+# Labels never decide where a PR targets — routing is by branch prefix
+# (see aidd_docs/memory/vcs.md).
 #
 # This file is the source of truth. When the GitHub label set drifts from
 # this file, sync manually with:
@@ -13,35 +17,19 @@
 # job). Plugins may create their own labels on install; those are documented in
 # the plugin, not here.
 
-# --- Triage --------------------------------------------------------------
-
-- name: bug
-  description: Something isn't working
-  color: d73a4a
-
-- name: enhancement
-  description: New feature or request
-  color: a2eeef
-
-- name: documentation
-  description: Improvements or additions to documentation
-  color: 0075ca
-
-- name: security
-  description: Security-sensitive issue or fix (cross-cutting, add to any kind)
-  color: B60205
+# --- Read by a human -----------------------------------------------------
 
 - name: good first issue
   description: Good for newcomers
   color: 7057ff
 
-# --- Dependencies --------------------------------------------------------
+# --- Applied by dependabot (.github/dependabot.yml) ----------------------
 
 - name: dependencies
   description: Dependency update (dependabot)
   color: 0366d6
 
-# --- Release tooling -----------------------------------------------------
+# --- Applied by release-please -------------------------------------------
 
 - name: "autorelease: pending"
   description: Release Please release PR awaiting merge


### PR DESCRIPTION
## 🎯 What & why

The issue forms applied `labels: ["bug"]` and `labels: ["enhancement"]`. Neither label exists on GitHub, so both directives were silently dropped: **zero of the repo's 300 issues carries either one**. Issue types (`Bug`, `Feature`, `Task`) are defined at the org level, and [issue forms support a top-level `type:` key](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms).

## 🛠️ How it works

- **Both forms swap `labels:` for `type:`.** [bug_report.yml](.github/ISSUE_TEMPLATE/bug_report.yml#L4) sets `type: Bug`, [feature_request.yml](.github/ISSUE_TEMPLATE/feature_request.yml#L4) sets `type: Feature`.
- **Titles carry a scope.** `fix(<scope>): ` and `feat(<scope>): `, matching the scope `commitlint.config.cjs` already expects on the commit that closes the issue.
- **New [roadmap.yml](.github/ISSUE_TEMPLATE/roadmap.yml)** for maintainer-authored work: `Problem`, `Scope`, `Acceptance criteria` required; `Prior art in this repo` and `Out of scope` optional. No Code of Conduct checkbox, no OS dropdown — those belong on a contributor intake form, not on a roadmap item. The two optional sections are the ones that surfaced duplicates during the backlog triage that prompted this PR.
- **[labels.yml](.github/labels.yml) drops `bug`, `enhancement`, `documentation`, `security`.** Types replace them. What survives is what a bot or a human actually reads: `good first issue`, `dependencies` (dependabot), `autorelease: *` (release-please).

The `dependencies` label was missing on GitHub too, so dependabot dropped it on every PR (#401, #400, #399, #398, #362 all landed unlabelled). It has been created out-of-band; the GitHub label set now matches `labels.yml` exactly.

## 🧪 How to verify

```bash
# every template parses, and none applies a label
for f in .github/ISSUE_TEMPLATE/*.yml .github/labels.yml; do yq e '.' "$f" >/dev/null && echo "OK $f"; done
grep -r '^labels:' .github/ISSUE_TEMPLATE/ ; echo "exit=$?  # 1 = no label left"

# live label set equals the canonical list
gh label list --repo ai-driven-dev/framework | cut -f1 | sort
yq e '.[].name' .github/labels.yml | sort
```

Then open <https://github.com/ai-driven-dev/framework/issues/new/choose>: three forms, each stamping a type.

## ✅ I certify

- [ ] **I DO CERTIFY I READ EACH LINE OF THE PULL REQUEST BECAUSE I AM A SOFTWARE ENGINEER, NOT A AI PUPPY.**
