### PR TITLE
fix(cli): move marketplace refresh --force cache clear into its use-case

### DIFF
--- a/cli/aidd_docs/tasks/2026_07/2026_07_27_e5-08-refresh-force-layering/phase-1.md
+++ b/cli/aidd_docs/tasks/2026_07/2026_07_27_e5-08-refresh-force-layering/phase-1.md
@@ -1,0 +1,58 @@
+---
+status: done
+---
+
+# Instruction: Move the --force cache clear into the use-case
+
+## Architecture projection
+
+> Tree of the final files. ✅ create · ✏️ modify · ❌ delete
+
+```txt
+.
+└── cli/
+    ├── src/
+    │   ├── application/use-cases/marketplace/
+    │   │   └── marketplace-refresh-use-case.ts        ✏️ modify (force option + cache dep)
+    │   ├── application/commands/marketplace.ts         ✏️ modify (pass the flag, drop the port call)
+    │   └── infrastructure/deps.ts                      ✏️ modify (inject cache, drop it from Deps)
+    └── tests/application/use-cases/marketplace/
+        ├── marketplace-refresh-use-case.unit.test.ts   ✏️ modify (new ctor arg + force coverage)
+        └── marketplace-refresh-progress.unit.test.ts   ✏️ modify (new ctor arg)
+```
+
+## Tasks to do
+
+### `1)` Teach the use-case about `force`
+
+1. Add `force?: boolean` to `MarketplaceRefreshOptions`, documented as "clear the cached copy before re-fetching".
+2. Add `private readonly cache: MarketplaceCachePort` to the constructor, positioned **before** the existing `logger?`/`fs?` optionals.
+3. At the top of `execute()`, before the target loop: `if (options.force) await this.cache.clear(options.name);` — ordering now enforced by the use-case rather than by the caller.
+
+### `2)` Make the command a pass-through
+
+1. Delete the `if (cmdOptions.force) { await deps.marketplaceCache.clear(name); }` block.
+2. Pass `force: cmdOptions.force` into `marketplaceRefreshUseCase.execute({ projectRoot, name, force })`.
+
+### `3)` Rewire deps
+
+1. Pass `marketplaceCache` into `new MarketplaceRefreshUseCase(...)` at its new position.
+2. Remove `marketplaceCache` from the `Deps` interface and from the returned object — internal wiring only now.
+
+### `4)` Update and extend the tests
+
+1. Add the new constructor argument at the 4 test sites (`tsc` lists them).
+2. Add coverage for the flag itself, which was previously unreachable from the use-case:
+   - `force: true` → `cache.clear` called once with the requested name, **before** any fetch
+   - `force: false`/absent → `cache.clear` never called
+   - `force: true` with no `name` → `clear(undefined)`, i.e. all marketplaces
+
+## Test acceptance criteria
+
+| Task | Acceptance criteria |
+| ---- | ------------------------------------------------------------------------------------------------------------------------ |
+| 1-3  | `aidd marketplace refresh --force` still clears before re-fetching; without the flag the cache is left alone. Same observable behaviour as before. |
+| 2    | `grep -n "marketplaceCache" src/application/commands/marketplace.ts` returns nothing. |
+| 3    | `grep -rn "deps.marketplaceCache" src/` returns nothing — the port is no longer on the public `Deps` surface. |
+| 4    | The force-path tests fail if the `clear` call is removed from the use-case. |
+| all  | `tsc --noEmit` clean, `pnpm test` green. |

