### PR TITLE
feat(vcs): add review-reply and review-apply skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 ## Agentic framework for software engineers to produce 100% quality code with IA, agonistically.
 
 <p>
-  <!--counts:start--><kbd>7 plugins</kbd> · <kbd>40 skills</kbd> · <kbd>2 agents</kbd><!--counts:end--> · <kbd>MIT</kbd>
+  <!--counts:start--><kbd>7 plugins</kbd> · <kbd>42 skills</kbd> · <kbd>2 agents</kbd><!--counts:end--> · <kbd>MIT</kbd>
 </p>
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
@@ -238,7 +238,7 @@ SDLC loop: plan, implement, assert, audit, review, test, refactor, debug.
 
 ### 🌿 [aidd-vcs](plugins/aidd-vcs/README.md)
 
-`5 skills` · stable
+`7 skills` · stable
 
 Repo init, commits, pull / merge requests, release tags, issues.
 

--- a/plugins/aidd-vcs/.claude-plugin/plugin.json
+++ b/plugins/aidd-vcs/.claude-plugin/plugin.json
@@ -12,7 +12,9 @@
     "./skills/01-commit",
     "./skills/02-pull-request",
     "./skills/03-release-tag",
-    "./skills/04-issue-create"
+    "./skills/04-issue-create",
+    "./skills/05-review-reply",
+    "./skills/06-review-apply"
   ],
   "keywords": [
     "git",

--- a/plugins/aidd-vcs/CATALOG.md
+++ b/plugins/aidd-vcs/CATALOG.md
@@ -13,6 +13,8 @@ Auto-generated index of skills, agents, references and assets shipped by the `ai
   - [`skills/02-pull-request`](#skills02-pull-request)
   - [`skills/03-release-tag`](#skills03-release-tag)
   - [`skills/04-issue-create`](#skills04-issue-create)
+  - [`skills/05-review-reply`](#skills05-review-reply)
+  - [`skills/06-review-apply`](#skills06-review-apply)
 
 ---
 
@@ -70,4 +72,24 @@ Auto-generated index of skills, agents, references and assets shipped by the `ai
 | `assets` | [CONTRIBUTING.md](skills/04-issue-create/assets/CONTRIBUTING.md) | `Project contribution guidelines template` |
 | `assets` | [issue-template.md](skills/04-issue-create/assets/issue-template.md) | `VCS issue/ticket template` |
 | `-` | [SKILL.md](skills/04-issue-create/SKILL.md) | `Create an issue in the configured ticketing tool. Use when the user wants to file a bug, open an issue, or report a problem. Not for committing, opening a pull request, or commenting on an existing issue.` |
+
+#### `skills/05-review-reply`
+
+| Group | File | Description |
+|-------|------|---|
+| `actions` | [01-collect.md](skills/05-review-reply/actions/01-collect.md) | - |
+| `actions` | [02-draft.md](skills/05-review-reply/actions/02-draft.md) | - |
+| `actions` | [03-post.md](skills/05-review-reply/actions/03-post.md) | - |
+| `references` | [tone.md](skills/05-review-reply/references/tone.md) | - |
+| `-` | [SKILL.md](skills/05-review-reply/SKILL.md) | `Reply to a developer's review comments on a GitHub pull request, one reply per thread, bots and Copilot excluded. Use when the user wants to answer, respond to, or reply to PR review comments. Not for creating a pull request, applying the requested changes, or reviewing a diff.` |
+
+#### `skills/06-review-apply`
+
+| Group | File | Description |
+|-------|------|---|
+| `actions` | [01-collect.md](skills/06-review-apply/actions/01-collect.md) | - |
+| `actions` | [02-apply.md](skills/06-review-apply/actions/02-apply.md) | - |
+| `actions` | [03-verify.md](skills/06-review-apply/actions/03-verify.md) | - |
+| `actions` | [04-explain.md](skills/06-review-apply/actions/04-explain.md) | - |
+| `-` | [SKILL.md](skills/06-review-apply/SKILL.md) | `Apply the fixes a pull request's review comments ask for, verify the result, then explain what changed and why. Use when the user wants to apply, address, or fix review comments on an open pull request. Not for replying to comments, creating a pull request, or committing.` |
 

--- a/plugins/aidd-vcs/README.md
+++ b/plugins/aidd-vcs/README.md
@@ -8,9 +8,9 @@ VCS workflow plugin for the AI-Driven Development framework.
 
 First time? Install with `/plugin install aidd-vcs@aidd-framework`, then run `aidd-vcs:01-commit`.
 
-Typical flow: `00-repo-init` once to set up the repo; `01-commit` after each unit of work; `02-pull-request` when the branch is ready; `03-release-tag` at release time; `04-issue-create` from anywhere.
+Typical flow: `00-repo-init` once to set up the repo; `01-commit` after each unit of work; `02-pull-request` when the branch is ready; `05-review-reply` and `06-review-apply` once review comments land; `03-release-tag` at release time; `04-issue-create` from anywhere.
 
-Covers all external artifact creation: repo init, commits, pull/merge requests, release tags, and issue tracking.
+Covers all external artifact creation: repo init, commits, pull/merge requests, review handling, release tags, and issue tracking.
 
 ## Skills
 
@@ -21,6 +21,8 @@ Covers all external artifact creation: repo init, commits, pull/merge requests, 
 | [3.2] | [pull-request](skills/02-pull-request/SKILL.md) | Create PR (GitHub) or MR (GitLab) with filled template. |
 | [3.3] | [release-tag](skills/03-release-tag/SKILL.md) | Create and push a semantic version git tag with release notes. |
 | [3.4] | [issue-create](skills/04-issue-create/SKILL.md) | Create issues in the configured ticketing tool. |
+| [3.5] | [review-reply](skills/05-review-reply/SKILL.md) | Reply to a PR's human review comments, one reply per thread. |
+| [3.6] | [review-apply](skills/06-review-apply/SKILL.md) | Apply a PR's requested review fixes, verify, and explain. |
 
 ## Assets
 

--- a/plugins/aidd-vcs/skills/05-review-reply/SKILL.md
+++ b/plugins/aidd-vcs/skills/05-review-reply/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: 05-review-reply
+description: "Reply to a developer's review comments on a GitHub pull request, one reply per thread, bots and Copilot excluded. Use when the user wants to answer, respond to, or reply to PR review comments. Not for creating a pull request, applying the requested changes, or reviewing a diff."
+argument-hint: collect | draft | post
+---
+
+# Review Reply
+
+```mermaid
+flowchart LR
+  collect --> draft --> post
+```
+
+## Actions
+
+Read only the next action's file before running it.
+
+| #   | Action    | Does                                                          |
+| --- | --------- | -------------------------------------------------------------- |
+| 01  | `collect` | Resolve the PR and fetch human review comments, bots excluded  |
+| 02  | `draft`   | Read the code at each comment and write a reply per thread     |
+| 03  | `post`    | Show the drafts, wait for confirmation, then post the replies  |
+
+## Transversal rules
+
+- Copilot and any user whose `type` is `Bot` are always excluded.
+- One thread, one reply — merge several comments from the same author on the same subject before drafting.
+- Never post before the user has seen and confirmed every draft.
+- Applying the changes a comment requests, and committing or pushing, are separate steps not run here.

--- a/plugins/aidd-vcs/skills/05-review-reply/actions/01-collect.md
+++ b/plugins/aidd-vcs/skills/05-review-reply/actions/01-collect.md
@@ -1,0 +1,24 @@
+# 01 - Collect
+
+Resolve the pull request and gather every human review comment, bots and already-answered threads filtered out.
+
+## Input
+
+An optional PR number or link from the user.
+
+## Output
+
+The list of threads to answer, each with id, author, path, line, body, and whether it is inline or a general review comment.
+
+## Process
+
+1. **Resolve.** Use the PR number the user gave, else detect it with `gh pr view --json number`.
+2. **Fetch inline.** Run `gh api repos/{owner}/{repo}/pulls/{pr}/comments --jq '.[] | select(.user.login != "Copilot" and (.user.type // "User") != "Bot") | {id, user: .user.login, path, line, body, in_reply_to_id}'`.
+3. **Fetch general.** Run `gh api repos/{owner}/{repo}/pulls/{pr}/reviews --jq '.[] | select(.user.login != "Copilot" and (.user.type // "User") != "Bot") | {id, user: .user.login, state, body}'`.
+4. **Group.** Merge several comments from the same author on the same file or subject into one thread entry.
+5. **Skip answered.** Drop a thread that already carries a reply from the current user.
+
+## Test
+
+- Run against a real PR carrying at least one Copilot or bot comment: the output excludes it.
+- A thread already replied to by the user is absent from the output.

--- a/plugins/aidd-vcs/skills/05-review-reply/actions/02-draft.md
+++ b/plugins/aidd-vcs/skills/05-review-reply/actions/02-draft.md
@@ -1,0 +1,22 @@
+# 02 - Draft
+
+Write one reply per thread from `collect`'s output.
+
+## Input
+
+The list of threads from `collect`.
+
+## Output
+
+A drafted reply text per thread, following [tone.md](../references/tone.md).
+
+## Process
+
+1. **Read.** For each thread, read the referenced file around the commented line (about 20 lines of context) to understand what the reviewer saw and why they commented.
+2. **Judge.** Decide the stance: the point is already fixed, the point stands and is answered with a reason, or a clarification is owed instead of a fix.
+3. **Write.** Draft the reply per [tone.md](../references/tone.md) — the why, not just the what — matching the reviewer's language.
+
+## Test
+
+- Every drafted reply names the specific mechanism from the code, not a restatement of the comment.
+- No draft exists for a thread `collect` excluded.

--- a/plugins/aidd-vcs/skills/05-review-reply/actions/03-post.md
+++ b/plugins/aidd-vcs/skills/05-review-reply/actions/03-post.md
@@ -1,0 +1,23 @@
+# 03 - Post
+
+Show every draft to the user, then post only after explicit confirmation.
+
+## Input
+
+The drafted replies from `draft`.
+
+## Output
+
+The posted comments, each with the id or URL GitHub returned.
+
+## Process
+
+1. **Show.** List every draft next to the thread it answers and wait for the user's go-ahead.
+2. **Post inline.** For a review comment: `gh api repos/{owner}/{repo}/pulls/{pr}/comments --method POST --field body="..." --field in_reply_to={comment_id}`.
+3. **Post general.** For a general review thread: `gh pr comment {pr} --body "..."`.
+4. **Report.** Echo back what was posted and where.
+
+## Test
+
+- No `gh api` or `gh pr comment` post runs before the user has confirmed the shown list.
+- Each posted reply's id or URL is reported back to the user.

--- a/plugins/aidd-vcs/skills/05-review-reply/references/tone.md
+++ b/plugins/aidd-vcs/skills/05-review-reply/references/tone.md
@@ -1,0 +1,22 @@
+# Reply tone
+
+Voice for a reply to a real PR review comment — a colleague's remark, not a lesson.
+
+- Natural and even, 2-4 sentences: state what was wrong (the actual trap, not just "fixed"), then what changed and why it is better. The reviewer should follow the reasoning, not just read "done."
+- Concrete over abstract: a specific example beats one more technical term.
+- Never open with a greeting or a thank-you formula ("Hi", "Thanks for the feedback", "Great catch", "Indeed,").
+- No bullet points unless the reply genuinely lists 3+ distinct items.
+- Affirmative when the fix is done, honest when disagreeing, and flag any real tradeoff (e.g. "this drifts a bit from the rest of the code, but it's cleaner here").
+- Reply in the reviewer's language.
+
+## Good
+
+- `Good catch, the condition was inverted. The trap is the OR: in prod the first check is false but the second passed as true, so it still logged. I flipped the second check, now it's silent in prod.`
+- `You're right, dayjs.locale() changes the locale globally for the whole app, not just this component, and calling it in render replays it on every re-render. Moved it into a useEffect([locale]) so it only runs when the locale actually changes.`
+- `I'd rather keep the cast here for now: the API's DTO isn't stable yet, we'll likely touch this again. Removing it once it's frozen.`
+
+## Bad
+
+- `Fixed.` — too terse, explains nothing.
+- `Thanks for the great feedback! Indeed, I made the following correction.` — AI-sounding, no substance.
+- `Hi, following your comment I made these changes:` — greeting, restates the comment instead of answering it.

--- a/plugins/aidd-vcs/skills/06-review-apply/SKILL.md
+++ b/plugins/aidd-vcs/skills/06-review-apply/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: 06-review-apply
+description: "Apply the fixes a pull request's review comments ask for, verify the result, then explain what changed and why. Use when the user wants to apply, address, or fix review comments on an open pull request. Not for replying to comments, creating a pull request, or committing."
+argument-hint: collect | apply | verify | explain
+---
+
+# Review Apply
+
+```mermaid
+flowchart LR
+  collect --> apply --> verify --> explain
+```
+
+## Actions
+
+Read only the next action's file before running it.
+
+| #   | Action    | Does                                                                |
+| --- | --------- | -------------------------------------------------------------------- |
+| 01  | `collect` | Confirm the branch matches the PR and fetch the open review comments |
+| 02  | `apply`   | Read the context per comment and apply one scoped fix each           |
+| 03  | `verify`  | Typecheck the touched files and review the diff                      |
+| 04  | `explain` | Summarize what each comment asked, the fix, and the verification     |
+
+## Transversal rules
+
+- Copilot and any user whose `type` is `Bot` are always excluded.
+- Never commit or push here — that is a separate, explicit step.
+- Never reply to the GitHub comments here — that is `aidd-vcs:05-review-reply`.
+- A fix stays scoped to its comment: no reformatting or refactor beyond what was asked.

--- a/plugins/aidd-vcs/skills/06-review-apply/actions/01-collect.md
+++ b/plugins/aidd-vcs/skills/06-review-apply/actions/01-collect.md
@@ -1,0 +1,23 @@
+# 01 - Collect
+
+Confirm the local branch matches the pull request, then gather every open review comment.
+
+## Input
+
+An optional PR number or link from the user.
+
+## Output
+
+The list of comments still needing a fix, each with id, author, path, line, body, and `diff_hunk`.
+
+## Process
+
+1. **Resolve.** Use the PR number the user gave, else detect it with `gh pr view --json number`.
+2. **Match branch.** Run `gh pr view {pr} --json headRefName,baseRefName,state` and `git branch --show-current`; if they differ, tell the user and stop.
+3. **Fetch.** Run `gh api repos/{owner}/{repo}/pulls/{pr}/comments --jq '.[] | select(.user.login != "Copilot" and (.user.type // "User") != "Bot") | {id, path, line, user: .user.login, body, diff_hunk, in_reply_to: .in_reply_to_id}'`.
+4. **Drop resolved.** Exclude a thread already answered with a visible fix in `git log` for the file it targets.
+
+## Test
+
+- Run on a PR whose local branch is checked out elsewhere: the mismatch is reported and the run stops before fetching.
+- The output excludes any comment already answered by a real code change.

--- a/plugins/aidd-vcs/skills/06-review-apply/actions/02-apply.md
+++ b/plugins/aidd-vcs/skills/06-review-apply/actions/02-apply.md
@@ -1,0 +1,24 @@
+# 02 - Apply
+
+Turn each collected comment into one scoped code fix.
+
+## Input
+
+The list of comments from `collect`.
+
+## Output
+
+The modified files, one intentional change per comment.
+
+## Process
+
+1. **Read.** For each comment, read the targeted file at the noted line plus enough context to see the whole mechanism — the function, the config, or a neighboring file the comment implies (e.g. `next.config.ts` for a `basePath`), not only the annotated line.
+2. **Judge.** Evaluate any fix the comment suggests instead of copying it verbatim — the repo's context may call for a different solution.
+3. **Trace flags.** When the comment or code touches an env var, flag, or conditional config, check explicitly what happens on the other branch of that condition, even if it is not active today.
+4. **Fix.** Apply one fix per comment, scoped to the point raised — no reformatting or refactor beyond it. If a comment flags scope creep, shrink the diff to the real intent rather than layering another change on top.
+5. **Check scope.** After each fix, diff against the base (`git diff {base}...HEAD -- {file}` and the working tree) and confirm only intentional changes remain.
+
+## Test
+
+- Each fixed file's diff against the base contains only the change its comment asked for.
+- A comment whose suggested fix was rejected has a recorded reason before the run moves on.

--- a/plugins/aidd-vcs/skills/06-review-apply/actions/03-verify.md
+++ b/plugins/aidd-vcs/skills/06-review-apply/actions/03-verify.md
@@ -1,0 +1,22 @@
+# 03 - Verify
+
+Confirm the applied fixes typecheck and hold up to review.
+
+## Input
+
+The files modified by `apply`.
+
+## Output
+
+A verification result: typecheck status and the review findings, all resolved.
+
+## Process
+
+1. **Typecheck.** Run the project's typecheck on the touched files or packages (e.g. `tsc --noEmit`, or the repo's equivalent).
+2. **Review.** Invoke `aidd-dev:05-review` on the modified files, at a level matched to the diff's size.
+3. **Resolve.** Fix every confirmed finding, then re-run both checks on the changed files.
+
+## Test
+
+- The typecheck run against the touched files reports no error.
+- Every finding `aidd-dev:05-review` confirmed is either fixed or explicitly reasoned against, never silently dropped.

