### PR TITLE
fix(cli): surface menu errors instead of swallowing them into an infinite loop

### DIFF
--- a/cli/aidd_docs/tasks/2026_07/2026_07_27_e5-02-menu-error-routing/phase-1.md
+++ b/cli/aidd_docs/tasks/2026_07/2026_07_27_e5-02-menu-error-routing/phase-1.md
@@ -1,0 +1,52 @@
+---
+status: done
+---
+
+# Instruction: Route menu errors through ErrorHandler
+
+## Architecture projection
+
+> Tree of the final files. ✅ create · ✏️ modify · ❌ delete
+
+```txt
+.
+└── cli/
+    ├── src/application/commands/menu.ts             ✏️ modify (route non-abort errors)
+    └── tests/application/commands/
+        └── menu-error-routing.unit.test.ts          ✅ create
+```
+
+## Tasks to do
+
+### `1)` Export a testable routing seam
+
+1. In `menu.ts`, add:
+   ```ts
+   /** ExitPromptError = the user pressed Ctrl-C at a prompt; a clean exit, not a failure. */
+   export function routeMenuError(error: unknown, errorHandler: ErrorHandler): never {
+     if (error instanceof Error && error.name === "ExitPromptError") process.exit(0);
+     return errorHandler.handle(error);
+   }
+   ```
+2. Both branches terminate the process, so the return type is `never` — no fallthrough back into the loop.
+
+### `2)` Use it in the loop
+
+1. Build the handler once before the loop: `const errorHandler = new ErrorHandler(new CLIOutput());`.
+2. Replace the `catch` body with `routeMenuError(error, errorHandler)`.
+3. Import `ErrorHandler` from `../error-handler.js` and `CLIOutput` from `../output.js`.
+
+### `3)` Cover the fixed behavior
+
+1. Create `tests/application/commands/menu-error-routing.unit.test.ts`.
+2. Stub `process.exit` (throw a sentinel so the `never` path is observable) and pass a fake `ErrorHandler` that records what it received.
+3. Assert: an `ExitPromptError` exits 0 **without** reaching the handler; any other error **does** reach `errorHandler.handle` with the original error — the regression that was silently swallowed before.
+
+## Test acceptance criteria
+
+| Task | Acceptance criteria |
+| ---- | ------------------------------------------------------------------------------------------------------------------------- |
+| 1-2  | A non-abort failure inside the menu prints its message to stderr and exits non-zero, instead of looping silently forever. |
+| 1-2  | Ctrl-C at a menu prompt still exits 0 silently — unchanged. |
+| 3    | The new test fails if the `errorHandler.handle` call is removed (i.e. if the silent-swallow regresses). |
+| all  | `tsc --noEmit` clean, full suite green. |