--- a/cli/aidd_docs/tasks/2026_07/2026_07_27_e5-08-refresh-force-layering/plan.md
+++ b/cli/aidd_docs/tasks/2026_07/2026_07_27_e5-08-refresh-force-layering/plan.md
@@ -1,0 +1,47 @@
+---
+objective: "marketplace refresh --force clears the cache through its use-case, so the command layer holds no refresh logic of its own."
+status: implemented
+---
+
+# Plan: SPIKE-E5-07 + BUG-E5-08 — refresh --force goes through the use-case
+
+## Overview
+
+| Field      | Value                                                             |
+| ---------- | ----------------------------------------------------------------- |
+| **Goal**   | Move the `--force` cache clear out of `marketplace.ts` and into `MarketplaceRefreshUseCase`. |
+| **Source** | `epic-E5-command-layer-safety.md` (SPIKE-E5-07, BUG-E5-08 — cartography item A14) |
+
+## Phases
+
+| #   | Phase                            | File                          |
+| --- | ---------------------------------- | ------------------------------ |
+| 1   | Move the cache clear into the use-case | [`phase-1.md`](./phase-1.md) |
+
+## Spike findings (SPIKE-E5-07) — confirmed
+
+`marketplace.ts:143-145`:
+
+```ts
+if (cmdOptions.force) {
+  await deps.marketplaceCache.clear(name);
+}
+const { results, failedCount } = await deps.marketplaceRefreshUseCase.execute({ projectRoot, name });
+```
+
+The command reaches straight into a port (`MarketplaceCachePort`) and performs a step of the refresh operation itself, instead of expressing it as an option on the use-case. That contradicts the project's layering rule — commands are wiring, orchestration belongs to use-cases — and it means the `--force` semantics are invisible to anyone reading `MarketplaceRefreshUseCase`.
+
+**Two consequences beyond style:**
+1. `--force` is untestable at the use-case level. Every existing refresh test constructs the use-case directly, so none of them can exercise the flag; it is only reachable through the CLI.
+2. Order matters and is currently implicit: the clear must happen *before* the fetch loop. Nothing in the use-case enforces or documents that.
+
+Related, not a defect: `fetchSource()` already passes `forceRefresh: true` unconditionally, so `--force` is specifically about **removing the cached directory first**, not about re-fetching. The two are different operations and the flag name only reads correctly once the clear lives beside the fetch.
+
+`deps.marketplaceCache` has exactly one consumer in `src/` — this command.
+
+## Decisions
+
+| Decision | Why |
+| -------- | --- |
+| Add `MarketplaceCachePort` as a **required** constructor dependency, not an optional one | The use-case's existing optionals (`logger?`, `fs?`) are genuine degradations — refresh still works without them. The cache is not: with `force: true` and no cache, the option would silently do nothing, which is the class of bug this epic keeps finding. Required means `tsc` enumerates the 4 construction sites instead of letting one slip through as `undefined`. |
+| Drop `marketplaceCache` from the exported `Deps` interface | Once the command stops calling it, its only consumer is `deps.ts` itself, wiring it into the use-case. Leaving it on the public surface would invite the next command to reach past the use-case the same way. It stays constructed internally. |

