### PR TITLE
fix(aidd-context): onboard shows the stack, and its keys are pressable

### DIFF
--- a/plugins/aidd-context/CATALOG.md
+++ b/plugins/aidd-context/CATALOG.md
@@ -1,6 +1,6 @@
 # aidd-context catalog
 
-Auto-generated framework content: agents, commands, rules, skills, and templates.
+Auto-generated index of skills, agents, references and assets shipped by the `aidd-context` plugin.
 
 > This file is automatically updated by the `scripts/summarize-markdown.js` script.
 

--- a/plugins/aidd-context/skills/00-onboard/actions/03-present.md
+++ b/plugins/aidd-context/skills/00-onboard/actions/03-present.md
@@ -16,6 +16,7 @@ The rendered screen, and the user's reply.
    - Framing line on the first report of the session only.
    - Exactly one action block per screen, carrying its key once.
    - The idle menu is a next-action block. Slot 1 is the action line, slots 2 to 4 join the options line. Never a list.
+   - The state block carries every foundation, so the foundations step count reads off it.
    - Glyphs: ✅ met · ⚠️ present, not wired · ❌ missing.
    - A used tool that lacks the block is `⚠️`, never `❌`. Only a missing required foundation takes `❌`.
    - Every `⚠️` shows its cause and a keyed fix.

--- a/plugins/aidd-context/skills/00-onboard/actions/03-present.md
+++ b/plugins/aidd-context/skills/00-onboard/actions/03-present.md
@@ -22,7 +22,8 @@ The rendered screen, and the user's reply.
    - Every `⚠️` shows its cause and a keyed fix.
    - Short lines.
    - The options line is the last line. Print nothing after it, no detail block, no state snapshot, no hint about what comes next.
-   - Command ids, tier clauses, and lookahead only under `[?]`.
+   - Command ids, tier clauses, and lookahead only under `[d]`.
+   - Keys are letters or digits. Never `?`, `!`, `/`, `@`, `#`: the host takes those.
 2. **Inject.**
    - Entry screen takes `@../assets/banner.txt`.
    - Flow or walk screen loads `@../references/flow.md`.

--- a/plugins/aidd-context/skills/00-onboard/actions/04-run.md
+++ b/plugins/aidd-context/skills/00-onboard/actions/04-run.md
@@ -29,5 +29,5 @@ The reply carried out.
 - `OK` runs AUTO unattended and pauses at each GUIDED.
 - A MANUAL step is shown, never run.
 - A gap invokes nothing.
-- `?`/`back` re-render with no re-scan.
+- `d`/`back` re-render with no re-scan.
 - A GUIDED handoff emits the return line.

--- a/plugins/aidd-context/skills/00-onboard/assets/report.md
+++ b/plugins/aidd-context/skills/00-onboard/assets/report.md
@@ -8,9 +8,10 @@
 👋  <framing, or "Welcome back.">
 
 Your AIDD setup:
-  AI tools   <detected, each ✅/⚠️, or "none yet" when none>
-  Plugins    <installed>   ✅
-  Memory     <aidd_docs · N synced ✅ | ❌ not set up yet>
+  AI tools    <detected, each ✅/⚠️, or "none yet" when none>
+  Plugins     <installed>   ✅
+  Tech stack  <✅ established | ❌ not chosen yet>
+  Memory      <aidd_docs · N synced ✅ | ❌ not set up yet>
 
 <state sentence>
 

--- a/plugins/aidd-context/skills/00-onboard/assets/report.md
+++ b/plugins/aidd-context/skills/00-onboard/assets/report.md
@@ -56,11 +56,11 @@ Foundations — step <n> of <total>
     <other keyed options>
 ```
 
-## [?] detail
+## [d] detail
 
 ```txt
 Details —
   1. <step>   <command-id>   (<tier clause>)
   <foundation lines, ✅/⚠️/❌>
-  explain <n> · explain project · recap · stop · back [<]
+  explain <n> · explain project · recap · stop · back [b]
 ```

--- a/plugins/aidd-context/skills/00-onboard/references/run/replies.md
+++ b/plugins/aidd-context/skills/00-onboard/references/run/replies.md
@@ -4,8 +4,8 @@
 | ------------- | --------------------------------------------------------------------------------- |
 | a number `[n]`| run that step, or open an idle-menu umbrella                                         |
 | `OK`          | walk the pending steps (ranks 1-3) in order, never the idle menu                     |
-| `?`           | expand the full detail (command ids, tier clauses, per-check reasons), read-only     |
-| `back` / `<`  | re-render the prior screen, read-only, no re-scan                                    |
+| `d` / `details` | expand the full detail (command ids, tier clauses, per-check reasons), read-only   |
+| `b` / `back`  | re-render the prior screen, read-only, no re-scan                                    |
 | `recap`       | summarize this session's conversation, read-only, only when a prior conversation exists |
 | `explain <n>` | describe a step in two or three plain lines, read-only                               |
 | `explain project` | summarize the project from its memory bank, read-only, only when memory is filled |


### PR DESCRIPTION
Two defects found by running v2.3.0 on real repos.

**The step count had no source.** The foundations block says `step 1 of 2` on an existing repo and `1 of 3` on a greenfield one, but the state block listed only AI tools, plugins and memory. The stack was a foundation the reader could not see, so the count rested on a sentence the model was free to drop — and dropped. The stack now has its own row; the count reads off the block.

**The detail key could never be pressed.** `?` opens the help prompt in Claude Code. Details moves to `[d]`, back to `[b]`, and a render rule reserves keys to letters and digits.

Verified on the demo fixtures:

| repo | before | after |
| ---- | ------ | ----- |
| `01-greenfield` | `1 of 3`, no stack row | `Tech stack ❌ not chosen yet` → `1 of 3` |
| `02-existing-no-memory` | `1 of 2`, no stack row | `Tech stack ✅ established` → `1 of 2` |

Keys now render `[1] [s] [d] [m]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)