### PR TITLE
docs: fix marketplace install steps and note host-wide duplicate commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,13 +100,16 @@ Same plugin names as Claude Code.
 
 Download your tool's bundle from the [latest release](https://github.com/ai-driven-dev/framework/releases/latest), then follow its steps:
 
+> [!NOTE]
+> Installing the framework host-wide for several tools can make the same command appear more than once in a tool's list (e.g. Cursor shows duplicate commands). This happens when one tool reads another tool's settings, and is harmless. In Cursor, disable **Include Third-Party Plugins, Skills, and Other Configs** under **Settings → Rules, Skills, Subagents** to hide the duplicates.
+
 <details>
 <summary><strong>Cursor</strong></summary>
 
 **Marketplace**
 
 1. Unzip the `cursor-marketplace` archive.
-2. Copy the plugins, then reload (**Developer → Reload Window**):
+2. Copy the plugins (Cursor reloads them automatically):
 
 ```bash
 cp -r plugins/aidd-* ~/.cursor/plugins/local/

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Same plugin names as Claude Code.
 Download your tool's bundle from the [latest release](https://github.com/ai-driven-dev/framework/releases/latest), then follow its steps:
 
 > [!NOTE]
-> Installing the framework host-wide for several tools can make the same command appear more than once in a tool's list (e.g. Cursor shows duplicate commands). This happens when one tool reads another tool's settings, and is harmless. In Cursor, disable **Include Third-Party Plugins, Skills, and Other Configs** under **Settings → Rules, Skills, Subagents** to hide the duplicates.
+> Installing the framework host-wide for several tools can make the same command appear more than once in a tool's list. This happens when one tool reads another tool's settings, and is harmless.
 
 <details>
 <summary><strong>Cursor</strong></summary>
@@ -120,6 +120,8 @@ cp -r plugins/aidd-* ~/.cursor/plugins/local/
 1. Unzip the `cursor-flat` archive into your project root → `.cursor/`.
 
 _All plans; team marketplaces need Teams/Enterprise. Also reads Claude format (`.claude/skills/`)._
+
+Disable **Include Third-Party Plugins, Skills, and Other Configs** under **Settings → Rules, Skills, Subagents** to hide the duplicate commands.
 
 [Docs](https://cursor.com/docs/plugins)
 


### PR DESCRIPTION
## 🎯 What & why

Fixes README Marketplace install steps that misled users, and documents a confusing (but harmless) side effect of host-wide installs.

## 🛠️ How it works

- Cursor: dropped the obsolete `Developer → Reload Window` step — Cursor reloads copied plugins automatically ([README.md:112](README.md#L112)).
- Duplicate commands: added a note that a host-wide install across several tools can surface the same command more than once (one tool reading another tool's settings) and how to hide them in Cursor via **Settings → Rules, Skills, Subagents** ([README.md:104](README.md#L104)).
- Copilot Marketplace command left unchanged — the local-archive command is correct; the `401 [fetchManagedSettings]` only appeared before the marketplace was installed (transient state, not a command error).

## 🧪 How to verify

- Read the Cursor + "Other tools" install sections in README; steps match a fresh Marketplace install with no manual reload.

## 🔗 Linked issue

Closes #461