### PR TITLE
fix(release-please): exclude manifest file from root path tracking

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -21,7 +21,8 @@
           "path": ".claude-plugin/marketplace.json",
           "jsonpath": "$.version"
         }
-      ]
+      ],
+      "exclude-paths": [".release-please-manifest.json"]
     },
     "plugins/aidd-context": {
       "package-name": "aidd-context",


### PR DESCRIPTION
## Summary
- Any commit touching `.release-please-manifest.json` (root-level file) counts toward the `.` package's own version bump, since root has no path restriction
- Today's cli version-regression fixes (#488, #493) needed to hand-edit that file directly, cutting two extra framework releases (`v5.5.3`, `v5.5.4`) with no real content change for root

## Fix
- Add `exclude-paths: [".release-please-manifest.json"]` to the `.` package only, using release-please's documented `exclude-paths` option (`ReleaserConfigOptions`, verified against the real schema)
- Scoped to root only; `cli`'s and the plugins' own path-based tracking are untouched

## Test plan
- [x] JSON schema validates
- [ ] CI green
- [ ] This PR itself still legitimately bumps root once more (it changes `release-please-config.json`, not excluded) — expected, last time for this cause
- [ ] Next manifest-only correction, if any, no longer bumps root