### PR TITLE
fix(cli): resolve buildClaudeStyleMarketplaceEntry and PluginTranslator name collisions

### DIFF
--- a/cli/aidd_docs/tasks/2026_07/2026_07_24_e6-name-collisions/phase-1.md
+++ b/cli/aidd_docs/tasks/2026_07/2026_07_24_e6-name-collisions/phase-1.md
@@ -1,0 +1,58 @@
+---
+status: done
+---
+
+# Instruction: Rename both collisions
+
+## Architecture projection
+
+> Tree of the final files. ✅ create · ✏️ modify · ❌ delete
+
+```txt
+.
+└── cli/src/
+    ├── application/use-cases/framework/strategies/
+    │   ├── marketplace-strategy-helpers.ts                          ✏️ modify (rename function)
+    │   └── tool-contracts.ts                                        ✏️ modify (call site)
+    ├── application/use-cases/plugin/
+    │   ├── plugin-add-use-case.ts                                   ✏️ modify (import)
+    │   └── plugin-update-use-case.ts                                ✏️ modify (import)
+    ├── application/use-cases/plugin/translator/
+    │   └── mode-b-flat-materialization-translator.ts                ✏️ modify (drop alias workaround)
+    ├── application/use-cases/shared/
+    │   └── apply-plugin-files-use-case.ts                           ✏️ modify (import)
+    └── domain/models/
+        ├── plugin-translator.ts                                     ❌ delete (renamed)
+        └── plugin-content-translator.ts                             ✅ create (renamed)
+cli/tests/domain/models/
+├── plugin-distribution-translate.unit.test.ts                       ✏️ modify (import)
+└── plugin-translator-skip.unit.test.ts                              ✏️ modify (import)
+```
+
+## Tasks to do
+
+### `1)` Rename `buildClaudeStyleMarketplaceEntry` → `buildClaudeStyleCatalogEntry`
+
+> The marketplace-catalog-entry side, `marketplace-strategy-helpers.ts:169`. The domain/capabilities one (`settings.json` entry) keeps its name.
+
+1. In `marketplace-strategy-helpers.ts`, rename the function definition (line 169).
+2. In `tool-contracts.ts`, update the 2 references (import + call, lines 65 and 109).
+
+### `2)` Rename the domain `PluginTranslator` class → `PluginContentTranslator`
+
+> The content-format-conversion side. The application-layer strategy interface (`plugin/translator/plugin-translator.ts`) keeps its name — do not touch it.
+
+1. Rename `src/domain/models/plugin-translator.ts` → `src/domain/models/plugin-content-translator.ts`, renaming the `export class PluginTranslator` to `export class PluginContentTranslator` inside it.
+2. Update imports in `plugin-add-use-case.ts`, `plugin-update-use-case.ts`, `apply-plugin-files-use-case.ts` — new path, new name, no more alias needed.
+3. In `mode-b-flat-materialization-translator.ts`, drop the `PluginTranslator as PluginTranslatorHelper` alias workaround — import `PluginContentTranslator` directly under its real name, update the local usages.
+4. Update the 2 test files (`tests/domain/models/plugin-distribution-translate.unit.test.ts`, `tests/domain/models/plugin-translator-skip.unit.test.ts`) — new import path/name. Consider also renaming these test files to match (`plugin-content-translator-*`) if the project's test-naming convention expects it; not required by the ticket's DoD, judgment call at implementation time.
+
+## Test acceptance criteria
+
+| Task | Acceptance criteria |
+| ---- | ------------------------------------------------------------------------------------------------------------------------ |
+| 1    | `grep -rn "buildClaudeStyleMarketplaceEntry" src/` finds only the domain/capabilities definition and its 2 tool-file consumers — never the catalog-building one. |
+| 1    | `aidd framework build` (marketplace mode) produces byte-identical output to before the rename. |
+| 2    | `grep -rn "PluginTranslator\b" src/` (word-boundary) finds only the application-layer interface and its 4 implementer/factory sites — never the domain class. |
+| 2    | `aidd plugin add`/`aidd plugin update` produce identical installed files to before the rename. |
+| all  | `tsc --noEmit` clean, full existing test suite passes with zero assertion changes (pure rename). |

