### PR TITLE
test(cli): add AiTool registry conformance suite

### DIFF
--- a/cli/aidd_docs/tasks/2026_07/2026_07_24_e9-aitool-contract-verifiable/phase-1.md
+++ b/cli/aidd_docs/tasks/2026_07/2026_07_24_e9-aitool-contract-verifiable/phase-1.md
@@ -1,0 +1,53 @@
+---
+status: done
+---
+
+# Instruction: Registry conformance test
+
+## Architecture projection
+
+> Tree of the final files. ✅ create · ✏️ modify · ❌ delete
+
+```txt
+.
+└── cli/tests/domain/tools/
+    └── registry-conformance.unit.test.ts   ✅ create
+```
+
+Zero production change — the whole deliverable is the safety net.
+
+## Tasks to do
+
+### `1)` Assert every registered AI tool satisfies the `AiTool<C>` shape
+
+> Iterate `getAllRegisteredTools()`, not a hardcoded list — that is the point.
+
+1. For each registered tool where `isAiTool(config)`: assert `kind === "ai"`, `toolId` is in `AI_TOOL_IDS`, `directory` is a non-empty string ending in `/`, `toolSuffix` is a non-empty string starting with `.`, `signalDir` is `string | null`, `capabilities` is a non-null object, and `rewriteContent` / `reverseRewriteContent` / `detectUserFileSectionKey` are all functions.
+2. Each assertion message must name the offending tool id and field — a bare `expect(x).toBe(true)` failure is useless to whoever adds tool #6. Use per-tool `it()` blocks (`it.each` over the registry) so the failing test's *name* carries the tool id.
+
+### `2)` Assert registry ↔ `AI_TOOL_IDS` agree in both directions
+
+1. Every `AI_TOOL_IDS` entry resolves via `getToolConfig()` and is an AI tool.
+2. Every registered AI tool's id is in `AI_TOOL_IDS` — catches a tool registered but missing from the closed union.
+
+### `3)` Assert every registered AI tool is reachable by `framework build`
+
+1. Every registered AI tool id appears at least once in `FRAMEWORK_BUILD_TARGET_MODES` (verified true today for all 5).
+2. Reverse: every `FRAMEWORK_BUILD_TARGET_MODES` target is a registered AI tool — catches a stale build entry for a removed tool.
+
+### `4)` Assert the probe tables have no orphan formats, and plugin-capable tools are ingestible
+
+> Precision matters — see plan.md. Probing the live registry found opencode has a marketplace probe but no manifest probe (flat plugin mode, no per-plugin manifest dirs). Do **not** assert manifest-probe coverage per tool.
+
+1. Every `format` in `PLUGIN_MANIFEST_PROBES` and in `MARKETPLACE_PROBES` is a registered AI tool id — catches stale/typo'd entries. (Holds today.)
+2. Every registered AI tool declaring a `plugins` capability appears in `MARKETPLACE_PROBES` — the "a new plugin-capable tool can't be silently unreadable" guard. (Holds today for all 5.)
+3. Do not assert the `PLUGIN_MANIFEST_PROBES` direction per tool — it is legitimately not universal.
+
+## Test acceptance criteria
+
+| Task | Acceptance criteria |
+| ---- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| 1-4  | All 5 existing tools pass with zero modification to any `ai/<tool>.ts`. |
+| 1    | A malformed tool fails with a message naming the tool and the field — verified by temporarily registering a broken tool locally during development, not shipped as a permanent fixture (registering a fake tool into the shared module-level registry map would leak into other test files in the same process). |
+| 2-4  | Removing a tool from `AI_TOOL_IDS`, from `FRAMEWORK_BUILD_TARGET_MODES`, or from `MARKETPLACE_PROBES` while leaving it registered makes this suite fail — verified by hand during development. |
+| all  | `tsc --noEmit` clean, full suite green, zero production files changed. |

