### PR TITLE
fix(cli): drop the auth gate from self-update

### DIFF
--- a/cli/aidd_docs/tasks/2026_07/2026_07_27_e5-04-self-update-no-auth/phase-1.md
+++ b/cli/aidd_docs/tasks/2026_07/2026_07_27_e5-04-self-update-no-auth/phase-1.md
@@ -1,0 +1,51 @@
+---
+status: done
+---
+
+# Instruction: Drop the auth gate from self-update
+
+## Architecture projection
+
+> Tree of the final files. ✅ create · ✏️ modify · ❌ delete
+
+```txt
+.
+└── cli/
+    ├── src/application/commands/self-update.ts              ✏️ modify (remove auth gate)
+    ├── tests/infrastructure/adapters/
+    │   └── self-updater-adapter.integration.test.ts         ✏️ modify (unauthenticated-user guard)
+    └── tests/e2e/
+        └── command-matrix-help.e2e.test.ts                  ✏️ modify (asserted the old gate)
+```
+
+## Tasks to do
+
+### `1)` Remove the gate
+
+1. Delete `await deps.requireAuthUseCase.execute();` from `self-update.ts`.
+2. Leave everything else untouched — the `try`/`catch` + `errorHandler.handle` wrapper and all four result branches stay exactly as they are.
+3. Check whether `deps.requireAuthUseCase` is still consumed elsewhere. **It is not** — self-update was its only caller in `src/`. Left wired anyway; see plan.md Decisions for why (documented architectural fixture, `knip:production` clean).
+
+### `2)` Cover it
+
+1. Cover it where the claim actually lives. `SelfUpdateUseCase` never touched auth — the gate was in the command — so a use-case test would prove nothing. The substantive claim is that the *adapter* resolves a version with no token.
+2. Add a case to `tests/infrastructure/adapters/self-updater-adapter.integration.test.ts`: construct `SelfUpdaterAdapter` with a `tokenProvider` resolving `null`, assert `fetchLatestRelease()` still returns the version and still hits the npm dist-tags URL.
+3. This fails first if any self-update path ever becomes token-dependent again, before a user is locked out.
+
+## Test acceptance criteria
+
+| Task | Acceptance criteria |
+| ---- | ------------------------------------------------------------------------------------------------------------------------ |
+| 1    | `aidd self-update --check` on a machine with no aidd credentials reports whether a newer version exists, instead of failing with "not authenticated". |
+| 1    | `aidd self-update` (real install) likewise proceeds without credentials — the npm shell-out never used them. |
+| 1    | `grep -n "requireAuthUseCase" src/application/commands/self-update.ts` returns nothing. |
+| 2    | The adapter resolves a version with a `tokenProvider` yielding `null`. |
+| all  | `tsc --noEmit` clean, `pnpm test` (build + vitest) green. |
+
+## Correction found during implementation
+
+The plan claimed no existing test asserted the auth gate. **That was wrong.** `tests/e2e/command-matrix-help.e2e.test.ts:262` asserted exactly it: *"self-update --check exits 1 when not authenticated (requires auth)"*.
+
+Two reasons the pre-removal check missed it: the grep looked for `requireAuth`/`NotAuthenticated`, but the test names the behaviour in prose (*"not authenticated"*); and `npx vitest run` alone passed, because e2e specs execute the **built** binary — which was stale, still containing the gate. Only `pnpm test` (`pnpm build && vitest run`, what the pre-push hook runs) surfaced it.
+
+The e2e now asserts the fixed behaviour, checking the *absence* of the auth failure rather than exit 0 — `--check` performs a real npm lookup, so the exit code depends on network reachability while "not authenticated" must never appear either way.