--- a/plugins/aidd-vcs/skills/06-review-apply/actions/04-explain.md
+++ b/plugins/aidd-vcs/skills/06-review-apply/actions/04-explain.md
@@ -1,0 +1,22 @@
+# 04 - Explain
+
+Summarize the run for the user.
+
+## Input
+
+The comments from `collect`, the fixes from `apply`, and the result from `verify`.
+
+## Output
+
+A concise summary the user can read without re-reading the diff.
+
+## Process
+
+1. **Restate.** For each comment, restate in one line what it asked, in the user's words rather than copied.
+2. **Report fix.** State the fix applied and why that solution over another, including any rejected suggestion and its reason.
+3. **Report verification.** State the typecheck and review outcome, and the final diff's scope.
+
+## Test
+
+- Every comment from `collect` has one matching line in the summary.
+- The summary stays free of diff prose — reasoning only, no line-by-line restatement.


### PR DESCRIPTION
## 🗒️ What

Adds two `aidd-vcs` skills: `05-review-reply` replies to a PR's human review comments thread by thread, and `06-review-apply` reads those same comments and applies the requested fixes.

## 🤔 Why

`02-pull-request` opens the request, but nothing in `aidd-vcs` closes the loop once review comments land — reviewers had no AIDD-native path to answer or act on feedback.

