### PR TITLE
fix(ci): promote.yml recognizes squash-merged back-merges as sync boundaries

### DIFF
--- a/.github/workflows/back-merge.yml
+++ b/.github/workflows/back-merge.yml
@@ -58,6 +58,10 @@ jobs:
             BRANCH="back-merge/main-to-next-${{ github.run_id }}"
             git checkout -b "$BRANCH" origin/main
             git push origin "$BRANCH"
+            # promote.yml matches this exact title prefix to recognize a
+            # squash-merged conflict resolution as a sync boundary (this repo
+            # disallows merge-commit PRs, so this can't land as a real merge
+            # commit). Keep both in sync if you change it.
             gh pr create --base next --head "$BRANCH" \
               --title "chore: back-merge main into next (conflicts)" \
               --body "Automated back-merge hit conflicts (CHANGELOG / manifest / version files). Resolve manually, then merge into next." \

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -50,14 +50,42 @@ jobs:
           BRANCH="promote/next-to-main-linear"
           git switch -C "$BRANCH" origin/main
 
-          mapfile -t MERGES < <(git rev-list --first-parent --merges --reverse origin/main..origin/next)
-          if [ "${#MERGES[@]}" -ge 2 ]; then
-            START="${MERGES[$((${#MERGES[@]} - 2))]}"
+          # A "sync commit" marks a point where main's history was already
+          # folded into next by back-merge.yml, so it (and everything before
+          # it) must NOT be replayed onto main again. back-merge.yml lands a
+          # sync two ways:
+          #   - no conflicts: a direct-pushed real merge commit (2 parents)
+          #   - conflicts: a PR merged by squash (this repo disallows
+          #     merge-commit PRs), whose subject is stamped verbatim from
+          #     back-merge.yml's fixed PR title
+          # Both must count as boundaries, or a squash sync gets mistaken for
+          # genuine next-only work and cherry-picked back onto main, colliding
+          # with content main already has. Keep the title prefix below in
+          # sync with back-merge.yml's `gh pr create --title`.
+          is_sync_commit() {
+            git rev-parse --verify -q "$1^2" >/dev/null 2>&1 && return 0
+            local subject
+            subject="$(git log -1 --format=%s "$1")"
+            [[ "$subject" == "chore: back-merge main into next"* ]]
+          }
+
+          mapfile -t CANDIDATES < <(git rev-list --first-parent --reverse origin/main..origin/next)
+          SYNCS=()
+          for c in "${CANDIDATES[@]}"; do
+            is_sync_commit "$c" && SYNCS+=("$c")
+          done
+
+          if [ "${#SYNCS[@]}" -ge 2 ]; then
+            START="${SYNCS[$((${#SYNCS[@]} - 2))]}"
           else
             START="origin/main"
           fi
 
-          mapfile -t COMMITS < <(git rev-list --first-parent --reverse --no-merges "${START}..origin/next")
+          COMMITS=()
+          while IFS= read -r c; do
+            is_sync_commit "$c" || COMMITS+=("$c")
+          done < <(git rev-list --first-parent --reverse "${START}..origin/next")
+
           if [ "${#COMMITS[@]}" -eq 0 ]; then
             echo "No commits to promote."
             exit 0


### PR DESCRIPTION
## Problem

`back-merge.yml`'s conflict path opens a PR that can only be squash-merged (this repo disallows merge-commit PRs), landing on `next` as a single-parent commit invisible to `promote.yml`'s `git rev-list --merges` boundary detection. The next "Promote next to main" run would treat already-synced main content as genuine next-only work and try to cherry-pick it back onto main, colliding with content main already has.

Confirmed by simulation: with the two real squash-merged back-merge PRs already in `next`'s history (#454, #499, #503 as of writing), the old logic found 0 merge commits and defaulted to promoting everything since `main`, including those redundant syncs.

## Fix

- `promote.yml`: detect a sync commit either by real merge (2 parents) or by matching `back-merge.yml`'s fixed PR-title prefix, and exclude those from the cherry-pick set the same way real merges already were.
- `back-merge.yml`: added a comment cross-referencing the title-prefix contract so a future edit doesn't silently break `promote.yml`'s detection.
- Repo setting `squash_merge_commit_title` flipped from `COMMIT_OR_PR_TITLE` to `PR_TITLE` (separately, already applied) — closes the edge case where a single-commit back-merge PR would have had GitHub use that commit's own message instead of the PR title, defeating the prefix match. Verified safe against 35 recent merged PRs (0 divergence between PR title and single-commit message).

## Verification

- Dry-run of the new boundary logic against real repo history: correctly finds all 3 sync commits, excludes them, and resolves to the right set of genuine next-only commits to promote.
- Full local cherry-pick simulation onto a `main`-based branch, tree-compared against `next`.
- Not fully bulletproof by design, and doesn't need to be: `promote.yml` only pushes when the resulting tree byte-matches `origin/next` — any detection error fails loud (empty/conflicting cherry-pick or a tree mismatch), never silently puts wrong content on `main`.
- Known residual: the real promote run will still hit a `cli/pnpm-lock.yaml` conflict during the actual cherry-pick (multiple dependabot lockfile bumps collide outside their original context) — accepted as a manual-resolution-at-promote-time cost, not fixed here.
- Full local build/typecheck/test suite green (2092/2092 tests).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>