### PR TITLE
fix(cli): restore correct version again after second regression, re-anchor for release-please

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -7,5 +7,5 @@
   "plugins/aidd-orchestrator": "2.1.1",
   "plugins/aidd-refine": "2.2.1",
   "plugins/aidd-ui": "0.2.1-alpha.0",
-  "cli": "4.0.0"
+  "cli": "5.1.3"
 }

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,22 +1,5 @@
 # Changelog
 
-## [4.0.0](https://github.com/ai-driven-dev/framework/compare/cli-v5.1.3...cli-v4.0.0) (2026-07-22)
-
-
-### Bug Fixes
-
-* **cli:** add license and keywords for the npm package page ([691c1c3](https://github.com/ai-driven-dev/framework/commit/691c1c3d30f572e9f13a83f9997d9780b2205914))
-* **cli:** migrate aidd-cli into framework as cli/, full history preserved ([daeef56](https://github.com/ai-driven-dev/framework/commit/daeef56aa3002142a1f2fbed048769e959ab60fe))
-* **cli:** repoint self-references from aidd-cli to framework ([601c30c](https://github.com/ai-driven-dev/framework/commit/601c30c84d2adb04e3c6327a1a7778a894db3b33))
-* **cli:** restore correct version after release-please regression ([#488](https://github.com/ai-driven-dev/framework/issues/488)) ([047bcb2](https://github.com/ai-driven-dev/framework/commit/047bcb29e5729d13dd7d27b0921ecc3cbb7eb9d3))
-
-
-### Miscellaneous
-
-* **framework:** release as 4.0.0 ([5b0fc9d](https://github.com/ai-driven-dev/framework/commit/5b0fc9d9116e37abe7ef5dbb5d06438f607475e8))
-* **framework:** trigger ci recheck after history rewrite ([391760e](https://github.com/ai-driven-dev/framework/commit/391760e19eb69fe80e098c3aefc3c527cda2169a))
-* release main ([#485](https://github.com/ai-driven-dev/framework/issues/485)) ([be7195b](https://github.com/ai-driven-dev/framework/commit/be7195b0978d729a1de39826d771511d15f03331))
-
 ## [5.1.3](https://github.com/ai-driven-dev/aidd-cli/compare/v5.1.2...v5.1.3) (2026-07-17)
 
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ai-driven-dev/cli",
-  "version": "4.0.0",
+  "version": "5.1.3",
   "description": "AI-Driven Development CLI — install AI tool configs and plugins from the AIDD marketplace",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
## Summary
- A second, unrelated release-please cycle (PR #489, auto-merged moments after #488) independently recomputed `cli`'s version and reintroduced `4.0.0` the same way #485 did, even though that run's own log correctly read `5.1.3` from the manifest as the baseline — the manifest baseline alone does not bound the version-bump walk, only a matching `cli-v*` release does, and none existed yet at that point
- Both npm and GitHub Packages rejected the resulting publish again (pre-existing `4.0.0`), real version still `5.1.3` on both registries, untouched
- Bad `cli-v4.0.0` tag/release deleted again
- A `cli-v5.1.3` anchor release now exists (target: `bdd12c66`, the commit right before the cli migration), created before this PR merges

## Fix
- Revert `cli/package.json` + manifest `cli` entry to `5.1.3` again, drop the bogus CHANGELOG entry again
- This commit also nudges release-please to re-evaluate `cli` against the new anchor

## Test plan
- [x] pre-commit hooks pass
- [ ] CI green
- [ ] After merge: release-please proposes exactly `5.1.4` for `cli` (single patch bump, real fix commits only) — verify before merging that release PR
- [ ] No mention of the old version-forcing commit in the release-please log this time