### PR TITLE
fix(cli): document intentional force on internal build-cache rebuild

### DIFF
--- a/cli/aidd_docs/tasks/2026_07/2026_07_23_bug-e2-01-force-cache-rebuild/phase-1.md
+++ b/cli/aidd_docs/tasks/2026_07/2026_07_23_bug-e2-01-force-cache-rebuild/phase-1.md
@@ -1,0 +1,55 @@
+---
+status: done
+---
+
+# Instruction: Document and pin the intentional cache-rebuild force
+
+## Architecture projection
+
+> Tree of the final files. ✅ create · ✏️ modify · ❌ delete
+
+```txt
+.
+└── cli/
+    ├── src/infrastructure/
+    │   └── deps.ts                                                                      ✏️ modify
+    └── tests/application/use-cases/shared/
+        └── ensure-built-marketplace-use-case.integration.test.ts                        ✏️ modify
+```
+
+## User Journey
+
+```mermaid
+flowchart TD
+  A[install/update triggers EnsureBuiltMarketplaceUseCase] --> B{cache stale?}
+  B -- no --> Z[reuse cache, no build]
+  B -- yes --> C[rebuild into .aidd/cache/built/...]
+  C --> D{destination file already exists in cache?}
+  D -- yes, differs --> E[force:true → overwrite silently, by design: cache is disposable]
+  D -- no --> F[write normally]
+```
+
+## Tasks to do
+
+### `1)` Document the intentional force at its source
+
+> Turn the unexplained `force: true` into a written decision, per BUG-E2-01's DoD.
+
+1. In `src/infrastructure/deps.ts`, above the `force: true` literal inside the `frameworkBuildFor` closure (~line 451-455), add a one-line comment stating: this `outDir` is always the internal `.aidd/cache/built/...` build cache (see `builtMarketplaceDir`), never a user-owned directory, so forcing collision-overwrite here is a cache invalidation, not a destructive overwrite of user data — unlike the direct `framework build --flat --force` CLI path, which threads the real user flag.
+2. Do not touch `framework.ts`, `flat-build-strategy.ts`, or any other call site — both already behave correctly; only this site was undocumented.
+
+### `2)` Pin the behavior with a regression test
+
+> Prove the collision-bypass is real and stays real, using the actual `FlatBuildStrategy` collaborator instead of the file's existing fake `buildFor` stub.
+
+1. In `tests/application/use-cases/shared/ensure-built-marketplace-use-case.integration.test.ts`, add a new test (own `describe` block, e.g. `"force behavior at the cache-rebuild path"`) that wires `EnsureBuiltMarketplaceUseCase` with a real `FrameworkBuildUseCase` + real `FlatBuildStrategy` (`force: true`, matching how `deps.ts` constructs it for `*:flat` targets), not the file's existing fake `buildFor`.
+2. Pre-seed the in-memory filesystem with a file already present at the exact destination path the flat build would write (different content than what the build produces).
+3. Assert `execute()` resolves without throwing `FlatTargetExistsError`, and that the destination file now holds the freshly-built content (proves the overwrite actually happened, not just "didn't throw").
+4. Run the full existing suite in this file plus `tests/application/use-cases/framework/flat-build-strategy.integration.test.ts` and `tests/e2e/framework-build.e2e.test.ts` — all must stay green, confirming the direct `framework build --force` CLI path (already correct) is untouched.
+
+## Test acceptance criteria
+
+| Task | Acceptance criteria                                                                                                                          |
+| ---- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1    | Reading `deps.ts` at the `force: true` site, a maintainer understands why it's always `true` without needing to trace `FlatBuildStrategy` or `paths.ts` themselves. |
+| 2    | The new test fails if `force: true` is changed to `force: false` at that site, and fails if the comment's cache-only claim becomes false (e.g. `outDir` starts pointing outside `.aidd/cache/built`). All other tests in the three named files still pass. |

