### PR TITLE
fix(cli): restore correct version after release-please regression

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -7,5 +7,5 @@
   "plugins/aidd-orchestrator": "2.1.1",
   "plugins/aidd-refine": "2.2.1",
   "plugins/aidd-ui": "0.2.1-alpha.0",
-  "cli": "4.0.0"
+  "cli": "5.1.3"
 }

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,20 +1,5 @@
 # Changelog
 
-## [4.0.0](https://github.com/ai-driven-dev/framework/compare/cli-v5.1.3...cli-v4.0.0) (2026-07-22)
-
-
-### Bug Fixes
-
-* **cli:** add license and keywords for the npm package page ([691c1c3](https://github.com/ai-driven-dev/framework/commit/691c1c3d30f572e9f13a83f9997d9780b2205914))
-* **cli:** migrate aidd-cli into framework as cli/, full history preserved ([daeef56](https://github.com/ai-driven-dev/framework/commit/daeef56aa3002142a1f2fbed048769e959ab60fe))
-* **cli:** repoint self-references from aidd-cli to framework ([601c30c](https://github.com/ai-driven-dev/framework/commit/601c30c84d2adb04e3c6327a1a7778a894db3b33))
-
-
-### Miscellaneous
-
-* **framework:** release as 4.0.0 ([5b0fc9d](https://github.com/ai-driven-dev/framework/commit/5b0fc9d9116e37abe7ef5dbb5d06438f607475e8))
-* **framework:** trigger ci recheck after history rewrite ([391760e](https://github.com/ai-driven-dev/framework/commit/391760e19eb69fe80e098c3aefc3c527cda2169a))
-
 ## [5.1.3](https://github.com/ai-driven-dev/aidd-cli/compare/v5.1.2...v5.1.3) (2026-07-17)
 
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ai-driven-dev/cli",
-  "version": "4.0.0",
+  "version": "5.1.3",
   "description": "AI-Driven Development CLI — install AI tool configs and plugins from the AIDD marketplace",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
## Summary
- release-please's PR #485 computed `cli`'s next version as `4.0.0` instead of bumping forward from `5.1.3`
- Root cause: `cli` had no prior `cli-v*` tag to anchor its version walk, so it fell through to an old, already-consumed root `Release-As: 4.0.0` directive (commit `5b0fc9d`, framework's own major-bump forcing from May 2026 — unrelated to `cli`) and applied it to the new component
- Both npm and GitHub Packages correctly rejected the resulting publish (`4.0.0` already existed on both registries from the pre-migration standalone repo; real current version is `5.1.3`, untouched on both)
- The bad `cli-v4.0.0` tag and GitHub release have already been deleted

## Fix
- Revert `cli/package.json` version and the manifest's `cli` entry back to `5.1.3`
- Drop the bogus `4.0.0` CHANGELOG entry
- A `cli-v5.1.3` tag/release will be created on top of this commit once merged, anchoring future release-please runs so the walk never reaches that old directive again

## Test plan
- [x] `cli-biome` / `cli-typecheck` / `markdown-links` pre-commit hooks pass
- [ ] CI green on this PR (Validate, cli CI)
- [ ] After merge: create `cli-v5.1.3` tag + release pointing at the merge commit
- [ ] Next real `cli` change triggers a correct release-please PR (5.1.4) and `Publish cli` succeeds end-to-end