--- a/cli/aidd_docs/tasks/2026_07/2026_07_24_e6-name-collisions/plan.md
+++ b/cli/aidd_docs/tasks/2026_07/2026_07_24_e6-name-collisions/plan.md
@@ -1,0 +1,38 @@
+---
+objective: "buildClaudeStyleMarketplaceEntry and PluginTranslator each name exactly one symbol in src/, so a grep or IDE jump-to-definition is never ambiguous."
+status: implemented
+---
+
+# Plan: SPIKE-E6-01 + BUG-E6-02 — resolve the 2 name collisions
+
+## Overview
+
+| Field      | Value                                                                            |
+| ---------- | ------------------------------------------------------------------------------- |
+| **Goal**   | Rename one side of each of the 2 confirmed name collisions; zero behavior change. |
+| **Source** | `aidd_docs/tasks/2026_07/2026_07_22_aidd-tool-contract-cartography/epic-E6-naming-di-hygiene.md` (SPIKE-E6-01, BUG-E6-02) |
+
+## Phases
+
+| #   | Phase                          | File                          |
+| --- | -------------------------------- | ------------------------------ |
+| 1   | Rename both collisions           | [`phase-1.md`](./phase-1.md) |
+
+## Spike findings (SPIKE-E6-01)
+
+**Collision 1 — `buildClaudeStyleMarketplaceEntry`, confirmed genuinely different functions:**
+- `src/domain/capabilities/marketplace-entry.ts:8` — `(input: MarketplaceSettingsInput) => MarketplaceSettingsEntry | null`. Builds a tool's own `settings.json` marketplace registration entry at install time. Imported by `domain/tools/ai/claude.ts:3` and `domain/tools/ai/copilot.ts:3` as each tool's `toEntry` capability callback.
+- `src/application/use-cases/framework/strategies/marketplace-strategy-helpers.ts:169` — `(name, description, version, srcEntry) => Record<string, unknown>`. Builds one plugin's row in the BUILT `marketplace.json` catalog file, at `framework build` time. Used only within the same file, consumed by `tool-contracts.ts:65,109`.
+- Never imported into the same file — no compile collision today, but identical names for unrelated concepts.
+
+**Collision 2 — `PluginTranslator`, confirmed genuinely different roles:**
+- `src/domain/models/plugin-translator.ts` — a **class**. Converts one plugin distribution's raw file content into a specific tool's installed format (markdown frontmatter, flat namespacing, hooks conversion). Value-imported (constructed via `new`) by `plugin-add-use-case.ts`, `plugin-update-use-case.ts`, `apply-plugin-files-use-case.ts`, plus 2 unit tests.
+- `src/application/use-cases/plugin/translator/plugin-translator.ts` — an **interface**. The strategy contract implemented by `BuiltTreeMaterializationTranslator`/`ModeAMarketplaceTranslator`/`ModeBFlatMaterializationTranslator`, resolved by `plugin-translator-factory.ts`. This is the protected Section-C strategy pattern — not touched by this fix, only disambiguated from the unrelated class.
+- **Direct evidence of real friction**: `mode-b-flat-materialization-translator.ts` already imports both under the same original name and had to locally alias the domain one to `PluginTranslatorHelper` just to compile. This ticket removes the need for that workaround.
+
+## Decisions
+
+| Decision | Why |
+| -------- | --- |
+| Rename `marketplace-strategy-helpers.ts`'s function to `buildClaudeStyleCatalogEntry`, leave the domain one alone | It's the narrower-blast-radius side (2 call sites, both same-file) and pairs naturally with the neighboring `buildClaudeStyleMarketplace` (catalog root) already in that file — reads as "build one catalog entry for the marketplace this file builds." |
+| Rename `domain/models/plugin-translator.ts`'s class to `PluginContentTranslator`, plus the file to `plugin-content-translator.ts` — leave the application-layer interface alone | The interface is the protected strategy-pattern contract (Section C, do-not-touch) with 4 implementer/factory sites; the domain class is a narrower content-format converter with 3 production call sites + tests. Renaming the file alongside the class matches this codebase's dominant convention (class name = file name) and removes `mode-b-flat-materialization-translator.ts`'s now-unnecessary import alias. |