--- a/cli/aidd_docs/tasks/2026_07/2026_07_23_bug-e2-01-force-cache-rebuild/plan.md
+++ b/cli/aidd_docs/tasks/2026_07/2026_07_23_bug-e2-01-force-cache-rebuild/plan.md
@@ -1,0 +1,25 @@
+---
+objective: "The implicit build-cache-rebuild force:true is documented in code as an intentional decision and pinned by a regression test, per BUG-E2-01's DoD."
+status: implemented
+---
+
+# Plan: BUG-E2-01 — document the implicit cache-rebuild force
+
+## Overview
+
+| Field      | Value                                                                                                        |
+| ---------- | ------------------------------------------------------------------------------------------------------------- |
+| **Goal**   | Make `deps.ts`'s hardcoded `force: true` for the internal build-cache rebuild an explicit, tested decision instead of an unexplained magic value. |
+| **Source** | `aidd_docs/tasks/2026_07/2026_07_22_aidd-tool-contract-cartography/epic-E2-install-build-integrity.md` (BUG-E2-01) |
+
+## Phases
+
+| #   | Phase                              | File                          |
+| --- | ----------------------------------- | ------------------------------ |
+| 1   | Document + pin the intentional force | [`phase-1.md`](./phase-1.md) |
+
+## Decisions
+
+| Decision | Why |
+| -------- | --- |
+| DoD option (b) — document the silent-force as intentional, do not propagate a real `--force` flag from `install`/`update` into it | Traced `outDir` for this closure (`ensure-built-marketplace-use-case.ts` → `builtMarketplaceDir()` → `paths.ts`): it is always `.aidd/cache/built/<marketplace>/<target>`, an aidd-owned disposable build cache, never the user's live tool config. No data-loss risk exists at this path, so there is nothing correct to propagate — `ai install --force`/`ide install --force` mean "overwrite the live tool install," a different concept, and would be a semantically wrong fit here. The direct `aidd framework build --flat --force` CLI command already threads the real user force correctly (`framework.ts:57,64`) and is unaffected. |

--- a/cli/src/infrastructure/deps.ts
+++ b/cli/src/infrastructure/deps.ts
@@ -448,6 +448,11 @@ export async function createDeps(
   );
   const assetProvider = new BundledAssetProviderAdapter();
   const jsonSchemaValidator = new AjvSchemaValidatorAdapter();