--- a/cli/aidd_docs/tasks/2026_07/2026_07_27_e5-04-self-update-no-auth/plan.md
+++ b/cli/aidd_docs/tasks/2026_07/2026_07_27_e5-04-self-update-no-auth/plan.md
@@ -1,0 +1,41 @@
+---
+objective: "aidd self-update works without being logged in, in every mode — because nothing it does requires authentication."
+status: implemented
+---
+
+# Plan: SPIKE-E5-03 + BUG-E5-04 — self-update requires no auth
+
+## Overview
+
+| Field      | Value                                                                    |
+| ---------- | ------------------------------------------------------------------------ |
+| **Goal**   | Remove the unconditional auth gate from `self-update`, which blocks an operation that never needed a token. |
+| **Source** | `epic-E5-command-layer-safety.md` (SPIKE-E5-03, BUG-E5-04 — cartography item A10) |
+
+## Phases
+
+| #   | Phase                    | File                          |
+| --- | -------------------------- | ------------------------------ |
+| 1   | Drop the auth gate         | [`phase-1.md`](./phase-1.md) |
+
+## Spike findings (SPIKE-E5-03) — confirmed, and broader than the ticket
+
+`self-update.ts:20` calls `await deps.requireAuthUseCase.execute()` unconditionally, before `selfUpdateUseCase.execute()`. `RequireAuthUseCase` throws `NotAuthenticatedError` when no token resolves — so an unauthenticated user cannot even ask *"is there a newer version?"*.
+
+The ticket assumed only `--check`/`--dry-run` were wrongly gated. Tracing every path through `SelfUpdaterAdapter` shows **no mode needs auth at all**:
+
+| Path | Auth requirement |
+| ---- | ---------------- |
+| `resolveLatestVersion()` — the version lookup behind every mode | Hits the **npm registry**, no token. Deliberate, with a standing in-code comment: *"Version comes from npm — the registry `npm install -g` actually pulls from, reachable without a token whether the GitHub repo is public or private."* |
+| `fetchChangelog()` | Token is **optional**: `(await this.tokenProvider?.resolve()) ?? undefined`. On any failure it logs at debug level and returns `null` — designed to degrade, not to fail. |
+| `install()` | `execSync("npm install -g …")`. A shell out to the package manager; the aidd token is never involved. |
+
+So the gate blocks all four outcomes (`check-available`, `check-current`, `dry-run`, `updated`) on a credential none of them consume.
+
+## Decisions
+
+| Decision | Why |
+| -------- | --- |
+| Remove the auth call entirely rather than skipping it only for `--check`/`--dry-run` | User-confirmed after the spike evidence was presented. Gating only the install path would encode a condition the code proves unnecessary — `install()` is `execSync("npm install -g")` and consumes no aidd token either. A conditional guarding nothing is worse than no conditional. |
+| Treat this as a bug fix, not a policy change | The spike found no mechanism by which the token affects any self-update outcome, so removing it changes no security boundary — it only stops rejecting users the operation never depended on. If a *product* decision to restrict updates to authenticated users is wanted later, it needs a real mechanism (licence check, private registry), not a gate in front of a public npm fetch. |
+| **Leave `requireAuthUseCase` wired in `deps.ts` even though it now has zero consumers** — flagged, not removed | Consequence discovered after the removal: `self-update.ts` was its *only* caller in `src/`, so `RequireAuthUseCase` is now unconsumed production wiring. Not deleted here for three reasons: it is a documented architectural fixture (`aidd_docs/memory/auth.md`: *"RequireAuthUseCase — single source of auth validation. Never duplicate auth checks across commands or use-cases"*), an `auth.ts` command exists that future auth-requiring work would route through it, and the project's own dead-code gate (`pnpm knip:production`) passes clean. Deleting an auth primitive as a side effect of a self-update bug fix is the wrong blast radius — surfaced for a separate decision instead. |

