### PR TITLE
refactor(cli): inject PostInstallPipelineUseCase and GitignoreUseCase

### DIFF
--- a/cli/aidd_docs/tasks/2026_07/2026_07_27_e6-us07-inject-postinstall-gitignore/phase-1.md
+++ b/cli/aidd_docs/tasks/2026_07/2026_07_27_e6-us07-inject-postinstall-gitignore/phase-1.md
@@ -1,0 +1,65 @@
+---
+status: done
+---
+
+# Instruction: Inject PostInstallPipelineUseCase and GitignoreUseCase
+
+## Architecture projection
+
+> Tree of the final files. ✅ create · ✏️ modify · ❌ delete
+
+```txt
+.
+└── cli/
+    ├── src/
+    │   ├── application/use-cases/
+    │   │   ├── shared/post-install-pipeline-use-case.ts   ✏️ modify (inject Gitignore, drop dead fs)
+    │   │   ├── install/install-ide-config-use-case.ts      ✏️ modify (inject pipeline)
+    │   │   ├── install/install-ide-tool-use-case.ts        ✏️ modify (inject pipeline)
+    │   │   ├── install/install-runtime-config-use-case.ts  ✏️ modify (inject pipeline)
+    │   │   └── clean-use-case.ts                            ✏️ modify (inject gitignore)
+    │   └── infrastructure/deps.ts                           ✏️ modify (build both, wire 4 consumers)
+    └── tests/helpers/ports/build-unit-deps.ts               ✏️ modify (mirror the new signatures)
+```
+
+## Tasks to do
+
+### `1)` `PostInstallPipelineUseCase` takes `GitignoreUseCase`
+
+1. Constructor becomes `(manifestRepo: ManifestRepository, gitignoreUseCase: GitignoreUseCase)` — `fs` removed (its only use was the `new` being deleted; verified by count).
+2. `execute()` calls `this.gitignoreUseCase.execute(...)` instead of `new GitignoreUseCase(this.fs).execute(...)`.
+3. Drop the now-unused `FileReader`/`FileWriter` type imports if nothing else in the file needs them.
+
+### `2)` The 3 install use-cases take the pipeline
+
+1. Add `private readonly postInstallPipelineUseCase: PostInstallPipelineUseCase` to each constructor (append — keeps existing positional args stable for any caller not updated in the same pass).
+2. Replace each `await new PostInstallPipelineUseCase(this.fs, this.manifestRepo).execute({...})` with `await this.postInstallPipelineUseCase.execute({...})`.
+3. Keep `fs`/`manifestRepo` — both still used elsewhere in all three.
+
+### `3)` `clean-use-case` takes `GitignoreUseCase`
+
+> `init-use-case` was dropped from scope mid-implementation — see plan.md Decisions (InitUseCase is itself outside the dependency graph; injecting there would add ad-hoc `new`s, not remove them).
+
+1. Insert `private readonly gitignoreUseCase: GitignoreUseCase` before the optional `prompter?` param.
+2. `clean-use-case.ts:55` → `this.gitignoreUseCase.remove(...)`.
+3. Keep `fs` (13 remaining uses).
+
+### `4)` Wire in `deps.ts`
+
+1. Build `gitignoreUseCase` first, then `postInstallPipelineUseCase(manifestRepo, gitignoreUseCase)`, both **before** the 5 consumers they feed.
+2. Pass them into `installIdeConfigUseCase`, `installIdeToolUseCase`, `installRuntimeConfigUseCase`, `cleanUseCase`.
+3. Expose neither on the `Deps` interface unless a command needs it directly — internal wiring only, keeps the public surface unchanged.
+
+### `5)` Mirror the signatures in the test helper
+
+1. `tests/helpers/ports/build-unit-deps.ts` constructs `installRuntimeConfigUseCase` and `installIdeConfigUseCase` directly — update those call sites to build and pass the two new collaborators.
+2. Grep for any other test constructing the 5 consumers directly and update the same way.
+
+## Test acceptance criteria
+
+| Task | Acceptance criteria |
+| ---- | ------------------------------------------------------------------------------------------------------------------------- |
+| 1-5  | `aidd install`, `aidd update`, `aidd clean`, `aidd setup` behave identically — `.gitignore` still gains `.aidd/cache/` on install/init, and `aidd clean` still removes it. Verified by the existing suite passing with zero assertion changes. |
+| 1-4  | `grep -rn "new PostInstallPipelineUseCase\|new GitignoreUseCase" src/` returns only the two construction sites in `deps.ts`, plus the one documented exception in `init-use-case.ts`. |
+| 1    | `PostInstallPipelineUseCase` no longer accepts `fs`; `tsc` proves no caller still passes it. |
+| all  | `tsc --noEmit` clean, full suite green. |

