### PR TITLE
fix(cli): repoint self-references from aidd-cli to framework

### DIFF
--- a/cli/aidd_docs/README.md
+++ b/cli/aidd_docs/README.md
@@ -133,7 +133,7 @@ Start at **Initialization**, then follow the path step by step. Each box shows t
 
 ### Step by Step
 
-1. Install the AI-Driven Development framework using the [CLI](https://github.com/ai-driven-dev/aidd-cli) or by copying the dist files to your project root.
+1. Install the AI-Driven Development framework using the [CLI](https://github.com/ai-driven-dev/framework/tree/main/cli) or by copying the dist files to your project root.
 
 2. Analyze your project and generate memory files.
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -2,6 +2,15 @@
   "name": "@ai-driven-dev/cli",
   "version": "5.1.3",
   "description": "AI-Driven Development CLI — install AI tool configs and plugins from the AIDD marketplace",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ai-driven-dev/framework.git",
+    "directory": "cli"
+  },
+  "homepage": "https://github.com/ai-driven-dev/framework/tree/main/cli",
+  "bugs": {
+    "url": "https://github.com/ai-driven-dev/framework/issues"
+  },
   "type": "module",
   "main": "dist/cli.js",
   "bin": {


### PR DESCRIPTION
## 🎯 What & why

Phase 4 follow-up from #462: cli/'s package.json never had repository/homepage/bugs fields, and one link in the standard aidd_docs scaffold still pointed at the old standalone repo.

## 🛠️ How it works

Added repository/homepage/bugs to cli/package.json pointing at ai-driven-dev/framework, directory: "cli". Fixed the one stale link in cli/aidd_docs/README.md.

## 🧪 How to verify

- `python3 -m json.tool cli/package.json` — valid
- `node scripts/check-markdown-links.js` — 0 broken

## 🔗 Linked issue

Refs #448

## ✅ I certify

- [ ] **I DO CERTIFY I READ EACH LINE OF THE PULL REQUEST BECAUSE I AM A SOFTWARE ENGINEER, NOT A AI PUPPY.**