### PR TITLE
fix(framework): worktree-create installs deps so the first commit works

### DIFF
--- a/.claude/hooks/worktree-create.js
+++ b/.claude/hooks/worktree-create.js
@@ -44,6 +44,18 @@ function createWorktree() {
 
   git("worktree", "add", worktreePath, "-b", newBranch, baseBranch);
 
+  // A fresh worktree has no node_modules, so its first commit fails the
+  // commit-msg hook (commitlint not found). Install deps best-effort: never
+  // let a failed install block the worktree the user asked for.
+  try {
+    execFileSync("pnpm", ["install", "--frozen-lockfile"], {
+      cwd: worktreePath,
+      stdio: ["ignore", "inherit", "inherit"],
+    });
+  } catch {
+    process.stderr.write("worktree-create: pnpm install skipped or failed; run it manually before committing\n");
+  }
+
   process.stdout.write(worktreePath + "\n");
 }
 


### PR DESCRIPTION
## 🎯 What & why

A fresh worktree has no `node_modules`, so its first commit failed the `commit-msg` hook with `commitlint not found`. Hit repeatedly this session.

## 🛠️ How it works

`.claude/hooks/worktree-create.js` runs `pnpm install --frozen-lockfile` after creating the worktree, **best-effort**: a failed install logs to stderr and is skipped, never blocking the worktree the user asked for.

The hook is internal (`.claude/` only, not shipped in a plugin) and this repo is pnpm-only (single lockfile, Makefile `setup` uses pnpm), so no package-manager detection is needed.

## 🧪 How to verify

```bash
node --check .claude/hooks/worktree-create.js
# then, in a Claude worktree: the first commit runs without "commitlint not found"
```

## ✅ I certify

- [ ] **I DO CERTIFY I READ EACH LINE OF THE PULL REQUEST BECAUSE I AM A SOFTWARE ENGINEER, NOT A AI PUPPY.**