--- a/cli/aidd_docs/tasks/2026_07/2026_07_27_e5-02-menu-error-routing/plan.md
+++ b/cli/aidd_docs/tasks/2026_07/2026_07_27_e5-02-menu-error-routing/plan.md
@@ -1,0 +1,44 @@
+---
+objective: "A failure inside the interactive menu prints an actionable message and exits, instead of being silently swallowed into an infinite loop."
+status: implemented
+---
+
+# Plan: SPIKE-E5-01 + BUG-E5-02 — menu.ts error routing
+
+## Overview
+
+| Field      | Value                                                                 |
+| ---------- | --------------------------------------------------------------------- |
+| **Goal**   | `menu.ts` surfaces non-abort errors through `ErrorHandler` like every other command, instead of discarding them. |
+| **Source** | `epic-E5-command-layer-safety.md` (SPIKE-E5-01, BUG-E5-02 — cartography item A9) |
+
+## Phases
+
+| #   | Phase                       | File                          |
+| --- | ----------------------------- | ------------------------------ |
+| 1   | Route menu errors + cover it  | [`phase-1.md`](./phase-1.md) |
+
+## Spike findings (SPIKE-E5-01) — confirmed, and worse than the ticket framed it
+
+`src/application/commands/menu.ts:40-42`, current code:
+
+```ts
+} catch (error) {
+  if (error instanceof Error && error.name === "ExitPromptError") process.exit(0);
+}
+```
+
+The ticket described this as "menu.ts never calls `ErrorHandler.handle`" — true, but understates the impact. The `catch` has **no else branch**: any error that is not an `ExitPromptError` is caught and discarded, then the enclosing `for (;;)` immediately re-runs the same code.
+
+**Consequences, both real:**
+1. **Violates the project's own error rule** (`.claude/rules/00-architecture/0-error-handling.md`: *"No silent errors, every failure surfaces to the user"*). Every other command routes through `errorHandler.handle(error)` — `ai.ts` alone does so 7 times.
+2. **Infinite silent spin.** A deterministic failure in `InteractiveMenuUseCase.execute()` (corrupt manifest, unreadable project root) throws on every iteration, is swallowed every time, and the loop never terminates — with zero output. The user sees a hung terminal, not an error.
+
+Three throw sources reach this `catch`: the menu prompt (`InteractiveMenuUseCase.execute()`), `spawnCliCommand()`, and `waitForEnter()`. All are menu *infrastructure* failures — sub-command failures do not surface here, because `spawnCliCommand` runs them as subprocesses and returns an exit code rather than throwing.
+
+## Decisions
+
+| Decision | Why |
+| -------- | --- |
+| Route non-abort errors to `ErrorHandler.handle()` — which prints to stderr and exits 1 — rather than printing and continuing the loop | The three throw sources are all menu infrastructure, not user command failures. If the menu itself cannot run, continuing the loop just reproduces the same failure; exiting with a clear message is the honest outcome and matches every other command. `handle()` returns `never`, so it also satisfies `runMenuLoop`'s `Promise<never>` signature without a cast. |
+| Extract the decision into an exported `routeMenuError(error, errorHandler)` instead of fixing it inline | `runMenuLoop` builds its own deps (`createMenuDeps(resolveProjectRoot())`) and calls `process.exit`, so it has no unit test today and cannot get one without being made injectable — scope beyond this ticket. A small exported seam lets the *actual fixed behavior* ("a non-abort error reaches the handler rather than being discarded") be asserted directly, honoring the backlog's rule that every BUG lands with regression coverage. |

--- a/cli/src/application/commands/menu.ts
+++ b/cli/src/application/commands/menu.ts
@@ -1,6 +1,8 @@
 import readline from "node:readline";
 import { createMenuDeps } from "../../infrastructure/deps.js";
 import { resolveProjectRoot } from "../../infrastructure/project-root.js";
+import { ErrorHandler } from "../error-handler.js";
+import { CLIOutput } from "../output.js";
 import { InteractiveMenuUseCase } from "../use-cases/menu-use-case.js";
 import { spawnCliCommand } from "./shared/spawn-cli-command.js";
 
@@ -27,9 +29,22 @@ function printBanner(): void {
   process.stdout.write(BANNER);
 }
 