--- a/cli/src/application/commands/self-update.ts
+++ b/cli/src/application/commands/self-update.ts
@@ -17,8 +17,6 @@ export function registerSelfUpdateCommand(program: Command): void {
       try {
         const deps = await createDeps(projectRoot, { verbose }, output);
 
-        await deps.requireAuthUseCase.execute();
-
         const result = await deps.selfUpdateUseCase.execute({
           check: cmdOptions.check,
           dryRun: cmdOptions.dryRun,

--- a/cli/tests/e2e/command-matrix-help.e2e.test.ts
+++ b/cli/tests/e2e/command-matrix-help.e2e.test.ts
@@ -259,14 +259,13 @@ describe.concurrent("Command Matrix: Globals", () => {
     }
   });
 
-  it("self-update --check exits 1 when not authenticated (requires auth)", async () => {
-    // NOTE from matrix: self-update requires valid auth; expected in test env.
-    // Flag is --check (not --check-only as in task spec — verified against actual CLI).
+  it("self-update --check works without authentication", async () => {
+    // --check performs a real npm lookup, so the exit code tracks network reachability;
+    // assert only that authentication is never demanded.
     const { projectDir, fakeHome, cleanup } = await createTestEnv("global-self-update-check");
     try {
-      const { stderr, exitCode } = await runCli(["self-update", "--check"], projectDir, fakeHome);
-      expect(exitCode).toBe(1);
-      expect(stderr).toMatch(/[Nn]ot authenticated|auth login/);
+      const { stderr } = await runCli(["self-update", "--check"], projectDir, fakeHome);
+      expect(stderr).not.toMatch(/[Nn]ot authenticated|auth login/);
     } finally {
       await cleanup();
     }

--- a/cli/tests/infrastructure/adapters/self-updater-adapter.integration.test.ts
+++ b/cli/tests/infrastructure/adapters/self-updater-adapter.integration.test.ts
@@ -88,6 +88,23 @@ describe("self-updater-adapter — fetchLatestRelease", () => {
     expect(release).toEqual({ version: "5.1.2", changelog: null });
   });
 
+  it("resolves the latest version for an unauthenticated user (token provider yields null)", async () => {
+    const calls: GetCall[] = [];
+    const http = fakeHttp(
+      {
+        [NPM_DIST_TAGS_URL]: () => jsonResponse({ latest: "5.1.2" }),
+        [GH_TAG_URL]: () => jsonResponse({ body: "Release notes" }),
+      },
+      calls
+    );
+    const tokenProvider = { resolve: async () => null };
+
+    const release = await new SelfUpdaterAdapter(http, { tokenProvider }).fetchLatestRelease();
+
+    expect(release.version).toBe("5.1.2");
+    expect(calls.some((c) => c.url === NPM_DIST_TAGS_URL)).toBe(true);
+  });
+
   it("traces the reason on the debug channel when the changelog fetch fails", async () => {
     const debug = vi.fn();
     const http = fakeHttp({


### PR DESCRIPTION
## 🎯 What & why

`self-update.ts` called `requireAuthUseCase.execute()` unconditionally, so an unauthenticated user couldn't even ask *"is there a newer version?"* — it failed with `NotAuthenticatedError` before reaching the use-case.

## 🛠️ How it works

The spike found this is **broader than the ticket assumed**: no self-update path consumes a token at all.

| Path | Auth requirement |
|---|---|
| `resolveLatestVersion()` | npm registry, no token — deliberate, with a standing in-code comment: *"reachable without a token whether the GitHub repo is public or private"* |
| `fetchChangelog()` | token **optional** (`tokenProvider?.resolve() ?? undefined`); on failure logs debug and returns `null` |
| `install()` | `execSync("npm install -g …")` — the aidd token is never involved |

The gate blocked all four outcomes on a credential none of them use. The ticket asked only for `--check`/`--dry-run` to skip it; removing it outright was confirmed after presenting this evidence, since gating only the install path would encode a condition the code disproves.

## 🧪 How to verify

`pnpm --filter cli test` — 2093/2093, tsc clean, knip clean.

Covered in the two places the claims actually live: the adapter integration test pins that a `tokenProvider` yielding `null` still resolves a version, and the e2e that asserted *"exits 1 when not authenticated"* now asserts the opposite.

## ⚠️ Heads-up

**I initially claimed no test asserted the gate. That was wrong** — `command-matrix-help.e2e.test.ts:262` asserted exactly it. Two reasons it was missed: the grep looked for `requireAuth`/`NotAuthenticated` while the test names the behaviour in prose, and `npx vitest run` alone *passes*, because e2e specs execute the **built** binary and the build was stale. Only `pnpm test` (`build && vitest run`, what pre-push runs) surfaced it. Worth knowing generally: for anything e2e-visible, `npx vitest run` on its own can be green against stale output.

The updated e2e checks for the *absence* of the auth failure rather than exit 0, since `--check` makes a real npm call whose exit code depends on network reachability.

**Left as-is and flagged:** self-update was `requireAuthUseCase`'s only caller, so it is now unconsumed wiring in `deps.ts`. Not deleted — it's a documented architectural fixture (`memory/auth.md`: *"single source of auth validation"*), an `auth.ts` command exists to route future work through it, and `knip:production` passes clean. Removing an auth primitive as a side effect of this fix would be the wrong blast radius; worth a separate decision.

Cartography item A10.