+  // force:true is safe here: outDir is always builtMarketplaceDir(), an aidd-owned
+  // disposable cache under .aidd/cache/built/, never a user-owned directory. A
+  // collision only means "the cache from a previous build already exists" — the
+  // whole point of a rebuild. The real user --force (framework.ts) is unrelated
+  // and already threaded correctly for the direct `framework build --flat` path.
   const frameworkBuildFor: FrameworkBuildFor = (target, mode, outDir) =>
     createFrameworkBuildUseCase(
       { fs, assetProvider, logger },

--- a/cli/tests/application/use-cases/shared/ensure-built-marketplace-use-case.integration.test.ts
+++ b/cli/tests/application/use-cases/shared/ensure-built-marketplace-use-case.integration.test.ts
@@ -1,7 +1,9 @@
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { beforeEach, describe, expect, it } from "vitest";
-import type { FrameworkBuildUseCase } from "../../../../src/application/use-cases/framework/framework-build-use-case.js";
+import { FrameworkBuildUseCase } from "../../../../src/application/use-cases/framework/framework-build-use-case.js";
+import { FlatBuildStrategy } from "../../../../src/application/use-cases/framework/strategies/flat-build-strategy.js";
+import { buildCopilotFlatContract } from "../../../../src/application/use-cases/framework/strategies/tool-contracts.js";
 import {
   EnsureBuiltMarketplaceUseCase,
   type FrameworkBuildFor,
@@ -12,10 +14,46 @@ import type {
 } from "../../../../src/application/use-cases/shared/resolve-marketplace-use-case.js";
 import { Marketplace } from "../../../../src/domain/models/marketplace.js";
 import { builtMarketplaceDir } from "../../../../src/domain/models/paths.js";
+import type { AssetProvider } from "../../../../src/domain/ports/asset-provider.js";
+import type { JsonSchemaValidator } from "../../../../src/domain/ports/json-schema-validator.js";
 import type { VersionReader } from "../../../../src/domain/ports/version-reader.js";
+import { CapturingLogger } from "../../../helpers/ports/capturing-logger.js";
 import { InMemoryFileAdapter } from "../../../helpers/ports/in-memory-file-adapter.js";
+import { seedFromDirectory } from "../../../helpers/ports/seed-from-directory.js";
 
 const PROJECT = "/proj";
+const FIXTURE_DIR = resolve(process.cwd(), "tests/fixtures/framework");
+const PLUGIN = "aidd-test";
+
+const MINIMAL_MANIFEST_SCHEMA = {
+  type: "object",
+  required: ["name"],
+  properties: { name: { type: "string" } },
+};
+
+function noopValidator(): JsonSchemaValidator {
+  return { validate: () => undefined };
+}
+
+function stubAssetProvider(): AssetProvider {
+  return {
+    loadConfigAsset: () => {
+      throw new Error("not used");
+    },
+    loadDefaultMarketplace: () => {
+      throw new Error("not used");
+    },
+    loadSchema: (name) => (name === "plugin-manifest" ? MINIMAL_MANIFEST_SCHEMA : {}),
+  };
+}
+
+function makeIsDirectory(memFs: InMemoryFileAdapter): (path: string) => Promise<boolean> {
+  return async (path: string): Promise<boolean> => {
+    if (memFs.has(path)) return false;
+    const prefix = path.endsWith("/") ? path : `${path}/`;
+    return memFs.listAll().some((k) => k.startsWith(prefix));
+  };
+}
 
 function makeMarketplace(): Marketplace {
   return Marketplace.create({
@@ -175,5 +213,61 @@ describe("EnsureBuiltMarketplaceUseCase", () => {
     await uc.execute(opts);
     await uc.execute(opts);
     expect(builds).toBe(1);
+  });
+});
+
+// BUG-E2-01: deps.ts hardcodes force:true for this rebuild path because outDir is always
+// builtMarketplaceDir() — an aidd-owned disposable cache, never a user-owned directory. A
+// collision here only means "the cache from a previous build already exists" and should be
+// overwritten, not treated as a destructive overwrite of user data. This pins that decision
+// with a real FlatBuildStrategy (not the fake buildFor stub used above), so it fails if
+// force is ever flipped to false here, or if outDir stops being cache-only.
+describe("force behavior at the cache-rebuild path (BUG-E2-01)", () => {
+  it("overwrites a colliding file already present in the build cache instead of throwing FlatTargetExistsError", async () => {
+    const memFs = new InMemoryFileAdapter();
+    await seedFromDirectory(memFs, FIXTURE_DIR, { useAbsolutePaths: true });
+
+    const builtDir = builtMarketplaceDir(PROJECT, "aidd-framework", "copilot");
+    const agentPath = `${builtDir}/.github/agents/${PLUGIN}-code-reviewer.agent.md`;
+    memFs.setFile(agentPath, "stale cache content from a previous build");
+
+    const realBuildFor: FrameworkBuildFor = (_target, _mode, outDir) => {
+      const validator = noopValidator();
+      const assetProvider = stubAssetProvider();
+      const strategy = new FlatBuildStrategy(
+        memFs,
+        validator,
+        assetProvider,
+        buildCopilotFlatContract(),
+        true, // force:true — mirrors deps.ts wiring for every *:flat target
+        outDir,
+        makeIsDirectory(memFs),
+        new CapturingLogger()
+      );
+      return new FrameworkBuildUseCase(
+        memFs,
+        validator,
+        assetProvider,
+        new CapturingLogger(),
+        strategy
+      );
+    };
+
+    const uc = new EnsureBuiltMarketplaceUseCase(
+      memFs,
+      fakeResolve(FIXTURE_DIR, "1.0.0"),
+      realBuildFor,
+      fakeVersion("5.0.0")
+    );
+
+    const result = await uc.execute({
+      projectRoot: PROJECT,
+      marketplace: makeMarketplace(),
+      target: "copilot",
+      mode: "flat",
+    });
+
+    expect(result.rebuilt).toBe(true);
+    expect(memFs.getFile(agentPath)).not.toBe("stale cache content from a previous build");
   });
 });


### PR DESCRIPTION
## 🎯 What & why

`EnsureBuiltMarketplaceUseCase`'s implicit rebuild path hardcoded `force: true` with no comment explaining why — flagged by a cartography pass as a possible silent-overwrite risk.

## 🛠️ How it works

Traced `outDir` for this specific path: it's always `builtMarketplaceDir()` → `.aidd/cache/built/<marketplace>/<target>`, an aidd-owned disposable cache — never a user directory. A collision there just means "the cache from a previous build already exists," which is exactly what a rebuild should overwrite. The direct `aidd framework build --flat --force` CLI path (a different call site) already threads the real user `--force` correctly and is untouched.

Added a comment at the `force: true` site making that explicit, and a regression test using a real `FlatBuildStrategy` (not the file's existing fake `buildFor` stub) that pins the collision-bypass — it fails if `force` is ever flipped to `false` here, or if `outDir` stops being cache-only.

## 🧪 How to verify

`pnpm --filter cli test tests/application/use-cases/shared/ensure-built-marketplace-use-case.integration.test.ts`

## ⚠️ Heads-up

Originally implemented in the (now-archived) standalone `aidd-cli` repo before the framework migration (#462); ported here as a fresh commit since the source repo no longer accepts pushes.