### PR TITLE
refactor(cli): inject shared StatusUseCase/RestoreUseCase/UpdateOneToolUseCase

### DIFF
--- a/cli/aidd_docs/tasks/2026_07/2026_07_24_e1-shared-instance-dedup/phase-1.md
+++ b/cli/aidd_docs/tasks/2026_07/2026_07_24_e1-shared-instance-dedup/phase-1.md
@@ -1,0 +1,75 @@
+---
+status: done
+---
+
+# Instruction: Inject shared instances into the 3 global "All" use-cases
+
+## Architecture projection
+
+> Tree of the final files. ✅ create · ✏️ modify · ❌ delete
+
+```txt
+.
+└── cli/
+    ├── src/
+    │   ├── infrastructure/deps.ts                                                ✏️ modify
+    │   └── application/use-cases/global/
+    │       ├── status-all-use-case.ts                                            ✏️ modify
+    │       ├── restore-all-use-case.ts                                           ✏️ modify
+    │       └── update-all-use-case.ts                                            ✏️ modify
+    └── tests/application/use-cases/
+        └── restore-all-use-case.unit.test.ts                                     ✏️ modify (constructor signature)
+```
+
+## User Journey
+
+```mermaid
+flowchart TD
+  A[deps.ts builds statusUseCase, restoreUseCase, updateOneToolUseCase once] --> B[ai.ts / ide.ts consume them directly]
+  A --> C[StatusAllUseCase / RestoreAllUseCase / UpdateAllUseCase now receive the SAME instances]
+  C -->|before| D["each rebuilt its own duplicate internally — 4 sites"]
+  C -->|after| E["zero duplicate construction — one instance per collaborator, everywhere"]
+```
+
+## Tasks to do
+
+### `1)` `StatusAllUseCase` receives `StatusUseCase` by injection
+
+> Simplest of the 3 — every current constructor param becomes dead once injected.
+
+1. In `status-all-use-case.ts`, change the constructor to `constructor(private readonly statusUseCase: StatusUseCase) {}`, dropping `fs`, `manifestRepo`, `hasher` (verified: used nowhere else in the class).
+2. In `execute()`/`collectCategoryReports()`, replace the local `const useCase = new StatusUseCase(...)` with `this.statusUseCase`.
+
+### `2)` `RestoreAllUseCase` receives `StatusUseCase` and `RestoreUseCase` by injection
+
+> Two duplicate sites in this one file (`promptForFiles`, `runConfigRestore`).
+
+1. In `restore-all-use-case.ts`, change the constructor to `(manifestRepo, prompter, statusUseCase, restoreUseCase)`, dropping `fs`, `hasher`, `logger`, `platform`, `pluginFetcher`, `pluginDistributionReader`, `assetProvider`, `builtDeps` (verified: each was used only to build the two now-injected instances; `manifestRepo` and `prompter` are still used directly elsewhere in the class and stay).
+2. In `promptForFiles()`, replace `new StatusUseCase(this.fs, this.manifestRepo, this.hasher)` with `this.statusUseCase`.
+3. In `runConfigRestore()`, replace the local `new RestoreUseCase(...)` (10 args) with `this.restoreUseCase`.
+
+### `3)` `UpdateAllUseCase` receives `UpdateOneToolUseCase` by injection
+
+> The duplicate here is built once in the constructor (not per-call), but it's still a second instance of the same collaborator `updateAiToolsUseCase`/`updateIdeToolsUseCase` already share.
+
+1. In `update-all-use-case.ts`, change the constructor to `(manifestRepo, versionReader, pluginUpdateUseCase, marketplaceRefreshUseCase, updateOneToolUseCase)`, dropping `installRuntimeConfigUseCase`, `installIdeConfigUseCase`, `conflictResolver`, `decisionUseCase`, `fs` (verified: each was an unstored constructor-body-only param, used solely to build the now-injected `updateOneToolUseCase`).
+2. Remove the constructor-body `this.updateOneToolUseCase = new UpdateOneToolUseCase(...)`; store the injected instance directly as `private readonly updateOneToolUseCase: UpdateOneToolUseCase`.
+
+### `4)` Rewire `deps.ts`
+
+1. Change `statusAllUseCase = new StatusAllUseCase(statusUseCase)`.
+2. Change `restoreAllUseCase = new RestoreAllUseCase(manifestRepo, prompter, statusUseCase, restoreUseCase)`.
+3. Change `updateAllUseCase = new UpdateAllUseCase(manifestRepo, currentVersionProvider, pluginUpdateUseCase, marketplaceRefreshUseCase, updateOneToolUseCase)`.
+4. No reordering needed — `statusUseCase`/`restoreUseCase`/`updateOneToolUseCase` are already constructed earlier in the file than their respective "All" consumer.
+
+### `5)` Update the one test that constructs `RestoreAllUseCase` directly
+
+1. In `tests/application/use-cases/restore-all-use-case.unit.test.ts`, update `makeRestoreAllUseCase` to build a `StatusUseCase`/`RestoreUseCase` first and pass them per the new constructor signature, instead of the old 10-arg list.
+
+## Test acceptance criteria
+
+| Task | Acceptance criteria |
+| ---- | -------------------------------------------------------------------------------------------------------------------------- |
+| 1-4  | `aidd status`, `aidd restore`, `aidd update` produce output identical to before this change (verified by the existing test suite, unmodified assertions, plus the updated `restore-all-use-case.unit.test.ts`). |
+| 1-4  | `grep -rn "new StatusUseCase\|new RestoreUseCase\|new UpdateOneToolUseCase" src/` finds only the 3 original construction sites in `deps.ts`, none inside `status-all-use-case.ts`, `restore-all-use-case.ts`, or `update-all-use-case.ts`. |
+| 5    | `tsc --noEmit` clean; full existing test suite (2045+ tests) passes unmodified. |