--- a/cli/aidd_docs/tasks/2026_07/2026_07_24_e9-aitool-contract-verifiable/plan.md
+++ b/cli/aidd_docs/tasks/2026_07/2026_07_24_e9-aitool-contract-verifiable/plan.md
@@ -1,0 +1,33 @@
+---
+objective: "Adding an AI tool that forgets a parallel list fails a test with an actionable message, instead of silently misbehaving at runtime."
+status: implemented
+---
+
+# Plan: Epic E9 — make the AiTool contract verifiable
+
+## Overview
+
+| Field      | Value                                                                     |
+| ---------- | ------------------------------------------------------------------------ |
+| **Goal**   | A conformance test that iterates the tool registry and fails when a registered tool is missing from any list the codebase derives behavior from. |
+| **Source** | `epic-E9-aitool-contract-verifiable.md` (SPIKE-E9-01, US-E9-02, US-E9-03, US-E9-04) — the original stated goal of this whole session. |
+
+## Phases
+
+| #   | Phase                    | File                          |
+| --- | -------------------------- | ------------------------------ |
+| 1   | Registry conformance test  | [`phase-1.md`](./phase-1.md) |
+
+Spike output: [`spike-findings.md`](./spike-findings.md) (SPIKE-E9-01, done).
+
+## Decisions
+
+| Decision | Why |
+| -------- | --- |
+| **US-E9-02 and US-E9-03 are deliberately scope-reduced** from "derive the probe tables / adapter dispatch from the tool contract" to "cover them with the conformance test." Stated here explicitly rather than silently reinterpreted — user-confirmed before planning. | The spike found `PluginFormat` ("a native on-disk layout aidd can *read*") and `AiToolId` ("a tool aidd installs *into*") are distinct concepts that merely coincide in membership today. Deriving one from the other would couple them permanently, force a function reference (each format's parser) into a contract that is otherwise pure data, and touch all 5 tool files plus `PluginsCapability` — for a guarantee the test delivers with zero production change. Same pattern the review of #514 just validated: keep the literal table where it is, make divergence loud. |
+| Assert only invariants that actually hold, verified by probing the live registry first — not invented rules | Probing found opencode is in `MARKETPLACE_PROBES` but **absent** from `PLUGIN_MANIFEST_PROBES` (its plugin mode is flat — no per-plugin manifest directories). A naive "every tool must appear in both probe tables" test would have been wrong. Direction matters: *every probe-table format must be a registered tool* holds universally and catches stale entries; *every tool must have a manifest probe* does not hold and is not asserted. |
+| Do not assert `PLUGIN_MANIFEST_PATHS` (`plugin-content-translator.ts`) equals `PLUGIN_MANIFEST_PROBES` | They have **already** diverged (the translator list omits copilot's two paths). Whether that is intentional (translation-time vs detection-time concerns) is unverified. Asserting equality would fail on landing; asserting nothing would hide it. Recorded in the spike findings for separate triage instead. |
+
+## Out of scope, recorded in spike-findings.md
+
+`MARKETPLACE_PROBES`'s copilot entry pointing at a manifest filename; `PLUGIN_MANIFEST_PATHS` divergence; `--help` strings hardcoding the five tool names; `HooksContentFormat` (explicit non-target — legitimately narrower).

--- a/cli/aidd_docs/tasks/2026_07/2026_07_24_e9-aitool-contract-verifiable/spike-findings.md
+++ b/cli/aidd_docs/tasks/2026_07/2026_07_24_e9-aitool-contract-verifiable/spike-findings.md
@@ -1,0 +1,76 @@
+# SPIKE-E9-01 — audit of remaining parallel lists (findings)
+
+Re-verified against the current `framework/cli` tree (post-migration, post-#514), not trusted from the original cartography.
+
+## Confirmed derivation targets
+
+### 1. `domain/models/plugin-format.ts` — two probe tables, zero imports
+
+```ts
+export type PluginFormat = "claude" | "cursor" | "codex" | "copilot" | "opencode";
+
+export const PLUGIN_MANIFEST_PROBES = [
+  { format: "claude",   relativePath: ".claude-plugin/plugin.json" },
+  { format: "cursor",   relativePath: ".cursor-plugin/plugin.json" },
+  { format: "codex",    relativePath: ".codex-plugin/plugin.json" },
+  { format: "copilot",  relativePath: ".plugin/plugin.json" },
+  { format: "copilot",  relativePath: ".github/plugin/plugin.json" },
+  { format: "copilot",  relativePath: "plugin.json" },
+];
+
+export const MARKETPLACE_PROBES = [
+  { format: "claude",   relativePath: ".claude-plugin/marketplace.json" },
+  { format: "cursor",   relativePath: ".cursor-plugin/marketplace.json" },
+  { format: "codex",    relativePath: ".agents/plugins/marketplace.json" },
+  { format: "copilot",  relativePath: ".github/plugin/plugin.json" },
+  { format: "opencode", relativePath: "opencode.json" },
+];
+```
+
+Consumers: `PluginDistributionReaderAdapter:15,36` (manifest probes), `PluginCatalogRepositoryAdapter:11,37` (marketplace probes).
+
+**Not a 1:1 tool mapping** — copilot has 3 manifest probe paths, 1 marketplace probe. Any derivation must be one-tool→many-paths, not one-tool→one-path.
+
+**Noted, not fixed here**: `MARKETPLACE_PROBES`'s copilot entry points at `.github/plugin/plugin.json` — a *manifest* filename in the *marketplace* table, and byte-identical to a `PLUGIN_MANIFEST_PROBES` entry. Either intentional (copilot's marketplace is its manifest) or a latent copy-paste bug. Out of scope for E9; flagged for separate triage.
+
+### 2. `infrastructure/adapters/plugin-catalog-repository-adapter.ts` — two dispatch sites, not one
+
+- `loadForeign()` (lines 36-47): the if/else chain the ticket names. Each branch calls a **different domain parser** (`parseCursorMarketplace`, `parseCodexMarketplace`, `parseCopilotMarketplace`, `parseOpencodeMarketplace`) returning `NormalizedPlugin[]`.
+- `load()` (lines 24-34): a **separate** hardcoded two-path sequence the ticket never mentions — `COPILOT_MARKETPLACE_PATH` (`.plugin/marketplace.json`) checked first, then `CLAUDE_MARKETPLACE_PATH`, with its own module constants and order significance. Note `.plugin/marketplace.json` here is a *fourth* distinct path string, in neither probe table.
+
+Deriving `loadForeign`'s dispatch means a tool file must carry a **function reference** (its parser) — architecturally legal (domain→domain) but a new kind of thing in a contract that is otherwise pure data.
+
+### 3. `domain/models/plugin-content-translator.ts:22-27` — a third manifest-path list
+
+```ts
+const PLUGIN_MANIFEST_PATHS: readonly string[] = [
+  ".claude-plugin/plugin.json",
+  ".cursor-plugin/plugin.json",
+  ".codex-plugin/plugin.json",
+  "plugin.json",
+];
+```
+
+Not in the original cartography. Used at line 136 to skip manifest files during translation. **Already diverged** from `PLUGIN_MANIFEST_PROBES`: missing copilot's `.plugin/plugin.json` and `.github/plugin/plugin.json`. Whether that divergence is intentional (translation-time vs detection-time concerns) or a bug is unverified — it is exactly the class of silent drift E9 exists to prevent.
+
+## Explicit non-targets
+
+- **`HooksContentFormat = "claude" | "cursor"`** (`domain/formats/cursor-hooks.ts:1`), referenced by `PluginsCapability.hooksContentFormat`. Legitimately narrower than the tool set — only two hook *wire formats* exist, and several tools share one. Do **not** try to unify this with `AiToolId` in a future ticket.
+- **`FrameworkBuildTarget`** — already handled by E2-US02 (#514): the canonical list now lives in `domain/models/framework-build.ts` with a registry drift-guard test.
+- **`--help` description strings** (`framework.ts:23`, `ai.ts:21`) hardcode the five names in prose. Cosmetic, goes stale when tool #6 lands. Known, low severity, decide separately.
+
+## The distinction the tickets did not model
+
+`PluginFormat` and `AiToolId` have the same five members **today**, but mean different things:
+- `AiToolId` — a tool aidd installs *into*.
+- `PluginFormat` — a native on-disk layout aidd can *read*, written by some other tool.
+
+Their coincidence is what makes derivation look trivial and is exactly what would make it fragile. A tool aidd supports need not have an ingestible foreign format, and one format can have several paths (copilot).
+
+## Blocking hazard for any derivation approach
+
+`plugin-format.ts` is currently a **zero-import pure-data module**. `getAllRegisteredTools()` reads a `Map` populated by *side-effect imports* (`import "../domain/tools/ai/claude.js"` etc., in `deps.ts` and `tests/helpers/ports/build-unit-deps.ts`).
+
+Making `PLUGIN_MANIFEST_PROBES` a module-level `const` derived from that registry would **snapshot whatever is registered at first import** — an empty or partial table depending on module import order, in exactly the test paths that construct adapters directly rather than through `deps.ts`. `tsc` and a fully green suite would not catch it.
+
+If derivation is chosen, the probes must become a **function evaluated at call time** (both consumers already use them inside an async method's `for` loop, so this is free), never a module-level const. This must be decided in the plan, not discovered in implementation.

--- a/cli/tests/domain/tools/registry-conformance.unit.test.ts
+++ b/cli/tests/domain/tools/registry-conformance.unit.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+// Side-effect imports: registering every shipped tool is what makes this suite meaningful.
+// A tool missing here would silently escape conformance, so the list must stay complete.
+import "../../../src/domain/tools/ai/claude.js";
+import "../../../src/domain/tools/ai/codex.js";
+import "../../../src/domain/tools/ai/copilot.js";
+import "../../../src/domain/tools/ai/cursor.js";
+import "../../../src/domain/tools/ai/opencode.js";
+import { FRAMEWORK_BUILD_TARGET_MODES } from "../../../src/domain/models/framework-build.js";
+import {
+  MARKETPLACE_PROBES,
+  PLUGIN_MANIFEST_PROBES,
+} from "../../../src/domain/models/plugin-format.js";
+import { AI_TOOL_IDS } from "../../../src/domain/models/tool-ids.js";
+import type { AiTool } from "../../../src/domain/tools/contracts.js";
+import {
+  getAllRegisteredTools,
+  getToolConfig,
+  isAiTool,
+} from "../../../src/domain/tools/registry.js";
+
+/**
+ * Conformance suite for the AiTool contract.
+ *
+ * Every assertion iterates the registry rather than a hardcoded list — that is the point:
+ * adding a tool file automatically subjects it to every rule below, so forgetting to add
+ * that tool to a parallel list somewhere else fails a test instead of misbehaving at runtime.
+ *
+ * Scope note: the probe tables (plugin-format.ts) and the build registry (deps.ts) keep
+ * their literal entries by design — "a format aidd can read" and "a tool aidd installs into"
+ * are distinct concepts that merely coincide today. These tests guard the agreement between
+ * them rather than collapsing one into the other.
+ */
+
+const registeredAiTools: [string, AiTool<unknown>][] = [
+  ...getAllRegisteredTools().entries(),
+].flatMap(([id, config]) =>
+  isAiTool(config) ? [[id as string, config] as [string, AiTool<unknown>]] : []
+);
+
+describe("AiTool contract conformance", () => {
+  it("the registry actually contains tools (guards against a no-op suite)", () => {
+    expect(registeredAiTools.length).toBeGreaterThan(0);
+  });
+
+  describe.each(registeredAiTools)("%s", (toolId, tool) => {
+    it("has a well-formed AiTool shape", () => {
+      expect(tool.kind, `${toolId}: kind must be "ai"`).toBe("ai");
+      expect(tool.toolId, `${toolId}: toolId must match its registry key`).toBe(toolId);
+      expect(
+        typeof tool.directory === "string" && tool.directory.length > 0,
+        `${toolId}: directory must be a non-empty string`
+      ).toBe(true);
+      expect(tool.directory.endsWith("/"), `${toolId}: directory must end with "/"`).toBe(true);
+      expect(
+        typeof tool.toolSuffix === "string" && tool.toolSuffix.startsWith("."),
+        `${toolId}: toolSuffix must be a string starting with "."`
+      ).toBe(true);
+      expect(
+        tool.signalDir === null || typeof tool.signalDir === "string",
+        `${toolId}: signalDir must be a string or null`
+      ).toBe(true);
+      expect(
+        typeof tool.capabilities === "object" && tool.capabilities !== null,
+        `${toolId}: capabilities must be an object`
+      ).toBe(true);
+    });
+
+    it("implements every required content method", () => {
+      for (const method of [
+        "rewriteContent",
+        "reverseRewriteContent",
+        "detectUserFileSectionKey",
+      ] as const) {
+        expect(typeof tool[method], `${toolId}: ${method} must be a function`).toBe("function");
+      }
+    });
+
+    it("is declared in AI_TOOL_IDS", () => {
+      expect(
+        (AI_TOOL_IDS as readonly string[]).includes(toolId),
+        `${toolId} is registered but missing from AI_TOOL_IDS (domain/models/tool-ids.ts)`
+      ).toBe(true);
+    });
+
+    it("is reachable by at least one framework build target/mode", () => {
+      expect(
+        FRAMEWORK_BUILD_TARGET_MODES.some((entry) => entry.target === toolId),
+        `${toolId} is registered but has no entry in FRAMEWORK_BUILD_TARGET_MODES (domain/models/framework-build.ts) — 'aidd framework build --target ${toolId}' would be rejected`
+      ).toBe(true);
+    });
+
+    it("is ingestible when it declares a plugins capability", () => {
+      const declaresPlugins = "plugins" in (tool.capabilities as object);
+      if (!declaresPlugins) return;
+      expect(
+        MARKETPLACE_PROBES.some((probe) => probe.format === toolId),
+        `${toolId} declares a plugins capability but has no MARKETPLACE_PROBES entry (domain/models/plugin-format.ts) — its native marketplace would never be detected`
+      ).toBe(true);
+    });
+  });
+});
+
+describe("no parallel list references an unregistered tool", () => {
+  it("every AI_TOOL_IDS entry resolves to a registered AI tool", () => {
+    for (const id of AI_TOOL_IDS) {
+      const config = getToolConfig(id);
+      expect(isAiTool(config), `AI_TOOL_IDS lists "${id}" but its config is not an AI tool`).toBe(
+        true
+      );
+    }
+  });
+
+  it("every FRAMEWORK_BUILD_TARGET_MODES target is a registered AI tool", () => {
+    const registered = new Set(registeredAiTools.map(([id]) => id));
+    for (const { target } of FRAMEWORK_BUILD_TARGET_MODES) {
+      expect(
+        registered.has(target),
+        `FRAMEWORK_BUILD_TARGET_MODES has an entry for "${target}", which is not a registered AI tool (stale entry?)`
+      ).toBe(true);
+    }
+  });
+
+  it("every probe-table format is a registered AI tool", () => {
+    const registered = new Set(registeredAiTools.map(([id]) => id));
+    for (const [label, probes] of [
+      ["PLUGIN_MANIFEST_PROBES", PLUGIN_MANIFEST_PROBES],
+      ["MARKETPLACE_PROBES", MARKETPLACE_PROBES],
+    ] as const) {
+      for (const probe of probes) {
+        expect(
+          registered.has(probe.format),
+          `${label} has an entry for format "${probe.format}" (${probe.relativePath}), which is not a registered AI tool (stale entry?)`
+        ).toBe(true);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## 🎯 What & why

Closes the goal this whole cartography backlog was built around: **"adding an AI tool is adding one file"** is now guaranteed by a test that fails when it isn't, rather than by human discipline. Today, forgetting to add a new tool to `AI_TOOL_IDS`, to the build target list, or to the marketplace probe table produces no error — just silently wrong behavior at runtime.

## 🛠️ How it works

Every assertion iterates `getAllRegisteredTools()` rather than a hardcoded list, so a new tool file is automatically subject to all of them. Guards:

- `AiTool<C>` shape and the three required content methods
- registry ↔ `AI_TOOL_IDS` agreement, both directions
- every registered tool reachable by at least one `framework build` target/mode
- every plugins-capable tool present in `MARKETPLACE_PROBES`
- no probe-table or build entry naming an unregistered tool (stale-entry guard)

**Assertions were chosen against the live registry, not invented.** Probing found opencode is deliberately absent from `PLUGIN_MANIFEST_PROBES` (flat plugin mode — no per-plugin manifest directories), so per-tool manifest-probe coverage is explicitly *not* asserted. A naive "every tool must be in both probe tables" test would have been wrong.

**All five guards were verified to actually fail** on a deliberate mutation — removed tool id, removed build entry, removed marketplace probe, typo'd probe format, malformed `directory` field — each with a message naming the tool, the field, and the file to fix. A conformance test that can't fail is worthless, so this was checked rather than assumed.

## 🧪 How to verify

`pnpm --filter cli test` — 2088/2088 (2059 + 29 new), tsc clean, **zero production files changed**.

To see it bite: delete any entry from `AI_TOOL_IDS`, `FRAMEWORK_BUILD_TARGET_MODES`, or `MARKETPLACE_PROBES` and re-run.

## ⚠️ Heads-up

**Deliberate scope reduction of US-E9-02/03, user-confirmed before planning — not a silent reinterpretation.** Those tickets asked to *derive* the probe tables and adapter dispatch from the tool contract. The spike found `PluginFormat` ("a native on-disk layout aidd can read") and `AiToolId` ("a tool aidd installs into") are distinct concepts that merely coincide in membership today. Deriving one from the other would couple them permanently, force a parser *function reference* into an otherwise pure-data contract, and touch all 5 tool files plus `PluginsCapability` — for a guarantee this test delivers with zero production change. Same outcome shape as the #514 review.

Also recorded in `spike-findings.md` for separate triage, deliberately not fixed here:
- `MARKETPLACE_PROBES`'s copilot entry points at a *manifest* filename (`.github/plugin/plugin.json`) — possibly intentional, possibly a copy-paste bug
- `PLUGIN_MANIFEST_PATHS` in `plugin-content-translator.ts` is a third hand-maintained manifest-path list that has **already diverged** (omits copilot's two paths)
- `--help` strings in `framework.ts` / `ai.ts` hardcode the five tool names in prose