### PR TITLE
fix(cli): add license and keywords for the npm package page

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -2,6 +2,18 @@
   "name": "@ai-driven-dev/cli",
   "version": "5.1.3",
   "description": "AI-Driven Development CLI — install AI tool configs and plugins from the AIDD marketplace",
+  "license": "MIT",
+  "keywords": [
+    "cli",
+    "ai-driven-development",
+    "claude-code",
+    "cursor",
+    "github-copilot",
+    "codex",
+    "opencode",
+    "developer-tools",
+    "ai-coding-assistant"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/ai-driven-dev/framework.git",


### PR DESCRIPTION
## 🎯 What & why

The upcoming real release from framework will publish cli/'s README correctly for the first time (previous bug fixed in #462) — while checking what actually shows on the npm package page, found license and keywords were never set.

## 🛠️ How it works

`license: "MIT"` — matches framework's own root LICENSE, same repo now, no ambiguity. `keywords` — reasonable set for npm search discoverability, matching the tools this CLI actually installs configs for.

## 🧪 How to verify

`python3 -m json.tool cli/package.json` — valid.

## 🔗 Linked issue

Refs #448

## ✅ I certify

- [ ] **I DO CERTIFY I READ EACH LINE OF THE PULL REQUEST BECAUSE I AM A SOFTWARE ENGINEER, NOT A AI PUPPY.**