--- a/cli/aidd_docs/tasks/2026_07/2026_07_24_e1-shared-instance-dedup/plan.md
+++ b/cli/aidd_docs/tasks/2026_07/2026_07_24_e1-shared-instance-dedup/plan.md
@@ -1,0 +1,49 @@
+---
+objective: "StatusAllUseCase, RestoreAllUseCase, and UpdateAllUseCase receive the already-wired StatusUseCase/RestoreUseCase/UpdateOneToolUseCase from deps.ts by injection, instead of each rebuilding its own duplicate instance."
+status: implemented
+---
+
+# Plan: SPIKE-E1-01 + BUG-E1-02 — one instance per shared collaborator
+
+## Overview
+
+| Field      | Value                                                                                                      |
+| ---------- | -------------------------------------------------------------------------------------------------------------- |
+| **Goal**   | Remove the 4 sites where a global "All" use-case reconstructs its own copy of a collaborator deps.ts already built and shares with ai.ts/ide.ts commands. |
+| **Source** | `aidd_docs/tasks/2026_07/2026_07_22_aidd-tool-contract-cartography/epic-E1-dependency-graph-hygiene.md` (SPIKE-E1-01, BUG-E1-02) |
+
+## Phases
+
+| #   | Phase                                              | File                          |
+| --- | ----------------------------------------------------- | ------------------------------ |
+| 1   | Inject shared instances, drop the 4 duplicate sites   | [`phase-1.md`](./phase-1.md) |
+
+## Resources
+
+None external — pure internal codebase tracing.
+
+## Decisions
+
+| Decision | Why |
+| -------- | --- |
+| Spike folded into this plan instead of a separate phase | Findings are small and mechanical (4 confirmed sites, no excluded site, all 3 target classes independently confirmed stateless by reading their full source — no memo maps, no accumulator fields, only `private readonly` constructor deps). Same precedent as BUG-E2-01. Recorded below in full per the ticket's DoD, which requires this to be attached to the fix. |
+| Corrected citation vs the ticket | The ticket's Gherkin cites `restore-all-use-case.ts:77/101-112` as one range. Re-reading the current file found **two separate** duplicate-construction sites inside it (`promptForFiles` and `runConfigRestore`), not one — both fixed here. |
+| Drop now-dead constructor params, not just add the shared instance alongside them | Each duplicate-construction site was the *only* consumer of several of its class's raw sub-dependency params (verified per class, see spike findings below). Keeping them as unused params after injection would violate the project's dead-code rule. Removing them is not scope creep — it's the direct, unavoidable consequence of injecting the real instance instead of its ingredients. |
+
+## Spike findings (SPIKE-E1-01)
+
+**Confirmed duplicate-construction sites (file:line, current code, re-verified — not trusted from the ticket):**
+
+1. `src/application/use-cases/global/status-all-use-case.ts:25` — `StatusAllUseCase.execute()` builds `new StatusUseCase(this.fs, this.manifestRepo, this.hasher)` on every call. `deps.ts:592` already builds `statusUseCase` with the identical args and exposes it as `deps.statusUseCase`, consumed directly by `ai.ts:124` and `ide.ts:118`.
+2. `src/application/use-cases/global/restore-all-use-case.ts` (`promptForFiles`) — builds `new StatusUseCase(this.fs, this.manifestRepo, this.hasher)` on every call. Same duplicate as site 1, inside a different class.
+3. `src/application/use-cases/global/restore-all-use-case.ts` (`runConfigRestore`) — builds `new RestoreUseCase(...)` (10 args) on every call. `deps.ts:608` already builds `restoreUseCase` with the identical args and exposes it as `deps.restoreUseCase`, consumed directly by `ai.ts:209` and `ide.ts:199`.
+4. `src/application/use-cases/global/update-all-use-case.ts` (constructor body) — builds `this.updateOneToolUseCase = new UpdateOneToolUseCase(...)` (5 args) once per `UpdateAllUseCase` instance. `deps.ts:635` already builds `updateOneToolUseCase` with the identical args and shares it with `updateAiToolsUseCase`/`updateIdeToolsUseCase` (`deps.ts:653-661`).
+
+**No site excluded from scope** — all 4 have a directly matching shared instance already in `deps.ts` with identical construction args; none has a legitimate reason to diverge.
+
+**Statelessness (read in full, not assumed):**
+- `StatusUseCase` (`status-use-case.ts`) — only `private readonly` constructor fields (`fs`, `manifestRepo`, `hasher`). No mutable field. Stateless.
+- `RestoreUseCase` (`restore-use-case.ts`) — only `private readonly` constructor fields. Every `execute()` call builds its own local `RestoreCtx`; nothing persists across calls. Stateless.
+- `UpdateOneToolUseCase` (`update-one-tool-use-case.ts`) — only `private readonly` constructor fields. `BulkConflictState` (the one piece of cross-call-shaped state in this area) is passed as an `execute()` *parameter* by the caller (`UpdateAllUseCase.execute()` creates a fresh one per invocation) — never stored on `this`. Stateless.
+
+All 3 confirmed safe to share as singletons across concurrent/sequential command invocations.