--- a/cli/aidd_docs/tasks/2026_07/2026_07_27_e6-us07-inject-postinstall-gitignore/plan.md
+++ b/cli/aidd_docs/tasks/2026_07/2026_07_27_e6-us07-inject-postinstall-gitignore/plan.md
@@ -1,0 +1,46 @@
+---
+objective: "PostInstallPipelineUseCase and GitignoreUseCase are built once in deps.ts and injected, so a test can substitute them at the command level like every other shared use-case."
+status: implemented
+---
+
+# Plan: US-E6-07 — inject PostInstallPipelineUseCase / GitignoreUseCase
+
+## Overview
+
+| Field      | Value                                                                              |
+| ---------- | ---------------------------------------------------------------------------------- |
+| **Goal**   | Replace 6 ad-hoc `new` sites with constructor injection, so both use-cases join the dependency graph instead of escaping it. |
+| **Source** | `epic-E6-naming-di-hygiene.md` (US-E6-07, cartography item B11) |
+
+## Phases
+
+| #   | Phase                          | File                          |
+| --- | -------------------------------- | ------------------------------ |
+| 1   | Inject both shared use-cases     | [`phase-1.md`](./phase-1.md) |
+
+## Findings (verified against current code, not trusted from the ticket)
+
+**6 ad-hoc instantiation sites, exactly as B11 claimed:**
+
+`new PostInstallPipelineUseCase(this.fs, this.manifestRepo)` — 3 sites:
+- `install/install-ide-config-use-case.ts:59`
+- `install/install-ide-tool-use-case.ts:99`
+- `install/install-runtime-config-use-case.ts:69`
+
+`new GitignoreUseCase(this.fs)` — 3 sites:
+- `clean-use-case.ts:55` (calls `.remove()`)
+- `init-use-case.ts:73` (calls `.execute()`)
+- `shared/post-install-pipeline-use-case.ts:23` (calls `.execute()`)
+
+**Both are stateless** — `GitignoreUseCase` holds only `private readonly fs`; `PostInstallPipelineUseCase` holds only `fs` + `manifestRepo`. No memoization, no accumulators. Safe to share as singletons (same check applied in E1/#508).
+
+**One nesting**: `PostInstallPipelineUseCase` itself instantiates `GitignoreUseCase`, so the graph is `GitignoreUseCase → PostInstallPipelineUseCase → 3 install use-cases`.
+
+## Decisions
+
+| Decision | Why |
+| -------- | --- |
+| Drop `fs` from `PostInstallPipelineUseCase`'s constructor after injecting `GitignoreUseCase` | Verified by count: `this.fs` appears exactly **once** in that file — the `new GitignoreUseCase(this.fs)` being removed. Leaving it would be an unused constructor param, against the project's dead-code rule. Same subtractive follow-through as #508. |
+| Keep `fs` on all other consumers | Verified by count: `clean-use-case` uses `this.fs` 13×, and the 3 install use-cases are file-heavy. |
+| **Correction found during implementation**: `manifestRepo` also goes dead in `install-ide-config` and `install-runtime-config` | The plan originally asserted `fs`/`manifestRepo` both stay used in all three install use-cases. That was wrong — I counted `this.fs` but not `this.manifestRepo`. Biome's `noUnusedPrivateClassMembers` caught it at commit time: those two classes used `manifestRepo` *only* to build the pipeline being injected, so it drops to 0 uses. Removed from both (and from all 8 call sites; `tsc` enumerated them). `install-ide-tool` still uses it once, so it keeps the param — checked per file, not assumed. |
+| **`init-use-case.ts` left as-is — 5 of the 6 sites converted, not 6** | Discovered mid-implementation: `InitUseCase` is not in the dependency graph at all. It has no `deps.ts` entry; it is itself ad-hoc constructed by `setup-use-case.ts:85` plus **13 test call sites**. Injecting `GitignoreUseCase` into it would force every one of those callers to write `new GitignoreUseCase(deps.fs)` themselves — *more* ad-hoc instantiation than before, and it would not achieve the ticket's stated goal (substituting a mock at the command level), since `InitUseCase` still escapes the graph one level up. The real fix is "wire `InitUseCase` into `deps.ts`", a distinct concern outside B11's scope. Recorded rather than silently half-done. |

--- a/cli/src/application/use-cases/clean-use-case.ts
+++ b/cli/src/application/use-cases/clean-use-case.ts
@@ -13,7 +13,7 @@ import type { Logger } from "../../domain/ports/logger.js";
 import type { ManifestRepository } from "../../domain/ports/manifest-repository.js";
 import type { Prompter } from "../../domain/ports/prompter.js";
 import type { ToolId } from "../../domain/tools/registry.js";
-import { GitignoreUseCase } from "./shared/gitignore-use-case.js";
+import type { GitignoreUseCase } from "./shared/gitignore-use-case.js";
 
 interface CleanOptions {
   projectRoot: string;
@@ -38,6 +38,7 @@ export class CleanUseCase {
     private readonly fs: FileReader & FileWriter,
     private readonly manifestRepo: ManifestRepository,
     private readonly logger: Logger,
+    private readonly gitignoreUseCase: GitignoreUseCase,
     private readonly prompter?: Prompter
   ) {}
 
@@ -52,7 +53,7 @@ export class CleanUseCase {
     if (dryRunResult !== null) return dryRunResult;
     const deleted = await this.deleteAllToolFiles(manifest, options.projectRoot);
     await this.fs.deleteDirectory(join(options.projectRoot, AIDD_DIR));
-    await new GitignoreUseCase(this.fs).remove(options.projectRoot, [`${AIDD_DIR}/cache/`]);
+    await this.gitignoreUseCase.remove(options.projectRoot, [`${AIDD_DIR}/cache/`]);
     return { dryRun: false, manifestFound: true, preview, fileCount: deleted };
   }
 

--- a/cli/src/application/use-cases/install/install-ide-config-use-case.ts
+++ b/cli/src/application/use-cases/install/install-ide-config-use-case.ts
@@ -10,9 +10,8 @@ import type { FileReader } from "../../../domain/ports/file-reader.js";
 import type { FileWriter } from "../../../domain/ports/file-writer.js";
 import type { Hasher } from "../../../domain/ports/hasher.js";
 import type { Logger } from "../../../domain/ports/logger.js";
-import type { ManifestRepository } from "../../../domain/ports/manifest-repository.js";
 import { getToolConfig } from "../../../domain/tools/registry.js";
-import { PostInstallPipelineUseCase } from "../shared/post-install-pipeline-use-case.js";
+import type { PostInstallPipelineUseCase } from "../shared/post-install-pipeline-use-case.js";
 
 export interface InstallIdeConfigOptions {
   toolId: IdeToolId;
@@ -35,10 +34,10 @@ export interface InstallIdeConfigResult {
 export class InstallIdeConfigUseCase {
   constructor(
     private readonly fs: FileReader & FileWriter & FileMerger,
-    private readonly manifestRepo: ManifestRepository,
     private readonly hasher: Hasher,
     private readonly logger: Logger,
-    private readonly assets: AssetProvider
+    private readonly assets: AssetProvider,
+    private readonly postInstallPipelineUseCase: PostInstallPipelineUseCase
   ) {}
 
   async execute(options: InstallIdeConfigOptions): Promise<InstallIdeConfigResult> {
@@ -56,7 +55,7 @@ export class InstallIdeConfigUseCase {
     const mergeEntries = await this.buildMergeEntries(mergeFiles, options.projectRoot);
     const allFiles = [...regularFiles, ...mergeFiles];
     manifest.addTool(toolId, options.version, allTracked, mergeEntries);
-    await new PostInstallPipelineUseCase(this.fs, this.manifestRepo).execute({
+    await this.postInstallPipelineUseCase.execute({
       projectRoot: options.projectRoot,
       manifest,
     });

--- a/cli/src/application/use-cases/install/install-ide-tool-use-case.ts
+++ b/cli/src/application/use-cases/install/install-ide-tool-use-case.ts
@@ -11,7 +11,7 @@ import type { FileWriter } from "../../../domain/ports/file-writer.js";
 import type { Hasher } from "../../../domain/ports/hasher.js";
 import type { ManifestRepository } from "../../../domain/ports/manifest-repository.js";
 import { getToolConfig, isAiTool } from "../../../domain/tools/registry.js";
-import { PostInstallPipelineUseCase } from "../shared/post-install-pipeline-use-case.js";
+import type { PostInstallPipelineUseCase } from "../shared/post-install-pipeline-use-case.js";
 import type {
   InstallIdeConfigResult,
   InstallIdeConfigUseCase,
@@ -31,6 +31,7 @@ export class InstallIdeToolUseCase {
     private readonly manifestRepo: ManifestRepository,
     private readonly fs: FileReader & FileWriter & FileMerger,
     private readonly hasher: Hasher,
+    private readonly postInstallPipelineUseCase: PostInstallPipelineUseCase,
     private readonly assetProvider?: AssetProvider
   ) {}
 
@@ -96,7 +97,7 @@ export class InstallIdeToolUseCase {
       newEntry,
     ];
     manifest.updateToolMergeFiles(aiId, updated);
-    await new PostInstallPipelineUseCase(this.fs, this.manifestRepo).execute({
+    await this.postInstallPipelineUseCase.execute({
       projectRoot,
       manifest,
     });

--- a/cli/src/application/use-cases/install/install-runtime-config-use-case.ts
+++ b/cli/src/application/use-cases/install/install-runtime-config-use-case.ts
@@ -10,9 +10,8 @@ import type { FileReader } from "../../../domain/ports/file-reader.js";
 import type { FileWriter } from "../../../domain/ports/file-writer.js";
 import type { Hasher } from "../../../domain/ports/hasher.js";
 import type { Logger } from "../../../domain/ports/logger.js";
-import type { ManifestRepository } from "../../../domain/ports/manifest-repository.js";
 import { getToolConfig, isAiTool } from "../../../domain/tools/registry.js";
-import { PostInstallPipelineUseCase } from "../shared/post-install-pipeline-use-case.js";
+import type { PostInstallPipelineUseCase } from "../shared/post-install-pipeline-use-case.js";
 
 export interface InstallRuntimeConfigOptions {
   toolId: AiToolId;
@@ -35,10 +34,10 @@ export interface InstallRuntimeConfigResult {
 export class InstallRuntimeConfigUseCase {
   constructor(
     private readonly fs: FileReader & FileWriter & FileMerger,
-    private readonly manifestRepo: ManifestRepository,
     private readonly hasher: Hasher,
     private readonly logger: Logger,
-    private readonly assets: AssetProvider
+    private readonly assets: AssetProvider,
+    private readonly postInstallPipelineUseCase: PostInstallPipelineUseCase
   ) {}
 
   async execute(options: InstallRuntimeConfigOptions): Promise<InstallRuntimeConfigResult> {
@@ -66,7 +65,7 @@ export class InstallRuntimeConfigUseCase {
     await this.writeMergeFiles(mergeFiles, options.projectRoot);
     const mergeEntries = await this.buildMergeEntries(mergeFiles, options.projectRoot);
     options.manifest.addTool(options.toolId, options.version, allTracked, mergeEntries);
-    await new PostInstallPipelineUseCase(this.fs, this.manifestRepo).execute({
+    await this.postInstallPipelineUseCase.execute({
       projectRoot: options.projectRoot,
       manifest: options.manifest,
     });

--- a/cli/src/application/use-cases/shared/post-install-pipeline-use-case.ts
+++ b/cli/src/application/use-cases/shared/post-install-pipeline-use-case.ts
@@ -1,9 +1,7 @@
 import type { Manifest } from "../../../domain/models/manifest.js";
 import { AIDD_DIR } from "../../../domain/models/paths.js";
-import type { FileReader } from "../../../domain/ports/file-reader.js";
-import type { FileWriter } from "../../../domain/ports/file-writer.js";
 import type { ManifestRepository } from "../../../domain/ports/manifest-repository.js";
-import { GitignoreUseCase } from "./gitignore-use-case.js";
+import type { GitignoreUseCase } from "./gitignore-use-case.js";
 
 interface PostInstallPipelineOptions {
   projectRoot: string;
@@ -12,14 +10,14 @@ interface PostInstallPipelineOptions {
 
 export class PostInstallPipelineUseCase {
   constructor(
-    private readonly fs: FileReader & FileWriter,
-    private readonly manifestRepo: ManifestRepository
+    private readonly manifestRepo: ManifestRepository,
+    private readonly gitignoreUseCase: GitignoreUseCase
   ) {}
 
   async execute(options: PostInstallPipelineOptions): Promise<void> {
     const { projectRoot, manifest } = options;
 
     await this.manifestRepo.save(manifest);
-    await new GitignoreUseCase(this.fs).execute(projectRoot, [`${AIDD_DIR}/cache/`]);
+    await this.gitignoreUseCase.execute(projectRoot, [`${AIDD_DIR}/cache/`]);
   }
 }

--- a/cli/src/infrastructure/deps.ts
+++ b/cli/src/infrastructure/deps.ts
@@ -68,6 +68,8 @@ import {
   type FrameworkBuildFor,
 } from "../application/use-cases/shared/ensure-built-marketplace-use-case.js";
 import { FetchMarketplaceSourceUseCase } from "../application/use-cases/shared/fetch-marketplace-source-use-case.js";
+import { GitignoreUseCase } from "../application/use-cases/shared/gitignore-use-case.js";
+import { PostInstallPipelineUseCase } from "../application/use-cases/shared/post-install-pipeline-use-case.js";
 import { ResolveMarketplaceUseCase } from "../application/use-cases/shared/resolve-marketplace-use-case.js";
 import { ResolveUpdateDecisionUseCase } from "../application/use-cases/shared/resolve-update-decision-use-case.js";
 import { UpdateOneToolUseCase } from "../application/use-cases/shared/update-one-tool-use-case.js";
@@ -503,25 +505,28 @@ export async function createDeps(
     assetProvider,
     logger
   );
+  const gitignoreUseCase = new GitignoreUseCase(fs);
+  const postInstallPipelineUseCase = new PostInstallPipelineUseCase(manifestRepo, gitignoreUseCase);
   const installRuntimeConfigUseCase = new InstallRuntimeConfigUseCase(
     fs,
-    manifestRepo,
     hasher,
     logger,
-    assetProvider
+    assetProvider,
+    postInstallPipelineUseCase
   );
   const installIdeConfigUseCase = new InstallIdeConfigUseCase(
     fs,
-    manifestRepo,
     hasher,
     logger,
-    assetProvider
+    assetProvider,
+    postInstallPipelineUseCase
   );
   const installIdeToolUseCase = new InstallIdeToolUseCase(
     installIdeConfigUseCase,
     manifestRepo,
     fs,
     hasher,
+    postInstallPipelineUseCase,
     assetProvider
   );
   const uninstallIdeUseCase = new UninstallIdeUseCase(fs, manifestRepo);
@@ -655,7 +660,7 @@ export async function createDeps(
     currentVersionProvider,
     updateOneToolUseCase
   );
-  const cleanUseCase = new CleanUseCase(fs, manifestRepo, logger, prompter);
+  const cleanUseCase = new CleanUseCase(fs, manifestRepo, logger, gitignoreUseCase, prompter);
   const doctorAllUseCase = new DoctorAllUseCase(doctorUseCase);
   const checkUpdateUseCase = new CheckUpdateUseCase(cliUpdater, currentVersionProvider, logger, fs);
   const deps: Deps = {

--- a/cli/tests/application/use-cases/clean-use-case.unit.test.ts
+++ b/cli/tests/application/use-cases/clean-use-case.unit.test.ts
@@ -16,7 +16,12 @@ describe("clean", () => {
     const gitignorePath = join(PROJECT_ROOT, ".gitignore");
     await deps.fs.writeFile(gitignorePath, "node_modules/\n.aidd/cache/\ndist/\n");
 
-    const useCase = new CleanUseCase(deps.fs, deps.manifestRepo, deps.logger);
+    const useCase = new CleanUseCase(
+      deps.fs,
+      deps.manifestRepo,
+      deps.logger,
+      deps.gitignoreUseCase
+    );
     await useCase.execute({ projectRoot: PROJECT_ROOT, force: true });
 
     const content = deps.fs.getFile(gitignorePath);
@@ -32,7 +37,12 @@ describe("clean", () => {
     const gitignorePath = join(PROJECT_ROOT, ".gitignore");
     await deps.fs.writeFile(gitignorePath, "node_modules/\n");
 
-    const useCase = new CleanUseCase(deps.fs, deps.manifestRepo, deps.logger);
+    const useCase = new CleanUseCase(
+      deps.fs,
+      deps.manifestRepo,
+      deps.logger,
+      deps.gitignoreUseCase
+    );
     await useCase.execute({ projectRoot: PROJECT_ROOT, force: true });
 
     const content = deps.fs.getFile(gitignorePath);
@@ -46,7 +56,12 @@ describe("clean", () => {
     const userFile = join(PROJECT_ROOT, "my-custom-file.txt");
     await deps.fs.writeFile(userFile, "user content");
 
-    const useCase = new CleanUseCase(deps.fs, deps.manifestRepo, deps.logger);
+    const useCase = new CleanUseCase(
+      deps.fs,
+      deps.manifestRepo,
+      deps.logger,
+      deps.gitignoreUseCase
+    );
     await useCase.execute({ projectRoot: PROJECT_ROOT, force: true });
 
     expect(deps.fs.has(userFile)).toBe(true);

--- a/cli/tests/application/use-cases/helpers.ts
+++ b/cli/tests/application/use-cases/helpers.ts
@@ -11,6 +11,8 @@ import { CLIOutput } from "../../../src/application/output.js";
 import { InitUseCase } from "../../../src/application/use-cases/init-use-case.js";
 import { InstallIdeConfigUseCase } from "../../../src/application/use-cases/install/install-ide-config-use-case.js";
 import { InstallRuntimeConfigUseCase } from "../../../src/application/use-cases/install/install-runtime-config-use-case.js";
+import { GitignoreUseCase } from "../../../src/application/use-cases/shared/gitignore-use-case.js";
+import { PostInstallPipelineUseCase } from "../../../src/application/use-cases/shared/post-install-pipeline-use-case.js";
 import { Manifest } from "../../../src/domain/models/manifest.js";
 import type { Platform } from "../../../src/domain/ports/platform.js";
 import type { Prompter } from "../../../src/domain/ports/prompter.js";
@@ -212,19 +214,21 @@ export function buildDeps(projectRoot: string) {
   const pluginFetcher = new PluginFetcherAdapter(fs);
   const pluginDistributionReader = new PluginDistributionReaderAdapter(fs);
   const pluginCatalogRepository = new PluginCatalogRepositoryAdapter(fs);
+  const gitignoreUseCase = new GitignoreUseCase(fs);
+  const postInstallPipelineUseCase = new PostInstallPipelineUseCase(manifestRepo, gitignoreUseCase);
   const installRuntimeConfigUseCase = new InstallRuntimeConfigUseCase(
     fs,
-    manifestRepo,
     hasher,
     logger,
-    assetProvider
+    assetProvider,
+    postInstallPipelineUseCase
   );
   const installIdeConfigUseCase = new InstallIdeConfigUseCase(
     fs,
-    manifestRepo,
     hasher,
     logger,
-    assetProvider
+    assetProvider,
+    postInstallPipelineUseCase
   );
   const currentVersionProvider: VersionReader = new CurrentVersionAdapter();
   return {

--- a/cli/tests/application/use-cases/install-ide-config-use-case.unit.test.ts
+++ b/cli/tests/application/use-cases/install-ide-config-use-case.unit.test.ts
@@ -9,10 +9,10 @@ const PROJECT_ROOT = "/test-project";
 function buildUseCase(deps: Awaited<ReturnType<typeof buildUnitDeps>>) {
   return new InstallIdeConfigUseCase(
     deps.fs,
-    deps.manifestRepo,
     deps.hasher,
     deps.logger,
-    deps.assetProvider
+    deps.assetProvider,
+    deps.postInstallPipelineUseCase
   );
 }
 

--- a/cli/tests/application/use-cases/install-ide-tool-use-case.unit.test.ts
+++ b/cli/tests/application/use-cases/install-ide-tool-use-case.unit.test.ts
@@ -18,6 +18,7 @@ function buildUseCase(deps: Awaited<ReturnType<typeof buildUnitDeps>>) {
     deps.manifestRepo,
     deps.fs,
     deps.hasher,
+    deps.postInstallPipelineUseCase,
     deps.assetProvider
   );
 }

--- a/cli/tests/application/use-cases/install-runtime-config-use-case.unit.test.ts
+++ b/cli/tests/application/use-cases/install-runtime-config-use-case.unit.test.ts
@@ -9,10 +9,10 @@ const PROJECT_ROOT = "/test-project";
 function buildUseCase(deps: Awaited<ReturnType<typeof buildUnitDeps>>) {
   return new InstallRuntimeConfigUseCase(
     deps.fs,
-    deps.manifestRepo,
     deps.hasher,
     deps.logger,
-    deps.assetProvider
+    deps.assetProvider,
+    deps.postInstallPipelineUseCase
   );
 }
 

--- a/cli/tests/application/use-cases/shared/post-install-pipeline-use-case.unit.test.ts
+++ b/cli/tests/application/use-cases/shared/post-install-pipeline-use-case.unit.test.ts
@@ -13,7 +13,7 @@ describe("post-install pipeline", () => {
     const manifest = await deps.manifestRepo.load();
     if (manifest === null) throw new Error("manifest not found");
 
-    await new PostInstallPipelineUseCase(deps.fs, deps.manifestRepo).execute({
+    await new PostInstallPipelineUseCase(deps.manifestRepo, deps.gitignoreUseCase).execute({
       projectRoot: PROJECT_ROOT,
       manifest,
     });

--- a/cli/tests/helpers/ports/build-unit-deps.ts
+++ b/cli/tests/helpers/ports/build-unit-deps.ts
@@ -17,6 +17,8 @@ import { InitUseCase } from "../../../src/application/use-cases/init-use-case.js
 import { InstallIdeConfigUseCase } from "../../../src/application/use-cases/install/install-ide-config-use-case.js";
 import { InstallRuntimeConfigUseCase } from "../../../src/application/use-cases/install/install-runtime-config-use-case.js";
 import { MarketplaceSyncSettingsUseCase } from "../../../src/application/use-cases/marketplace/marketplace-sync-settings-use-case.js";
+import { GitignoreUseCase } from "../../../src/application/use-cases/shared/gitignore-use-case.js";
+import { PostInstallPipelineUseCase } from "../../../src/application/use-cases/shared/post-install-pipeline-use-case.js";
 import { ResolveUpdateDecisionUseCase } from "../../../src/application/use-cases/shared/resolve-update-decision-use-case.js";
 import { UpdateOneToolUseCase } from "../../../src/application/use-cases/shared/update-one-tool-use-case.js";
 import { SyncConflictResolverUseCase } from "../../../src/application/use-cases/sync/sync-conflict-resolver-use-case.js";
@@ -52,19 +54,21 @@ export async function buildUnitDeps(_projectRoot: string) {
   const pluginDistributionReader = new PluginDistributionReaderAdapter(fs);
   const pluginCatalogRepository = new PluginCatalogRepositoryAdapter(fs);
   const marketplaceRegistry = new InMemoryMarketplaceRegistry();
+  const gitignoreUseCase = new GitignoreUseCase(fs);
+  const postInstallPipelineUseCase = new PostInstallPipelineUseCase(manifestRepo, gitignoreUseCase);
   const installRuntimeConfigUseCase = new InstallRuntimeConfigUseCase(
     fs,
-    manifestRepo,
     hasher,
     logger,
-    assetProvider
+    assetProvider,
+    postInstallPipelineUseCase
   );
   const installIdeConfigUseCase = new InstallIdeConfigUseCase(
     fs,
-    manifestRepo,
     hasher,
     logger,
-    assetProvider
+    assetProvider,
+    postInstallPipelineUseCase
   );
 
   const currentVersionProvider = new FakeCurrentVersion();
@@ -97,6 +101,8 @@ export async function buildUnitDeps(_projectRoot: string) {
     marketplaceSyncSettings,
     installRuntimeConfigUseCase,
     installIdeConfigUseCase,
+    gitignoreUseCase,
+    postInstallPipelineUseCase,
     currentVersionProvider,
     syncConflictResolver,
   };


### PR DESCRIPTION
## 🎯 What & why

`PostInstallPipelineUseCase` and `GitignoreUseCase` were instantiated ad hoc at 6 sites, escaping the dependency graph entirely — no test could substitute either at the command level, unlike every other shared use-case.

## 🛠️ How it works

`deps.ts` now builds each once and injects them: `GitignoreUseCase` → `PostInstallPipelineUseCase` → the 3 install use-cases, and `GitignoreUseCase` → `CleanUseCase`. Both verified stateless (only `readonly` constructor deps) before being shared as singletons — same check applied in #508.

**Dead constructor params removed as a consequence, each checked per file rather than assumed:**
- `PostInstallPipelineUseCase` drops `fs` — its only use was the removed `new GitignoreUseCase(this.fs)`
- `InstallIdeConfigUseCase` / `InstallRuntimeConfigUseCase` drop `manifestRepo` — their only use was the removed `new PostInstallPipelineUseCase(...)`
- `InstallIdeToolUseCase` keeps `manifestRepo` (still used once); `CleanUseCase` keeps `fs` (used 13×)

I initially got the `manifestRepo` part wrong — the plan asserted it stayed in use across all three install use-cases because I'd counted `this.fs` but not `this.manifestRepo`. Biome's `noUnusedPrivateClassMembers` caught it at commit time; `tsc` then enumerated all 8 affected call sites. Recorded in the plan's Decisions rather than quietly fixed.

## 🧪 How to verify

`pnpm --filter cli test` — 2088/2088 unmodified, tsc clean. Pure DI wiring, zero behavior change: `.gitignore` still gains `.aidd/cache/` on install, `aidd clean` still removes it.

```
grep -rn "new PostInstallPipelineUseCase\|new GitignoreUseCase" src/
# -> only the two construction sites in deps.ts, plus the documented init-use-case exception
```

## ⚠️ Heads-up

**5 of the 6 sites converted, not 6.** `init-use-case.ts` is deliberately left alone: `InitUseCase` is not in the dependency graph at all — no `deps.ts` entry, and it is itself ad-hoc constructed by `setup-use-case.ts` plus **13 test call sites**. Injecting `GitignoreUseCase` there would force every one of those callers to write `new GitignoreUseCase(deps.fs)` itself — *more* ad-hoc instantiation, not less — while still not achieving the ticket's goal, since `InitUseCase` keeps escaping the graph one level up. Wiring `InitUseCase` into `deps.ts` is a distinct concern; recorded in the plan rather than half-done here.

Planned in the (now-archived) standalone `aidd-cli` repo before the framework migration (#462), cartography item B11.