+/** The name inquirer gives the error it throws when the user hits Ctrl-C at a prompt. */
+const USER_ABORT_ERROR_NAME = "ExitPromptError";
+
+function isUserAbort(error: unknown): boolean {
+  return error instanceof Error && error.name === USER_ABORT_ERROR_NAME;
+}
+
+export function routeMenuError(error: unknown, errorHandler: ErrorHandler): never {
+  if (isUserAbort(error)) process.exit(0);
+  return errorHandler.handle(error);
+}
+
 export async function runMenuLoop(): Promise<never> {
   printBanner();
   const { manifestRepo, prompter } = createMenuDeps(resolveProjectRoot());
+  const errorHandler = new ErrorHandler(new CLIOutput());
   for (;;) {
     try {
       const result = await new InteractiveMenuUseCase(manifestRepo, prompter).execute();
@@ -38,7 +53,7 @@ export async function runMenuLoop(): Promise<never> {
       await waitForEnter();
       if (exitCode !== 0 && result.command[0] === "setup") process.exit(exitCode);
     } catch (error) {
-      if (error instanceof Error && error.name === "ExitPromptError") process.exit(0);
+      routeMenuError(error, errorHandler);
     }
   }
 }

--- a/cli/tests/application/commands/menu-error-routing.unit.test.ts
+++ b/cli/tests/application/commands/menu-error-routing.unit.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { routeMenuError } from "../../../src/application/commands/menu.js";
+import type { ErrorHandler } from "../../../src/application/error-handler.js";
+
+/** Makes the `never` return observable — both routing branches call process.exit. */
+class ProcessExited extends Error {
+  constructor(readonly code: number) {
+    super(`process.exit(${code})`);
+  }
+}
+
+function stubExit() {
+  return vi.spyOn(process, "exit").mockImplementation((code) => {
+    throw new ProcessExited(typeof code === "number" ? code : 0);
+  });
+}
+
+function recordingErrorHandler(): ErrorHandler & { received: unknown[] } {
+  const received: unknown[] = [];
+  return {
+    received,
+    handle(error: unknown): never {
+      received.push(error);
+      throw new ProcessExited(1);
+    },
+  } as ErrorHandler & { received: unknown[] };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("routeMenuError", () => {
+  it("exits 0 without reporting when the user aborts a prompt (Ctrl-C)", () => {
+    stubExit();
+    const errorHandler = recordingErrorHandler();
+    const abort = Object.assign(new Error("prompt aborted"), { name: "ExitPromptError" });
+
+    expect(() => routeMenuError(abort, errorHandler)).toThrow(ProcessExited);
+    try {
+      routeMenuError(abort, errorHandler);
+    } catch (err) {
+      expect((err as ProcessExited).code).toBe(0);
+    }
+    expect(errorHandler.received).toHaveLength(0);
+  });
+
+  it("reports any other error through the ErrorHandler instead of swallowing it", () => {
+    stubExit();
+    const errorHandler = recordingErrorHandler();
+    const failure = new Error("manifest is corrupt");
+
+    expect(() => routeMenuError(failure, errorHandler)).toThrow(ProcessExited);
+    expect(errorHandler.received).toEqual([failure]);
+  });
+
+  it("reports non-Error throws too, rather than treating them as an abort", () => {
+    stubExit();
+    const errorHandler = recordingErrorHandler();
+
+    expect(() => routeMenuError("boom", errorHandler)).toThrow(ProcessExited);
+    expect(errorHandler.received).toEqual(["boom"]);
+  });
+
+  it("does not treat a same-message Error as an abort — only the ExitPromptError name", () => {
+    stubExit();
+    const errorHandler = recordingErrorHandler();
+    const lookalike = new Error("ExitPromptError");
+
+    expect(() => routeMenuError(lookalike, errorHandler)).toThrow(ProcessExited);
+    expect(errorHandler.received).toEqual([lookalike]);
+  });
+});


### PR DESCRIPTION
## 🎯 What & why

`menu.ts` caught every error inside `for (;;)` and discarded anything that wasn't an `ExitPromptError`:

```ts
} catch (error) {
  if (error instanceof Error && error.name === "ExitPromptError") process.exit(0);
}
```

No else branch. A deterministic failure — corrupt manifest, unreadable project root, spawn failure — was swallowed, and the loop immediately retried it. **The result was an infinite silent spin: the user saw a hung terminal, never an error.**

The ticket described this as "menu.ts never calls `ErrorHandler.handle`", which understated it. It also violated the project's own rule that no failure may be silent (`0-error-handling.md`); every other command routes through `errorHandler.handle` — `ai.ts` alone does so 7 times.

## 🛠️ How it works

Non-abort errors now go through `ErrorHandler`: message to stderr, exit 1. Ctrl-C at a prompt still exits 0 silently, unchanged.

**Continuing the loop was considered and rejected.** All three throw sources here (`InteractiveMenuUseCase.execute()`, `spawnCliCommand`, `waitForEnter`) are menu *infrastructure* — retrying only reproduces the same failure. Sub-command failures never reach this catch, because `spawnCliCommand` runs them as subprocesses and returns an exit code rather than throwing.

The decision is extracted as an exported `routeMenuError(error, errorHandler)`. `runMenuLoop` builds its own deps (`createMenuDeps(resolveProjectRoot())`) and calls `process.exit`, so it has no unit coverage today and can't get one without being made injectable — out of scope here. The seam lets the actual fixed behavior be asserted directly, honoring the backlog's rule that every bug fix lands with regression coverage.

## 🧪 How to verify

`pnpm --filter cli test` — 2092/2092 (2088 + 4 new), tsc clean.

The 4 new tests were **verified to fail** (3 of 4) when the silent-swallow is reintroduced, so they genuinely guard the regression rather than just passing.

## ⚠️ Heads-up

`runMenuLoop` itself remains untested for the same reason it was untestable before — it isn't dependency-injected. Making it so is a separate concern, not folded in here.

Cartography item A9; planned in the (now-archived) standalone `aidd-cli` repo before the framework migration (#462).