--- a/cli/src/application/use-cases/global/restore-all-use-case.ts
+++ b/cli/src/application/use-cases/global/restore-all-use-case.ts
@@ -1,19 +1,9 @@
 import { DOCS_DIR } from "../../../domain/models/paths.js";
-import type { AssetProvider } from "../../../domain/ports/asset-provider.js";
-import type { FileMerger } from "../../../domain/ports/file-merger.js";
-import type { FileReader } from "../../../domain/ports/file-reader.js";
-import type { FileWriter } from "../../../domain/ports/file-writer.js";
-import type { Hasher } from "../../../domain/ports/hasher.js";
-import type { Logger } from "../../../domain/ports/logger.js";
 import type { ManifestRepository } from "../../../domain/ports/manifest-repository.js";
-import type { Platform } from "../../../domain/ports/platform.js";
-import type { PluginDistributionReader } from "../../../domain/ports/plugin-distribution-reader.js";
-import type { PluginFetcher } from "../../../domain/ports/plugin-fetcher.js";
 import type { Prompter } from "../../../domain/ports/prompter.js";
 import { NoManifestError } from "../../errors.js";
-import { RestoreUseCase } from "../restore/restore-use-case.js";
-import type { BuiltMaterializationDeps } from "../shared/apply-plugin-files-use-case.js";
-import { StatusUseCase } from "../status-use-case.js";
+import type { RestoreUseCase } from "../restore/restore-use-case.js";
+import type { StatusUseCase } from "../status-use-case.js";
 import type { GlobalExecutionError } from "./update-all-use-case.js";
 
 export interface RestoreAllResult {
@@ -25,16 +15,10 @@ export interface RestoreAllResult {
 
 export class RestoreAllUseCase {
   constructor(
-    private readonly fs: FileReader & FileWriter & FileMerger,
     private readonly manifestRepo: ManifestRepository,
-    private readonly hasher: Hasher,
-    private readonly logger: Logger,
-    private readonly platform: Platform,
     private readonly prompter: Prompter,
-    private readonly pluginFetcher: PluginFetcher,
-    private readonly pluginDistributionReader: PluginDistributionReader,
-    private readonly assetProvider?: AssetProvider,
-    private readonly builtDeps?: BuiltMaterializationDeps
+    private readonly statusUseCase: StatusUseCase,
+    private readonly restoreUseCase: RestoreUseCase
   ) {}
 
   async execute(projectRoot: string, interactive: boolean): Promise<RestoreAllResult> {
@@ -71,8 +55,7 @@ export class RestoreAllUseCase {
   }
 
   private async promptForFiles(projectRoot: string): Promise<string[] | undefined> {
-    const statusUseCase = new StatusUseCase(this.fs, this.manifestRepo, this.hasher);
-    const report = await statusUseCase.execute({ projectRoot });
+    const report = await this.statusUseCase.execute({ projectRoot });
     const driftedFiles = report.tools.flatMap((t) =>
       t.drifted
         .filter((d) => d.status === "modified" || d.status === "deleted")
@@ -95,20 +78,8 @@ export class RestoreAllUseCase {
     errors: GlobalExecutionError[]
   ): Promise<{ totalRestored: number; totalKept: number; restoredPluginNames: string[] }> {
     try {
-      const restoreUseCase = new RestoreUseCase(
-        this.fs,
-        this.manifestRepo,
-        this.hasher,
-        this.logger,
-        this.platform,
-        this.prompter,
-        this.pluginFetcher,
-        this.pluginDistributionReader,
-        this.assetProvider,
-        this.builtDeps
-      );
       if (manifest === null) return { totalRestored: 0, totalKept: 0, restoredPluginNames: [] };
-      const result = await restoreUseCase.execute({
+      const result = await this.restoreUseCase.execute({
         version,
         docsDir: DOCS_DIR,
         projectRoot,

--- a/cli/src/application/use-cases/global/status-all-use-case.ts
+++ b/cli/src/application/use-cases/global/status-all-use-case.ts
@@ -1,7 +1,4 @@
-import type { FileReader } from "../../../domain/ports/file-reader.js";
-import type { Hasher } from "../../../domain/ports/hasher.js";
-import type { ManifestRepository } from "../../../domain/ports/manifest-repository.js";
-import { StatusUseCase } from "../status-use-case.js";
+import type { StatusUseCase } from "../status-use-case.js";
 import type { GlobalExecutionError } from "./update-all-use-case.js";
 
 type StatusReport = Awaited<ReturnType<StatusUseCase["execute"]>>;
@@ -14,17 +11,12 @@ export interface StatusAllResult {
 }
 
 export class StatusAllUseCase {
-  constructor(
-    private readonly fs: FileReader,
-    private readonly manifestRepo: ManifestRepository,
-    private readonly hasher: Hasher
-  ) {}
+  constructor(private readonly statusUseCase: StatusUseCase) {}
 
   async execute(projectRoot: string): Promise<StatusAllResult> {
     const errors: GlobalExecutionError[] = [];
-    const useCase = new StatusUseCase(this.fs, this.manifestRepo, this.hasher);
     const [aiTools, ideTools, plugins] = await this.collectCategoryReports(
-      useCase,
+      this.statusUseCase,
       projectRoot,
       errors
     );

--- a/cli/src/application/use-cases/global/update-all-use-case.ts
+++ b/cli/src/application/use-cases/global/update-all-use-case.ts
@@ -1,21 +1,14 @@
 import { Manifest } from "../../../domain/models/manifest.js";
-import type { FileReader } from "../../../domain/ports/file-reader.js";
 import type { ManifestRepository } from "../../../domain/ports/manifest-repository.js";
 import type { VersionReader } from "../../../domain/ports/version-reader.js";
 import type { ToolId } from "../../../domain/tools/registry.js";
-import type { InstallIdeConfigUseCase } from "../install/install-ide-config-use-case.js";
-import type { InstallRuntimeConfigUseCase } from "../install/install-runtime-config-use-case.js";
 import type { MarketplaceRefreshUseCase } from "../marketplace/marketplace-refresh-use-case.js";
 import type { PluginUpdateUseCase } from "../plugin/plugin-update-use-case.js";
-import {
-  BulkConflictState,
-  type ResolveUpdateDecisionUseCase,
-} from "../shared/resolve-update-decision-use-case.js";
-import {
-  type GlobalExecutionError,
+import { BulkConflictState } from "../shared/resolve-update-decision-use-case.js";
+import type {
+  GlobalExecutionError,
   UpdateOneToolUseCase,
 } from "../shared/update-one-tool-use-case.js";
-import type { SyncConflictResolverUseCase } from "../sync/sync-conflict-resolver-use-case.js";
 
 export type { GlobalExecutionError };
 
@@ -33,27 +26,13 @@ export interface UpdateAllResult {
 }
 
 export class UpdateAllUseCase {
-  private readonly updateOneToolUseCase: UpdateOneToolUseCase;
-
   constructor(
     private readonly manifestRepo: ManifestRepository,
     private readonly versionReader: VersionReader,
-    installRuntimeConfigUseCase: InstallRuntimeConfigUseCase,
-    installIdeConfigUseCase: InstallIdeConfigUseCase,
     private readonly pluginUpdateUseCase: PluginUpdateUseCase,
     private readonly marketplaceRefreshUseCase: MarketplaceRefreshUseCase,
-    conflictResolver: SyncConflictResolverUseCase,
-    decisionUseCase: ResolveUpdateDecisionUseCase,
-    fs: FileReader
-  ) {
-    this.updateOneToolUseCase = new UpdateOneToolUseCase(
-      installRuntimeConfigUseCase,
-      installIdeConfigUseCase,
-      conflictResolver,
-      decisionUseCase,
-      fs
-    );
-  }
+    private readonly updateOneToolUseCase: UpdateOneToolUseCase
+  ) {}
 
   async execute(input: UpdateAllInput): Promise<UpdateAllResult> {
     const { projectRoot, userForce, interactive } = input;

--- a/cli/src/infrastructure/deps.ts
+++ b/cli/src/infrastructure/deps.ts
@@ -623,18 +623,12 @@ export async function createDeps(
     builtMaterializationDeps
   );
   const uninstallUseCase = new UninstallUseCase(fs, manifestRepo, logger);
-  const statusAllUseCase = new StatusAllUseCase(fs, manifestRepo, hasher);
+  const statusAllUseCase = new StatusAllUseCase(statusUseCase);
   const restoreAllUseCase = new RestoreAllUseCase(
-    fs,
     manifestRepo,
-    hasher,
-    logger,
-    platform,
     prompter,
-    pluginFetcher,
-    pluginDistributionReader,
-    assetProvider,
-    builtMaterializationDeps
+    statusUseCase,
+    restoreUseCase
   );
   const resolveUpdateDecisionUseCase = new ResolveUpdateDecisionUseCase(prompter);
   const updateOneToolUseCase = new UpdateOneToolUseCase(
@@ -647,13 +641,9 @@ export async function createDeps(
   const updateAllUseCase = new UpdateAllUseCase(
     manifestRepo,
     currentVersionProvider,
-    installRuntimeConfigUseCase,
-    installIdeConfigUseCase,
     pluginUpdateUseCase,
     marketplaceRefreshUseCase,
-    syncConflictResolverUseCase,
-    resolveUpdateDecisionUseCase,
-    fs
+    updateOneToolUseCase
   );
   const updateAiToolsUseCase = new UpdateAiToolsUseCase(
     manifestRepo,

--- a/cli/tests/application/use-cases/restore-all-use-case.unit.test.ts
+++ b/cli/tests/application/use-cases/restore-all-use-case.unit.test.ts
@@ -2,6 +2,8 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { RestoreAllUseCase } from "../../../src/application/use-cases/global/restore-all-use-case.js";
 import { PluginAddUseCase } from "../../../src/application/use-cases/plugin/plugin-add-use-case.js";
+import { RestoreUseCase } from "../../../src/application/use-cases/restore/restore-use-case.js";
+import { StatusUseCase } from "../../../src/application/use-cases/status-use-case.js";
 import { PluginDistributionReaderAdapter } from "../../../src/infrastructure/adapters/plugin-distribution-reader-adapter.js";
 import { buildUnitDeps, initAndInstall, installTool } from "../../helpers/ports/build-unit-deps.js";
 import { fakeEnsureBuiltMarketplace } from "../../helpers/ports/fake-ensure-built-marketplace.js";
@@ -50,7 +52,8 @@ function makeRestoreAllUseCase(
   prompter: OverwritePrompter | ScriptedPrompter = new OverwritePrompter(),
   withBuiltDeps = false
 ): RestoreAllUseCase {
-  return new RestoreAllUseCase(
+  const statusUseCase = new StatusUseCase(deps.fs, deps.manifestRepo, deps.hasher);
+  const restoreUseCase = new RestoreUseCase(
     deps.fs,
     deps.manifestRepo,
     deps.hasher,
@@ -62,6 +65,7 @@ function makeRestoreAllUseCase(
     deps.assetProvider,
     withBuiltDeps ? builtDeps(deps) : undefined
   );
+  return new RestoreAllUseCase(deps.manifestRepo, prompter, statusUseCase, restoreUseCase);
 }
 
 function countingReader(fs: Deps["fs"]): {


### PR DESCRIPTION
## 🎯 What & why

`StatusAllUseCase`, `RestoreAllUseCase`, and `UpdateAllUseCase` each rebuilt their own duplicate of a collaborator `deps.ts` already constructs and shares with `ai.ts`/`ide.ts` (`deps.statusUseCase`, `deps.restoreUseCase`, `deps.updateOneToolUseCase`, consumed directly by those commands). Two of the four duplicate sites rebuilt on every `execute()` call.

## 🛠️ How it works

Confirmed all 3 target classes are stateless before sharing them as singletons — no memo maps, no accumulator fields; `BulkConflictState` is passed as an `execute()` parameter by the caller, never stored on `UpdateOneToolUseCase`. Each class now receives the real instance by constructor injection; every now-dead raw-sub-dependency param was removed rather than left unused (e.g. `UpdateAllUseCase` drops from 9 constructor params to 5).

`grep -rn "new StatusUseCase\|new RestoreUseCase\|new UpdateOneToolUseCase" src/` finds only the 3 original construction sites in `deps.ts`.

Pure DI wiring — zero behavior change. 2049/2049 tests pass unmodified.

## 🧪 How to verify

`pnpm --filter cli test`

## ⚠️ Heads-up

Redo of #507 — that PR merged into the intermediate `fix/e3-02-restore-plugin-scope-dedup` branch, which itself then merged into `next` via a *separate* squash commit (#506) that didn't carry #507's diff forward, so #507's changes never actually reached `next`. This PR is the same commit cherry-picked onto current `next` directly.

Originally planned in the (now-archived) standalone `aidd-cli` repo before the framework migration (#462).