--- a/cli/src/application/use-cases/framework/strategies/marketplace-strategy-helpers.ts
+++ b/cli/src/application/use-cases/framework/strategies/marketplace-strategy-helpers.ts
@@ -166,7 +166,7 @@ export function buildClaudeStyleMarketplace(
   return obj;
 }
 
-export function buildClaudeStyleMarketplaceEntry(
+export function buildClaudeStyleCatalogEntry(
   name: string,
   description: string,
   version: string,

--- a/cli/src/application/use-cases/framework/strategies/tool-contracts.ts
+++ b/cli/src/application/use-cases/framework/strategies/tool-contracts.ts
@@ -61,8 +61,8 @@ import { mergeCodexConfigToml } from "../../../../domain/tools/ai/codex.js";
 import { transformMcpToOpencode } from "../../../../domain/tools/ai/opencode.js";
 import type { PluginPresence, ToolBuildContract } from "../../../../domain/tools/build-contract.js";
 import {
+  buildClaudeStyleCatalogEntry,
   buildClaudeStyleMarketplace,
-  buildClaudeStyleMarketplaceEntry,
   buildCodexMarketplace,
   buildCodexMarketplaceEntry,
   resolveDescription,
@@ -106,7 +106,7 @@ async function buildClaudeStyleEntry(
   const args = [fs, name, srcEntry, outDir, manifestRelative] as const;
   const version = await resolveVersion(...args);
   const description = await resolveDescription(...args);
-  return buildClaudeStyleMarketplaceEntry(
+  return buildClaudeStyleCatalogEntry(
     name,
     description,
     version,

--- a/cli/src/application/use-cases/plugin/plugin-add-use-case.ts
+++ b/cli/src/application/use-cases/plugin/plugin-add-use-case.ts
@@ -9,10 +9,10 @@ import {
 import type { Manifest } from "../../../domain/models/manifest.js";
 import { DOCS_DIR, PLUGIN_CACHE_SUBDIR } from "../../../domain/models/paths.js";
 import { Plugin } from "../../../domain/models/plugin.js";
+import { PluginContentTranslator } from "../../../domain/models/plugin-content-translator.js";
 import type { PluginDistribution } from "../../../domain/models/plugin-distribution.js";
 import type { PluginSource } from "../../../domain/models/plugin-source.js";
 import type { ReadonlySkipList } from "../../../domain/models/plugin-translation-skip.js";
-import { PluginTranslator } from "../../../domain/models/plugin-translator.js";
 import type { AiToolId } from "../../../domain/models/tool-ids.js";
 import type { FileReader } from "../../../domain/ports/file-reader.js";
 import type { FileWriter } from "../../../domain/ports/file-writer.js";
@@ -273,7 +273,7 @@ export class PluginAddUseCase {
         previousMcpEntries
       );
     }
-    const { files, componentPaths, skipped } = new PluginTranslator(
+    const { files, componentPaths, skipped } = new PluginContentTranslator(
       this.hasher
     ).translateWithComponentPaths(dist, toolConfig, docsDir);
     if (files.length === 0) return { skipped };

--- a/cli/src/application/use-cases/plugin/plugin-update-use-case.ts
+++ b/cli/src/application/use-cases/plugin/plugin-update-use-case.ts
@@ -4,8 +4,8 @@ import type { PluginsCapability } from "../../../domain/capabilities/plugins-cap
 import type { Manifest } from "../../../domain/models/manifest.js";
 import { DOCS_DIR, PLUGIN_CACHE_SUBDIR } from "../../../domain/models/paths.js";
 import { Plugin } from "../../../domain/models/plugin.js";
+import { PluginContentTranslator } from "../../../domain/models/plugin-content-translator.js";
 import type { PluginDistribution } from "../../../domain/models/plugin-distribution.js";
-import { PluginTranslator } from "../../../domain/models/plugin-translator.js";
 import { compareSemver } from "../../../domain/models/semver.js";
 import type { AiToolId } from "../../../domain/models/tool-ids.js";
 import type { FileReader } from "../../../domain/ports/file-reader.js";
@@ -127,7 +127,7 @@ export class PluginUpdateUseCase {
       );
       return;
     }
-    const { files: newFiles, componentPaths } = new PluginTranslator(
+    const { files: newFiles, componentPaths } = new PluginContentTranslator(
       this.hasher
     ).translateWithComponentPaths(dist, toolConfig, docsDir);
     const isLocalMarketplace = plugin.source.kind === "local" && plugin.marketplace !== undefined;

--- a/cli/src/application/use-cases/plugin/translator/mode-b-flat-materialization-translator.ts
+++ b/cli/src/application/use-cases/plugin/translator/mode-b-flat-materialization-translator.ts
@@ -6,13 +6,13 @@ import { mergeOpencodeMcp } from "../../../../domain/formats/opencode-mcp-merge.
 import type { InstallationFile } from "../../../../domain/models/file.js";
 import type { Manifest } from "../../../../domain/models/manifest.js";
 import { Plugin } from "../../../../domain/models/plugin.js";
+import { PluginContentTranslator } from "../../../../domain/models/plugin-content-translator.js";
 import type { PluginDistribution } from "../../../../domain/models/plugin-distribution.js";
 import type { PluginSource } from "../../../../domain/models/plugin-source.js";
 import type {
   PluginTranslationSkip,
   ReadonlySkipList,
 } from "../../../../domain/models/plugin-translation-skip.js";
-import { PluginTranslator as PluginTranslatorHelper } from "../../../../domain/models/plugin-translator.js";
 import type { AiToolId } from "../../../../domain/models/tool-ids.js";
 import type { FileReader } from "../../../../domain/ports/file-reader.js";
 import type { FileWriter } from "../../../../domain/ports/file-writer.js";
@@ -85,7 +85,7 @@ export class ModeBFlatMaterializationTranslator implements PluginTranslator {
     if (pluginsCap.mode === "native" && pluginsCap.installScope !== "user") {
       throw new CursorProjectScopeUnsupportedError();
     }
-    const { files, componentPaths, skipped } = new PluginTranslatorHelper(
+    const { files, componentPaths, skipped } = new PluginContentTranslator(
       this.hasher
     ).translateWithComponentPaths(dist, toolConfig, docsDir);
     const baseDir = this.resolveBaseDir(pluginsCap, projectRoot);

--- a/cli/src/application/use-cases/shared/apply-plugin-files-use-case.ts
+++ b/cli/src/application/use-cases/shared/apply-plugin-files-use-case.ts
@@ -2,8 +2,8 @@ import { join } from "node:path";
 import type { PluginsCapability } from "../../../domain/capabilities/plugins-capability.js";
 import type { Manifest } from "../../../domain/models/manifest.js";
 import type { Plugin } from "../../../domain/models/plugin.js";
+import { PluginContentTranslator } from "../../../domain/models/plugin-content-translator.js";
 import type { PluginDistribution } from "../../../domain/models/plugin-distribution.js";
-import { PluginTranslator } from "../../../domain/models/plugin-translator.js";
 import type { AiToolId } from "../../../domain/models/tool-ids.js";
 import type { FileReader } from "../../../domain/ports/file-reader.js";
 import type { FileWriter } from "../../../domain/ports/file-writer.js";
@@ -93,7 +93,7 @@ export class ApplyPluginFilesUseCase {
     options: ApplyPluginFilesOptions
   ): Promise<number> {
     const { toolId, plugin, toolConfig, projectRoot, manifest, docsDir, fileFilter } = options;
-    const files = new PluginTranslator(this.hasher).translate(dist, toolConfig, docsDir);
+    const files = new PluginContentTranslator(this.hasher).translate(dist, toolConfig, docsDir);
     let restored = 0;
     for (const f of files) {
       if (fileFilter !== null && fileFilter !== undefined && !fileFilter(f.relativePath)) continue;

--- a/cli/src/domain/models/plugin-content-translator.ts
+++ b/cli/src/domain/models/plugin-content-translator.ts
@@ -42,7 +42,7 @@ interface SkillCap {
   serialize: (fm: Record<string, unknown>, body: string) => string;
 }
 
-export class PluginTranslator {
+export class PluginContentTranslator {
   constructor(private readonly hasher: Hasher) {}
 
   translate(dist: PluginDistribution, toolConfig: ToolConfig, docsDir: string): InstallationFile[] {

--- a/cli/tests/application/use-cases/framework/marketplace-strategy-helpers.unit.test.ts
+++ b/cli/tests/application/use-cases/framework/marketplace-strategy-helpers.unit.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 import type { PluginPresenceFlags } from "../../../../src/application/use-cases/framework/strategies/marketplace-strategy-helpers.js";
 import {
+  buildClaudeStyleCatalogEntry,
   buildClaudeStyleMarketplace,
-  buildClaudeStyleMarketplaceEntry,
   synthesizeClaudeStyleManifest,
 } from "../../../../src/application/use-cases/framework/strategies/marketplace-strategy-helpers.js";
 
@@ -223,9 +223,9 @@ describe("buildClaudeStyleMarketplace", () => {
   });
 });
 
-describe("buildClaudeStyleMarketplaceEntry", () => {
+describe("buildClaudeStyleCatalogEntry", () => {
   it("builds entry with name, source, description, version", () => {
-    const entry = buildClaudeStyleMarketplaceEntry("aidd-dev", "AI Dev plugin", "1.0.0", undefined);
+    const entry = buildClaudeStyleCatalogEntry("aidd-dev", "AI Dev plugin", "1.0.0", undefined);
     expect(entry.name).toBe("aidd-dev");
     expect(entry.source).toBe("./plugins/aidd-dev");
     expect(entry.description).toBe("AI Dev plugin");
@@ -233,7 +233,7 @@ describe("buildClaudeStyleMarketplaceEntry", () => {
   });
 
   it("passes through strict and recommended when present", () => {
-    const entry = buildClaudeStyleMarketplaceEntry("aidd-dev", "desc", "1.0.0", {
+    const entry = buildClaudeStyleCatalogEntry("aidd-dev", "desc", "1.0.0", {
       strict: true,
       recommended: false,
     });
@@ -242,13 +242,13 @@ describe("buildClaudeStyleMarketplaceEntry", () => {
   });
 
   it("omits strict and recommended when absent", () => {
-    const entry = buildClaudeStyleMarketplaceEntry("aidd-dev", "desc", "1.0.0", undefined);
+    const entry = buildClaudeStyleCatalogEntry("aidd-dev", "desc", "1.0.0", undefined);
     expect(entry.strict).toBeUndefined();
     expect(entry.recommended).toBeUndefined();
   });
 
   it("only includes strict when it is boolean (not string/number)", () => {
-    const entry = buildClaudeStyleMarketplaceEntry("aidd-dev", "desc", "1.0.0", { strict: true });
+    const entry = buildClaudeStyleCatalogEntry("aidd-dev", "desc", "1.0.0", { strict: true });
     expect(typeof entry.strict).toBe("boolean");
   });
 });

--- a/cli/tests/domain/models/plugin-content-translator-skip.unit.test.ts
+++ b/cli/tests/domain/models/plugin-content-translator-skip.unit.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from "vitest";
 import { FileHash } from "../../../src/domain/models/file.js";
+import { PluginContentTranslator } from "../../../src/domain/models/plugin-content-translator.js";
 import { PluginDistribution } from "../../../src/domain/models/plugin-distribution.js";
 import { OPENCODE_HOOKS_SKIP_REASON } from "../../../src/domain/models/plugin-translation-skip.js";
-import { PluginTranslator } from "../../../src/domain/models/plugin-translator.js";
 import { cursor } from "../../../src/domain/tools/ai/cursor.js";
 import { opencode } from "../../../src/domain/tools/ai/opencode.js";
 
 const stubHasher = { hash: (_content: string) => new FileHash("a".repeat(32)) };
-const translator = new PluginTranslator(stubHasher);
+const translator = new PluginContentTranslator(stubHasher);
 
 const HOOKS_CONTENT = JSON.stringify({
   hooks: { PreToolUse: [{ hooks: [{ type: "command", command: "node ./hooks/pre.js" }] }] },
@@ -49,7 +49,7 @@ function buildDistWithHooks(name = "test-plugin"): PluginDistribution {
   });
 }
 
-describe("PluginTranslator skip list", () => {
+describe("PluginContentTranslator skip list", () => {
   describe("flat mode (opencode)", () => {
     it("returns empty skipped list when plugin has no hooks or mcp", () => {
       const dist = buildDistWithNoHooksMcp();

--- a/cli/tests/domain/models/plugin-content-translator.unit.test.ts
+++ b/cli/tests/domain/models/plugin-content-translator.unit.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { FileHash } from "../../../src/domain/models/file.js";
+import { PluginContentTranslator } from "../../../src/domain/models/plugin-content-translator.js";
 import {
   type PluginComponentFile,
   PluginDistribution,
 } from "../../../src/domain/models/plugin-distribution.js";
-import { PluginTranslator } from "../../../src/domain/models/plugin-translator.js";
 import { claude } from "../../../src/domain/tools/ai/claude.js";
 import { codex } from "../../../src/domain/tools/ai/codex.js";
 import { copilot } from "../../../src/domain/tools/ai/copilot.js";
@@ -14,7 +14,7 @@ import { vscodeToolConfig } from "../../../src/domain/tools/ide/vscode.js";
 import type { ToolConfig } from "../../../src/domain/tools/registry.js";
 
 const stubHasher = { hash: (_content: string) => new FileHash("a".repeat(32)) };
-const translator = new PluginTranslator(stubHasher);
+const translator = new PluginContentTranslator(stubHasher);
 
 const greetContent = `---
 name: aidd:04:greet
@@ -80,7 +80,7 @@ function pathsFor(tool: ToolConfig, dist = makeDist()): string[] {
   return translator.translate(dist, tool, "").map((f) => f.relativePath);
 }
 
-describe("PluginTranslator.translate()", () => {
+describe("PluginContentTranslator.translate()", () => {
   describe("claude target", () => {
     it("emits all components claude supports under .claude/plugins/sample-plugin/", () => {
       const paths = pathsFor(claude);
@@ -286,7 +286,7 @@ describe("cross-format matrix (source × target)", () => {
   }
 });
 
-describe("PluginTranslator.detectFlatCollisions()", () => {
+describe("PluginContentTranslator.detectFlatCollisions()", () => {
   it("reports no collision when plugins use different plugin names", () => {
     const dist1 = makeDist({ manifest: { name: "plugin-a", version: "1.0.0" } });
     const dist2 = makeDist({ manifest: { name: "plugin-b", version: "1.0.0" } });


### PR DESCRIPTION
## 🎯 What & why

Two genuinely different symbols shared the same name in `src/` — `buildClaudeStyleMarketplaceEntry` and `PluginTranslator`. A grep or IDE jump-to-definition on either was ambiguous about which one you'd land on.

## 🛠️ How it works

**`buildClaudeStyleMarketplaceEntry`**: one version (`domain/capabilities/marketplace-entry.ts:8`) builds a tool's own `settings.json` marketplace registration entry at install time — consumed by `claude.ts`/`copilot.ts`. The other (`marketplace-strategy-helpers.ts:169`) builds one plugin's row in the *built* `marketplace.json` catalog at `framework build` time. Renamed the catalog-row one to `buildClaudeStyleCatalogEntry` — pairs naturally with the neighboring `buildClaudeStyleMarketplace` already in that file. The settings-entry one keeps its name.

**`PluginTranslator`**: one is a domain **class** (`domain/models/plugin-translator.ts`) that converts a plugin distribution's raw content into a specific tool's installed file format. The other is an application-layer **interface** (`plugin/translator/plugin-translator.ts`) — the strategy contract implemented by `BuiltTreeMaterializationTranslator`/`ModeAMarketplaceTranslator`/`ModeBFlatMaterializationTranslator`. Renamed the domain class to `PluginContentTranslator` (file renamed to match); the strategy interface is untouched.

This wasn't cosmetic — `mode-b-flat-materialization-translator.ts` already had to import both under an alias (`PluginTranslator as PluginTranslatorHelper`) just to compile with both in scope. That workaround is gone now that the names don't collide.

Pure rename, zero behavior change.

## 🧪 How to verify

`pnpm --filter cli test` — 2049/2049, zero assertion changes (pure rename).

```
grep -rn "buildClaudeStyleMarketplaceEntry" src/   # only domain/capabilities + claude.ts + copilot.ts
grep -rn "class PluginTranslator\b" src/            # no matches — only the interface remains under that name
```

## ⚠️ Heads-up

Originally planned in the (now-archived) standalone `aidd-cli` repo before the framework migration (#462); implemented fresh here.