--- a/cli/src/application/commands/marketplace.ts
+++ b/cli/src/application/commands/marketplace.ts
@@ -140,12 +140,10 @@ export function registerMarketplaceCommand(program: Command): void {
       const errorHandler = new ErrorHandler(output);
       try {
         const deps = await createDeps(projectRoot, { verbose }, output);
-        if (cmdOptions.force) {
-          await deps.marketplaceCache.clear(name);
-        }
         const { results, failedCount } = await deps.marketplaceRefreshUseCase.execute({
           projectRoot,
           name,
+          force: cmdOptions.force,
         });
         await deps.marketplaceSyncSettingsUseCase.execute({ projectRoot });
         for (const r of results)

--- a/cli/src/application/use-cases/marketplace/marketplace-refresh-use-case.ts
+++ b/cli/src/application/use-cases/marketplace/marketplace-refresh-use-case.ts
@@ -8,6 +8,7 @@ import {
 } from "../../../domain/models/plugin-catalog.js";
 import type { FileReader } from "../../../domain/ports/file-reader.js";
 import type { Logger } from "../../../domain/ports/logger.js";
+import type { MarketplaceCachePort } from "../../../domain/ports/marketplace-cache.js";
 import type { MarketplaceRegistry } from "../../../domain/ports/marketplace-registry.js";
 import type { PluginCatalogRepository } from "../../../domain/ports/plugin-catalog-repository.js";
 import type { FetchMarketplaceSourceUseCase } from "../shared/fetch-marketplace-source-use-case.js";
@@ -15,6 +16,7 @@ import type { FetchMarketplaceSourceUseCase } from "../shared/fetch-marketplace-
 export interface MarketplaceRefreshOptions {
   projectRoot: string;
   name?: string;
+  force?: boolean;
 }
 
 export interface RefreshEntryResult {
@@ -35,11 +37,13 @@ export class MarketplaceRefreshUseCase {
     private readonly catalogRepo: PluginCatalogRepository,
     private readonly registry: MarketplaceRegistry,
     private readonly fetchMarketplaceSource: FetchMarketplaceSourceUseCase,
+    private readonly cache: MarketplaceCachePort,
     private readonly logger?: Logger,
     private readonly fs?: FileReader
   ) {}
 
   async execute(options: MarketplaceRefreshOptions): Promise<MarketplaceRefreshResult> {
+    if (options.force) await this.cache.clear(options.name);
     const all = await this.registry.list(options.projectRoot);
     const targets = options.name ? all.filter((m) => m.name === options.name) : all;
     const results: RefreshEntryResult[] = [];

--- a/cli/src/infrastructure/deps.ts
+++ b/cli/src/infrastructure/deps.ts
@@ -146,7 +146,6 @@ interface Deps {
   pluginCatalogRepository: PluginCatalogRepository;
   pluginFetcher: PluginFetcher;
   pluginDistributionReader: PluginDistributionReader;
-  marketplaceCache: MarketplaceCachePort;
   marketplaceRegistry: MarketplaceRegistry;
   marketplaceTrustStore: MarketplaceTrustStore;
   pluginAddUseCase: PluginAddUseCase;
@@ -435,6 +434,7 @@ export async function createDeps(
     pluginCatalogRepository,
     marketplaceRegistry,
     fetchMarketplaceSource,
+    marketplaceCache,
     logger,
     fs
   );
@@ -680,7 +680,6 @@ export async function createDeps(
     pluginCatalogRepository,
     pluginFetcher,
     pluginDistributionReader,
-    marketplaceCache,
     marketplaceRegistry,
     marketplaceTrustStore,
     pluginAddUseCase,

--- a/cli/tests/application/use-cases/marketplace/marketplace-refresh-progress.unit.test.ts
+++ b/cli/tests/application/use-cases/marketplace/marketplace-refresh-progress.unit.test.ts
@@ -9,6 +9,7 @@ import { CapturingLogger } from "../../../helpers/ports/capturing-logger.js";
 import { DeterministicHasher } from "../../../helpers/ports/deterministic-hasher.js";
 import { FixturePluginFetcher } from "../../../helpers/ports/fixture-plugin-fetcher.js";
 import { InMemoryFileAdapter } from "../../../helpers/ports/in-memory-file-adapter.js";
+import { InMemoryMarketplaceCache } from "../../../helpers/ports/in-memory-marketplace-cache.js";
 import { InMemoryMarketplaceRegistry } from "../../../helpers/ports/in-memory-marketplace-registry.js";
 import { seedFromDirectory } from "../../../helpers/ports/seed-from-directory.js";
 
@@ -29,6 +30,7 @@ async function buildUseCase() {
     new PluginCatalogRepositoryAdapter(fs),
     registry,
     fetchMarketplaceSource,
+    new InMemoryMarketplaceCache(),
     logger
   );
   return { useCase, registry, logger };

--- a/cli/tests/application/use-cases/marketplace/marketplace-refresh-use-case.unit.test.ts
+++ b/cli/tests/application/use-cases/marketplace/marketplace-refresh-use-case.unit.test.ts
@@ -9,6 +9,7 @@ import { PluginCatalogRepositoryAdapter } from "../../../../src/infrastructure/a
 import { DeterministicHasher } from "../../../helpers/ports/deterministic-hasher.js";
 import { FixturePluginFetcher } from "../../../helpers/ports/fixture-plugin-fetcher.js";
 import { InMemoryFileAdapter } from "../../../helpers/ports/in-memory-file-adapter.js";
+import { InMemoryMarketplaceCache } from "../../../helpers/ports/in-memory-marketplace-cache.js";
 import { InMemoryMarketplaceRegistry } from "../../../helpers/ports/in-memory-marketplace-registry.js";
 import { seedFromDirectory } from "../../../helpers/ports/seed-from-directory.js";
 
@@ -29,13 +30,55 @@ async function buildUseCase() {
   };
   const pluginFetcher = new FixturePluginFetcher(fetchers);
   const fetchMarketplaceSource = new FetchMarketplaceSourceUseCase(pluginFetcher);
+  const cache = new InMemoryMarketplaceCache();
   const useCase = new MarketplaceRefreshUseCase(
     new PluginCatalogRepositoryAdapter(fs),
     registry,
-    fetchMarketplaceSource
+    fetchMarketplaceSource,
+    cache
   );
-  return { useCase, registry };
+  return { useCase, registry, cache };
 }
+
+describe("MarketplaceRefreshUseCase — force", () => {
+  async function withRegistered(name: string) {
+    const built = await buildUseCase();
+    await built.registry.save(
+      PROJECT_ROOT,
+      Marketplace.create({
+        name,
+        source: { kind: "local", path: VALID_FIXTURE },
+        scope: "project",
+        addedAt: "2026-04-29T10:00:00.000Z",
+      })
+    );
+    return built;
+  }
+
+  it("clears the named marketplace's cache before re-fetching", async () => {
+    const { useCase, cache } = await withRegistered("awesome");
+
+    await useCase.execute({ projectRoot: PROJECT_ROOT, name: "awesome", force: true });
+
+    expect(cache.clearCalls).toEqual(["awesome"]);
+  });
+
+  it("clears every cached marketplace when no name is given", async () => {
+    const { useCase, cache } = await withRegistered("awesome");
+
+    await useCase.execute({ projectRoot: PROJECT_ROOT, force: true });
+
+    expect(cache.clearCalls).toEqual([undefined]);
+  });
+
+  it("leaves the cache untouched without the flag", async () => {
+    const { useCase, cache } = await withRegistered("awesome");
+
+    await useCase.execute({ projectRoot: PROJECT_ROOT, name: "awesome" });
+
+    expect(cache.clearCalls).toEqual([]);
+  });
+});
 
 describe("MarketplaceRefreshUseCase", () => {
   it("refreshes a registered marketplace and updates lastFetched", async () => {
@@ -177,6 +220,7 @@ describe("MarketplaceRefreshUseCase", () => {
         new PluginCatalogRepositoryAdapter(fs),
         registry,
         fetchMarketplaceSource,
+        new InMemoryMarketplaceCache(),
         logger,
         fs
       );
@@ -220,6 +264,7 @@ describe("MarketplaceRefreshUseCase", () => {
         new PluginCatalogRepositoryAdapter(fs),
         registry,
         fetchMarketplaceSource,
+        new InMemoryMarketplaceCache(),
         logger,
         fs
       );

--- a/cli/tests/helpers/ports/in-memory-marketplace-cache.ts
+++ b/cli/tests/helpers/ports/in-memory-marketplace-cache.ts
@@ -6,6 +6,8 @@ import type { MarketplaceCachePort } from "../../../src/domain/ports/marketplace
  */
 export class InMemoryMarketplaceCache implements MarketplaceCachePort {
   private readonly entries = new Map<string, MarketplaceCacheEntry>();
+  /** Every clear() argument in call order, so callers can assert whether and how it was cleared. */
+  readonly clearCalls: (string | undefined)[] = [];
 
   constructor(seed: MarketplaceCacheEntry[] = []) {
     for (const entry of seed) {
@@ -18,6 +20,7 @@ export class InMemoryMarketplaceCache implements MarketplaceCachePort {
   }
 
   async clear(name?: string): Promise<void> {
+    this.clearCalls.push(name);
     if (name !== undefined) {
       this.entries.delete(name);
     } else {


### PR DESCRIPTION
## 🎯 What & why

The refresh command reached straight into a port to perform part of the refresh itself:

```ts
if (cmdOptions.force) await deps.marketplaceCache.clear(name);
await deps.marketplaceRefreshUseCase.execute({ projectRoot, name });
```

Commands are wiring; orchestration belongs to the use-case. Two practical consequences beyond style:

1. **`--force` was untestable at the use-case level** — every existing refresh test constructs `MarketplaceRefreshUseCase` directly, so none could reach the flag. It was only exercisable through the CLI.
2. **The ordering requirement lived in the caller.** The clear must happen before the fetch loop; nothing in the use-case enforced or documented that.

## 🛠️ How it works

`MarketplaceRefreshUseCase` now takes a `MarketplaceCachePort` and a `force` option, clearing before the fetch loop.

The port is **required, not optional**. The use-case's existing optionals (`logger?`, `fs?`) are genuine degradations — refresh still works without them. A missing cache is not: with `force: true` it would silently do nothing, which is precisely the class of bug this epic keeps turning up. Required means `tsc` enumerates the construction sites rather than letting one default to `undefined`.

`marketplaceCache` also leaves the exported `Deps` surface — its only consumer was this command, and keeping it public invites the next command to reach past the use-case the same way. It stays wired internally.

## 🧪 How to verify

`pnpm --filter cli test` — 2096/2096, tsc clean.

The three new force tests were **verified to fail** (2 of 3) when the `clear` call is removed from the use-case.

```
grep -n  "marketplaceCache"      src/application/commands/marketplace.ts   # nothing
grep -rn "deps.marketplaceCache" src/                                      # nothing
```

## 📎 Why `forceRefresh` is always on but `--force` is opt-in

Worth stating, since both end up deleting cache and the difference is not obvious. They differ in **scope**, not in kind:

| | deletes | rationale |
|---|---|---|
| `forceRefresh: true`, passed unconditionally by `fetchSource()` | `cacheDir/<source-key>/` — e.g. `…/marketplaces/foo/github-owner-repo-HEAD/` (`bustCacheIfNeeded`, plugin-fetcher-adapter) | refreshing *is* re-fetching, so it must never serve a stale clone of the source it is about to fetch |
| `--force` | `cacheDir/` in full — `…/marketplaces/foo/` (`MarketplaceCacheAdapter.clear`) | also removes subdirectories left by *previous* source specs (an old ref, a changed repo) and the raw catalog file written directly into `cacheDir`. Garbage collection, not re-fetch — hence opt-in |

So the always-on flag is correct, and `--force` is opt-in because it is strictly broader and discards more.

Cartography item A14.