### PR TITLE
feat(aidd-dev): install shared worktree setup

### DIFF
--- a/plugins/aidd-dev/README.md
+++ b/plugins/aidd-dev/README.md
@@ -10,6 +10,14 @@ First time? Install with `/plugin install aidd-dev@aidd-framework`, then run `ai
 
 Covers the full SDLC coding loop: orchestrator, planning, implementation, assertions, audits, code review, testing, refactoring, debugging, for-sure, and parallel todo fan-out. Also hosts AI agents.
 
+## Préparation de worktree Codex
+
+`scripts/dev-sync.sh aidd-dev` installe aussi `pre-init-worktree.sh` dans
+`~/.aidd/hooks/` (ou `$AIDD_HOME/hooks/`). Les environnements Codex peuvent alors
+l’appeler avant le démarrage de la tâche. Le manifeste Codex ne fournit pas de
+lifecycle `post-install` : cette copie est donc effectuée par l’installateur AIDD
+pour un checkout Framework, pas par `codex plugin add` seul.
+
 ## Skills
 
 | Bracket ID | Skill | Description |

--- a/plugins/aidd-dev/hooks/pre-init-worktree.sh
+++ b/plugins/aidd-dev/hooks/pre-init-worktree.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env sh
+# Prepare a fresh Codex worktree before the task starts.
+# Installed by scripts/dev-sync.sh at ~/.aidd/hooks/pre-init-worktree.sh.
+set -eu
+
+remote="${AIDD_WORKTREE_REMOTE:-origin}"
+base_branch="${AIDD_WORKTREE_BASE_BRANCH:-main}"
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  printf '%s\n' 'pre-init-worktree: expected a Git worktree.' >&2
+  exit 1
+fi
+
+current_branch="$(git branch --show-current)"
+if [ -n "$current_branch" ]; then
+  printf '%s\n' "pre-init-worktree: refusing to move named branch '$current_branch'." >&2
+  exit 1
+fi
+
+if [ -n "$(git status --porcelain)" ]; then
+  printf '%s\n' 'pre-init-worktree: refusing to reset a dirty worktree.' >&2
+  exit 1
+fi
+
+git fetch --prune "$remote" "$base_branch"
+git switch --detach "$remote/$base_branch"
+"${MAKE:-make}" install setup

--- a/scripts/dev-sync.sh
+++ b/scripts/dev-sync.sh
@@ -26,6 +26,8 @@ BUILD="${BUILD:-$HOME/.cache/aidd-framework-dev}"  # per-tool native trees the m
 CODEX_CACHE="${CODEX_CACHE:-$HOME/.codex/plugins/cache}"
 CLAUDE_CACHE="${CLAUDE_CACHE:-$HOME/.claude/plugins/cache}"
 CODEX_AGENTS="${CODEX_AGENTS:-$HOME/.codex/agents}"
+AIDD_HOME="${AIDD_HOME:-$HOME/.aidd}"
+AIDD_HOOKS="${AIDD_HOOKS:-$AIDD_HOME/hooks}"
 
 HAVE_CODEX=0;  command -v codex  >/dev/null 2>&1 && HAVE_CODEX=1
 HAVE_CLAUDE=0; command -v claude >/dev/null 2>&1 && HAVE_CLAUDE=1
@@ -52,6 +54,17 @@ register_marketplace() { # tool
       claude plugin marketplace remove "$MKT" --scope user >/dev/null 2>&1 || true
       claude plugin marketplace add "$FW" --scope user >/dev/null 2>&1 ;;
   esac
+}
+
+install_aidd_dev_worktree_setup() {
+  local source="$FW/plugins/aidd-dev/hooks/pre-init-worktree.sh"
+  local destination="$AIDD_HOOKS/pre-init-worktree.sh"
+
+  [ -f "$source" ] || { echo "aidd-dev worktree setup: MISSING" >&2; return 1; }
+  mkdir -p "$AIDD_HOOKS"
+  cp -f "$source" "$destination"
+  chmod 755 "$destination"
+  printf 'aidd-dev worktree setup: %s\n' "$destination"
 }
 
 sync_one() {
@@ -125,6 +138,9 @@ if [ "$HAVE_CLAUDE" = 1 ]; then
   register_marketplace claude
 fi
 
-for t in "${targets[@]}"; do sync_one "$t"; done
+for t in "${targets[@]}"; do
+  sync_one "$t"
+  [ "$t" = "aidd-dev" ] && install_aidd_dev_worktree_setup
+done
 
 echo "Done. Restart the Claude/Codex session to load the refreshed files."

--- a/scripts/dev-sync.sh
+++ b/scripts/dev-sync.sh
@@ -117,15 +117,19 @@ sync_one() {
   echo
 }
 
-if [ "$HAVE_CODEX" = 0 ] && [ "$HAVE_CLAUDE" = 0 ]; then
-  echo "Neither Claude nor Codex CLI found - nothing to install."; exit 0
-fi
-
 targets=()
 if [ $# -eq 0 ] || [ "${1:-}" = "all" ]; then
   for d in "$FW"/plugins/*/; do targets+=("$(basename "$d")"); done
 else
   targets=("$@")
+fi
+
+for t in "${targets[@]}"; do
+  [ "$t" = "aidd-dev" ] && install_aidd_dev_worktree_setup
+done
+
+if [ "$HAVE_CODEX" = 0 ] && [ "$HAVE_CLAUDE" = 0 ]; then
+  echo "Neither Claude nor Codex CLI found - user hook installed; plugin caches unchanged."; exit 0
 fi
 
 # Codex needs a native build (md -> toml); register against it. Claude installs from the raw
@@ -140,7 +144,6 @@ fi
 
 for t in "${targets[@]}"; do
   sync_one "$t"
-  [ "$t" = "aidd-dev" ] && install_aidd_dev_worktree_setup
 done
 
 echo "Done. Restart the Claude/Codex session to load the refreshed files."


### PR DESCRIPTION
## Summary
- Package the Codex pre-worktree setup script in `aidd-dev`.
- Publish it to `$AIDD_HOME/hooks/pre-init-worktree.sh` during `scripts/dev-sync.sh aidd-dev`.
- Document the stable path and the Codex post-install lifecycle limitation.

## Validation
- `sh -n plugins/aidd-dev/hooks/pre-init-worktree.sh`
- `bash -n scripts/dev-sync.sh`
- `npm exec --yes @ai-driven-dev/cli@5.1.2 -- framework build --target codex`
- Disposable real-Git worktree setup test
- Isolated `dev-sync` user-hook installation test