### PR TITLE
test(cli): drop ticket and point-in-time references from test comments

### DIFF
--- a/cli/tests/application/use-cases/restore-all-use-case.unit.test.ts
+++ b/cli/tests/application/use-cases/restore-all-use-case.unit.test.ts
@@ -82,7 +82,7 @@ function countingReader(fs: Deps["fs"]): {
   return { reader, count: () => calls };
 }
 
-describe("RestoreAllUseCase — plugin materialization (BUG-E3-02 / A3)", () => {
+describe("RestoreAllUseCase — plugin materialization", () => {
   it("restores a corrupted plugin file with exactly one materialization call (translate-mode: claude)", async () => {
     const deps = await buildUnitDeps(PROJECT_ROOT);
     await initAndInstall(deps, PROJECT_ROOT, "claude");
@@ -103,13 +103,11 @@ describe("RestoreAllUseCase — plugin materialization (BUG-E3-02 / A3)", () => 
   });
 
   it("restores a corrupted plugin file with exactly one materialization call (cursor — installScope:user tool)", async () => {
-    // A local-source install never hits restoreViaBuiltTree (that path requires
-    // plugin.marketplace to be set — see apply-plugin-files-use-case.ts), so this
-    // still exercises restoreViaTranslate like claude, just for a second, differently
-    // -configured AI tool (installScope:"user", pluginsDir:""). It's not the true
-    // built-tree double-*write* path (that needs a marketplace-sourced install, out
-    // of scope here), but it does independently confirm the collapse-to-one-pass
-    // fix isn't accidentally claude-specific.
+    // A local-source install never reaches restoreViaBuiltTree — that path requires
+    // plugin.marketplace to be set (see apply-plugin-files-use-case.ts) — so this exercises
+    // restoreViaTranslate, same as claude, but for a differently configured tool
+    // (installScope:"user", pluginsDir:""). Confirms single-pass materialization is not
+    // claude-specific; the true built-tree write path needs a marketplace-sourced install.
     const deps = await buildUnitDeps(PROJECT_ROOT);
     await initAndInstall(deps, PROJECT_ROOT, "cursor");
     await seedFromDirectory(deps.fs, PLUGIN_FIXTURE, { useAbsolutePaths: true });
@@ -174,13 +172,10 @@ describe("RestoreAllUseCase — plugin materialization (BUG-E3-02 / A3)", () => 
   });
 
   it("interactive restore with an explicit file selection also skips unselected plugin files (translate-mode)", async () => {
-    // Plugin drift isn't offered by the interactive picker at all (StatusUseCase's
-    // pluginDrift is never read by promptForFiles) — so once the user picks ANY
-    // specific regular file, ctx.fileFilter becomes active and every plugin path
-    // fails to match it (it was never a selectable option). This mirrors what
-    // ai.ts/ide.ts's `restore <file>` already does today (ctx.fileFilter already
-    // reached plugin restore for THAT path before this fix) — this test proves the
-    // global `aidd restore` command now behaves the same way, consistently.
+    // The interactive picker never offers plugin drift (promptForFiles does not read
+    // StatusUseCase's pluginDrift), so once the user picks any specific regular file,
+    // ctx.fileFilter is active and no plugin path can match it. Same behaviour as
+    // ai.ts/ide.ts's `restore <file>`.
     const deps = await buildUnitDeps(PROJECT_ROOT);
     await initAndInstall(deps, PROJECT_ROOT, "claude");
     await installTool(deps, PROJECT_ROOT, "vscode");
@@ -197,12 +192,11 @@ describe("RestoreAllUseCase — plugin materialization (BUG-E3-02 / A3)", () => 
 
     // User selects only the regular vscode file from the drifted-files checkbox
     // (StatusUseCase reports relativePath, not the absolute path). Whether
-    // keybindings.json itself is actually repaired isn't asserted here: RestoreAllUseCase
-    // never supplies frameworkPath to RestoreUseCase, so CONFIG_REFS-driven regular-file
-    // content can't regenerate through this path at all — a separate, pre-existing gap,
-    // out of scope for BUG-E3-02. What this test proves is narrower and in scope: making
-    // ANY explicit selection turns fileFilter on, and once on, it excludes every plugin
-    // path (never offered as a choice), where pre-fix Pass 2 ignored fileFilter entirely.
+    // Whether keybindings.json is itself repaired is not asserted: RestoreAllUseCase never
+    // supplies frameworkPath to RestoreUseCase, so CONFIG_REFS-driven content cannot
+    // regenerate through this path at all. What is asserted is narrower: any explicit
+    // selection turns fileFilter on, and once on it excludes every plugin path, since a
+    // plugin file is never offered as a choice.
     const prompter = new ScriptedPrompter([
       ScriptedPrompter.answer.checkbox([".vscode/keybindings.json"]),
     ]);

--- a/cli/tests/application/use-cases/restore-use-case.unit.test.ts
+++ b/cli/tests/application/use-cases/restore-use-case.unit.test.ts
@@ -191,7 +191,7 @@ describe("restore", () => {
     expect(cursorContent).toBe('{"modified": true}');
   });
 
-  it("toolIds filter also scopes plugin restore — does not leak to other AI tools (BUG-E3-02 / A2)", async () => {
+  it("toolIds filter also scopes plugin restore — does not leak to other AI tools", async () => {
     const deps = await buildUnitDeps(PROJECT_ROOT);
     await initProject(deps, PROJECT_ROOT);
     await installTool(deps, PROJECT_ROOT, "claude");
@@ -217,7 +217,7 @@ describe("restore", () => {
     expect(deps.fs.getFile(codexPluginFile)).toBe("CORRUPTED CODEX");
   });
 
-  it("ide restore never touches AI plugin files, scoped or unscoped (BUG-E3-02 / A2) — IDE_TOOL_IDS has a single member so this covers both", async () => {
+  it("ide restore never touches AI plugin files, scoped or unscoped", async () => {
     const deps = await buildUnitDeps(PROJECT_ROOT);
     await initProject(deps, PROJECT_ROOT);
     await installTool(deps, PROJECT_ROOT, "vscode");

--- a/cli/tests/application/use-cases/shared/ensure-built-marketplace-use-case.integration.test.ts
+++ b/cli/tests/application/use-cases/shared/ensure-built-marketplace-use-case.integration.test.ts
@@ -216,13 +216,11 @@ describe("EnsureBuiltMarketplaceUseCase", () => {
   });
 });
 
-// BUG-E2-01: deps.ts hardcodes force:true for this rebuild path because outDir is always
-// builtMarketplaceDir() — an aidd-owned disposable cache, never a user-owned directory. A
-// collision here only means "the cache from a previous build already exists" and should be
-// overwritten, not treated as a destructive overwrite of user data. This pins that decision
-// with a real FlatBuildStrategy (not the fake buildFor stub used above), so it fails if
-// force is ever flipped to false here, or if outDir stops being cache-only.
-describe("force behavior at the cache-rebuild path (BUG-E2-01)", () => {
+// outDir here is always builtMarketplaceDir() — an aidd-owned disposable cache, never a
+// user directory — so a collision just means "a previous build is still there" and must be
+// overwritten. Uses a real FlatBuildStrategy rather than the fake buildFor stub above, so it
+// fails if force is flipped to false or outDir stops being cache-only.
+describe("force behavior at the cache-rebuild path", () => {
   it("overwrites a colliding file already present in the build cache instead of throwing FlatTargetExistsError", async () => {
     const memFs = new InMemoryFileAdapter();
     await seedFromDirectory(memFs, FIXTURE_DIR, { useAbsolutePaths: true });

--- a/cli/tests/domain/tools/registry-conformance.unit.test.ts
+++ b/cli/tests/domain/tools/registry-conformance.unit.test.ts
@@ -22,14 +22,14 @@ import {
 /**
  * Conformance suite for the AiTool contract.
  *
- * Every assertion iterates the registry rather than a hardcoded list — that is the point:
- * adding a tool file automatically subjects it to every rule below, so forgetting to add
- * that tool to a parallel list somewhere else fails a test instead of misbehaving at runtime.
+ * Every assertion iterates the registry rather than a hardcoded list, so adding a tool file
+ * automatically subjects it to all of them: omitting that tool from a parallel list elsewhere
+ * fails a test instead of misbehaving at runtime.
  *
- * Scope note: the probe tables (plugin-format.ts) and the build registry (deps.ts) keep
- * their literal entries by design — "a format aidd can read" and "a tool aidd installs into"
- * are distinct concepts that merely coincide today. These tests guard the agreement between
- * them rather than collapsing one into the other.
+ * The probe tables (plugin-format.ts) and the build registry (deps.ts) keep their own literal
+ * entries — "a format aidd can read" and "a tool aidd installs into" are distinct concepts
+ * that happen to share members. These assertions check the two agree, not that one derives
+ * from the other.
  */
 
 const registeredAiTools: [string, AiTool<unknown>][] = [


### PR DESCRIPTION
## 🎯 What & why

Test names and comments carried backlog identifiers (`BUG-E2-01`, `BUG-E3-02`, `A2`/`A3`) and phrasing anchored to a moment in time — *"before this fix"*, *"the collapse-to-one-pass fix"*, *"Scope note"*.

Both rot. The identifiers point at a backlog that isn't tracked in this repo, so they're unresolvable for any future reader. And *"before this fix"* stops meaning anything the moment the fix is history — which it already is.

## 🛠️ How it works

Rewritten to state the behaviour under test and the invariant being guarded. Where a comment carried a genuinely durable fact — why a local-source install never reaches `restoreViaBuiltTree`, why `PluginFormat` and `AiToolId` only *look* interchangeable — that fact is kept, stripped of the historical framing. Git history already holds when and why each line changed.

Four files:
- `restore-all-use-case.unit.test.ts` — describe name + 2 comment blocks
- `restore-use-case.unit.test.ts` — 2 test names
- `ensure-built-marketplace-use-case.integration.test.ts` — describe name + header comment
- `registry-conformance.unit.test.ts` — header comment

## 🧪 How to verify

`pnpm --filter cli test` — 2092/2092. Comments and test names only; no test logic touched, no assertion changed.

## ⚠️ Heads-up

Two older instances of the same pattern were left alone, since they predate this work and aren't mine to rewrite here — say the word if you want them included:
- `plugin-add-use-case.unit.test.ts:515` — *"Before this fix, ModeAMarketplaceTranslator bypassed the guard."*
- `command-matrix-plugin.e2e.test.ts:124` — *"plugin doctor used to gate on the FULL …"*