## 🛠️ How

Both mirror `02-pull-request`'s router/action pattern:

- `05-review-reply` (`collect → draft → post`): fetches inline and general review comments via `gh api`, excluding Copilot and any `Bot`-typed user and threads already answered; reads the code around each comment to draft a reply that explains the why, not just "fixed"; shows every draft to the user and waits for confirmation before posting anything.
- `06-review-apply` (`collect → apply → verify → explain`): confirms the checked-out branch actually matches the PR's head before touching anything; applies one fix per comment, scoped to what was raised, evaluating a suggested fix rather than copy-pasting it; verifies with a typecheck and `aidd-dev:05-review` on the touched files; ends with a plain-language summary of what each comment asked and why the chosen fix.

Deliberately out of scope for both: neither commits, pushes, or replies on the other's behalf — `06-review-apply` explicitly defers replying to `05-review-reply`.

`plugin.json`, the plugin `README.md`, its `CATALOG.md`, and the root `README.md` skill/plugin counts are updated to match (`5 → 7 skills` for `aidd-vcs`, `40 → 42` overall).

## 🧪 How to verify

- `node scripts/check-markdown-links.js --ignore cli/tests/fixtures --ignore cli/aidd_docs/tasks` → `0 broken`.
- Install the plugin locally and run `/aidd-vcs:05-review-reply` and `/aidd-vcs:06-review-apply` against any PR carrying review comments (including at least one bot/Copilot comment, to check the exclusion) and confirm: comments are fetched correctly, no reply/fix lands without an explicit confirmation step, and the `06-review-apply` diff stays scoped to what each comment asked.

## ✅ I certify

- [ ] **I DO CERTIFY I READ EACH LINE OF THE PULL REQUEST BECAUSE I AM A SOFTWARE ENGINEER, NOT A AI PUPPY.**
