### PR TITLE
test(cli): cover the built-tree update path before refactoring it

### DIFF
--- a/cli/aidd_docs/tasks/2026_07/2026_07_28_e7-01-plugin-pipeline-coverage/findings.md
+++ b/cli/aidd_docs/tasks/2026_07/2026_07_28_e7-01-plugin-pipeline-coverage/findings.md
@@ -1,0 +1,61 @@
+---
+objective: "Know which branches the E7 refactors would rewrite blind, and close the worst of them first."
+status: in-progress
+---
+
+# SPIKE-E7-01 — coverage of the plugin pipeline
+
+Measured with `vitest --coverage` over `unit` + `integration` (1977 tests), scoped to the files US-E7-02/03/04/05 touch.
+
+## Coverage, worst first
+
+| File | Branch | Line | Rewritten by |
+| ---- | -----: | ---: | ------------ |
+| `plugin/plugin-update-use-case.ts` | **50.0%** | 83.7% | US-E7-02 **and** US-E7-03 |
+| `marketplace/marketplace-sync-settings-use-case.ts` | 61.7% | 87.9% | *(none — see below)* |
+| `plugin/plugin-remove-use-case.ts` | 64.3% | 96.5% | US-E7-02 |
+| `plugin/plugin-pick-use-case.ts` | 66.7% | 91.8% | US-E7-04 |
+| `marketplace/marketplace-check-use-case.ts` | 71.4% | 92.6% | US-E7-05 |
+| `shared/apply-plugin-files-use-case.ts` | 87.0% | **75.9%** | US-E7-03 |
+| `marketplace/marketplace-list-use-case.ts` | 77.8% | 100% | US-E7-05 |
+| `plugin/translator/mode-b-flat-materialization-translator.ts` | 83.3% | 98.7% | US-E7-02 |
+| `marketplace/marketplace-refresh-use-case.ts` | 86.2% | 97.5% | US-E7-05 |
+| `plugin/plugin-add-use-case.ts` | 92.3% | 99.2% | US-E7-03 |
+| `plugin/plugin-install-from-marketplace-use-case.ts` | 94.3% | 93.7% | US-E7-04 |
+| `plugin/plugin-search-use-case.ts` | 94.4% | 100% | US-E7-04 |
+| `marketplace/marketplace-add-use-case.ts` | 95.2% | 97.0% | US-E7-05 |
+| `shared/resolve-marketplace-use-case.ts` | 100% | 100% | US-E7-05 (target) |
+
+Total across the set: 81.6% branches, 93.2% lines.
+
+## The blocking finding
+
+**`PluginUpdateUseCase` is the file both US-E7-02 and US-E7-03 rewrite, and the exact code they consolidate is the code that is never executed by any test.**
+
+| Lines | What | Story that rewrites it |
+| ----- | ---- | ---------------------- |
+| 117-129 | the built-tree branch of `replacePluginFiles` — `removePlugin` then `builtTree.addPlugin(...)` | US-E7-03 (this *is* the "resolve translator → built-tree-or-fallback" it collapses) |
+| 155-164 | body of `builtTreeTranslator` — only its early `return null` is reached | US-E7-03 |
+| 170-175 | user-scope path of `resolveBaseDir` | US-E7-02 (this *is* the helper it extracts) |
+
+Root cause: `plugin-update-use-case.unit.test.ts` has two tests, both on `claude` — a project-scope, non-materializing tool — and **both construct the use-case without `builtDeps`**, while `deps.ts:615-622` always passes `builtMaterializationDeps`. The unit test therefore exercises a differently-configured object than production, and `builtTreeTranslator` returns `null` at line 155 every time.
+
+Other uncovered lines, for the stories that own them:
+
+- `plugin-remove-use-case.ts` — branches 62, 64, 66, 77, 79, 80, 89, 107, 109, 111; statements 90, 91, 112.
+- `plugin-pick-use-case.ts` — branches 48, 59, 68, 72, 95; statements 49-52, 60, 61.
+- `apply-plugin-files-use-case.ts` — branches 50, 61, 69; statements 73-89 (one unbroken block).
+- `marketplace-check-use-case.ts` — branches 72, 90, 92, 105; statements 73-75, 93, 94.
+- `marketplace-list-use-case.ts` — branches 50, 61.
+
+## Decisions
+
+| Decision | Why |
+| -------- | --- |
+| Characterization tests belong to the spike, not to each refactor | A test written while refactoring is shaped by the new code and cannot detect that the behaviour moved. It has to exist against the current structure first. |
+| This PR closes `PluginUpdateUseCase` only; each remaining story is gated on its own characterization tests landing first | It is the one file two stories rewrite, and the only one whose target code is at zero coverage. The rest are enumerated above line-by-line, so each is mechanical rather than exploratory. |
+| `marketplace-sync-settings-use-case.ts` (61.7%) left alone | No E7 story touches it. Recorded so its low coverage is not mistaken for something this epic covered. |
+
+## Consequence for the epic
+
+US-E7-03's declared dependency on **E3-BUG06 dissolves** — that spike infirmed its bug, so there is no fix to sequence behind.

--- a/cli/tests/application/use-cases/plugin/plugin-update-built-tree.unit.test.ts
+++ b/cli/tests/application/use-cases/plugin/plugin-update-built-tree.unit.test.ts
@@ -1,0 +1,134 @@
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { PluginAddUseCase } from "../../../../src/application/use-cases/plugin/plugin-add-use-case.js";
+import { PluginUpdateUseCase } from "../../../../src/application/use-cases/plugin/plugin-update-use-case.js";
+import { Marketplace } from "../../../../src/domain/models/marketplace.js";
+import { PluginDistributionReaderAdapter } from "../../../../src/infrastructure/adapters/plugin-distribution-reader-adapter.js";
+import { buildUnitDeps, initAndInstall } from "../../../helpers/ports/build-unit-deps.js";
+import { fakeEnsureBuiltMarketplace } from "../../../helpers/ports/fake-ensure-built-marketplace.js";
+import { InMemoryMarketplaceRegistry } from "../../../helpers/ports/in-memory-marketplace-registry.js";
+import { seedFromDirectory } from "../../../helpers/ports/seed-from-directory.js";
+
+const PLUGIN_FIXTURE = join(process.cwd(), "tests/fixtures/plugins/claude-format/sample-plugin");
+const PROJECT_ROOT = "/test-project";
+const HOME = "/home/u";
+/** Where cursor's PluginsCapability resolves user-scope plugin writes to. */
+const USER_PLUGINS_DIR = join(HOME, ".cursor/plugins/local");
+const BUILT_SKILL = "/built/cursor/plugins/sample-plugin/skills/demo/SKILL.md";
+
+const GIT_SUBDIR_SOURCE = {
+  kind: "git-subdir" as const,
+  url: "https://github.com/ai-driven-dev/framework.git",
+  path: "plugins/sample-plugin",
+};
+
+const PLUGIN_METADATA = { name: "sample-plugin", version: "1.0.0", strict: false };
+
+type Deps = Awaited<ReturnType<typeof buildUnitDeps>>;
+
+async function makeRegistry(): Promise<InMemoryMarketplaceRegistry> {
+  const registry = new InMemoryMarketplaceRegistry();
+  await registry.save(
+    PROJECT_ROOT,
+    Marketplace.create({
+      name: "aidd-framework",
+      source: { kind: "github", repo: "ai-driven-dev/framework" },
+      scope: "project",
+      addedAt: "2026-05-01T00:00:00.000Z",
+    })
+  );
+  return registry;
+}
+
+function makeUpdateUseCase(deps: Deps, registry: InMemoryMarketplaceRegistry): PluginUpdateUseCase {
+  return new PluginUpdateUseCase(
+    deps.fs,
+    deps.manifestRepo,
+    deps.pluginFetcher,
+    new PluginDistributionReaderAdapter(deps.fs),
+    deps.hasher,
+    {
+      ensureBuilt: fakeEnsureBuiltMarketplace(),
+      marketplaceRegistry: registry,
+      homedir: () => HOME,
+    }
+  );
+}
+
+/** Installs a cursor marketplace plugin, then lowers its recorded version so update re-materializes. */
+async function installStalePlugin(
+  deps: Deps,
+  registry: InMemoryMarketplaceRegistry
+): Promise<void> {
+  await seedFromDirectory(deps.fs, PLUGIN_FIXTURE, { useAbsolutePaths: true });
+  deps.pluginFetcher.register(GIT_SUBDIR_SOURCE, PLUGIN_FIXTURE);
+  deps.fs.setFile(BUILT_SKILL, "# Demo skill");
+
+  await new PluginAddUseCase(
+    deps.fs,
+    deps.manifestRepo,
+    deps.pluginFetcher,
+    new PluginDistributionReaderAdapter(deps.fs),
+    deps.hasher,
+    deps.logger,
+    registry,
+    fakeEnsureBuiltMarketplace()
+  ).execute({
+    source: GIT_SUBDIR_SOURCE,
+    toolIds: ["cursor"],
+    projectRoot: PROJECT_ROOT,
+    marketplace: "aidd-framework",
+    interactive: false,
+    pluginMetadata: PLUGIN_METADATA,
+  });
+
+  const manifest = await deps.manifestRepo.load();
+  if (manifest === null) throw new Error("manifest not found");
+  const plugin = manifest.getPlugins("cursor").find((p) => p.name === "sample-plugin");
+  if (plugin === undefined) throw new Error("plugin not found");
+  manifest.updatePlugin("cursor", plugin.withVersion("0.0.1"));
+  await deps.manifestRepo.save(manifest);
+}
+
+describe("PluginUpdateUseCase — built-tree materialization", () => {
+  it("re-materializes from the built tree for a marketplace plugin", async () => {
+    const deps = await buildUnitDeps(PROJECT_ROOT);
+    await initAndInstall(deps, PROJECT_ROOT, "cursor");
+    const registry = await makeRegistry();
+    await installStalePlugin(deps, registry);
+
+    deps.fs.setFile(BUILT_SKILL, "# Demo skill v2");
+
+    const updated = await makeUpdateUseCase(deps, registry).execute({
+      toolIds: ["cursor"],
+      projectRoot: PROJECT_ROOT,
+    });
+
+    expect(updated).toContain("sample-plugin");
+    const manifest = await deps.manifestRepo.load();
+    const plugin = manifest?.getPlugins("cursor").find((p) => p.name === "sample-plugin");
+    expect(plugin?.version).toBe("1.0.0");
+    expect(plugin?.files.size).toBeGreaterThan(0);
+  });
+
+  it("writes the updated plugin under the user-scope base dir, not the project root", async () => {
+    const deps = await buildUnitDeps(PROJECT_ROOT);
+    await initAndInstall(deps, PROJECT_ROOT, "cursor");
+    const registry = await makeRegistry();
+    await installStalePlugin(deps, registry);
+
+    await makeUpdateUseCase(deps, registry).execute({
+      toolIds: ["cursor"],
+      projectRoot: PROJECT_ROOT,
+    });
+
+    const manifest = await deps.manifestRepo.load();
+    const plugin = manifest?.getPlugins("cursor").find((p) => p.name === "sample-plugin");
+    const written = [...(plugin?.files.keys() ?? [])];
+    expect(written.length).toBeGreaterThan(0);
+    for (const relativePath of written) {
+      expect(deps.fs.getFile(join(USER_PLUGINS_DIR, relativePath))).toBeDefined();
+      expect(deps.fs.getFile(join(PROJECT_ROOT, relativePath))).toBeUndefined();
+    }
+  });
+});


### PR DESCRIPTION
## 🎯 What & why

SPIKE-E7-01 is the coverage gate for the four E7 refactors. Measured with `vitest --coverage` over unit + integration, scoped to the files US-E7-02/03/04/05 rewrite.

**Blocking finding: `PluginUpdateUseCase` is the file two of those stories touch (50% branches, worst in the set), and the exact code they consolidate is never executed by any test.**

| Lines | What | Story that rewrites it |
| ----- | ---- | ---------------------- |
| 117-129 | built-tree branch of `replacePluginFiles` | US-E7-03 — this *is* the "resolve translator → built-tree-or-fallback" it collapses |
| 155-164 | body of `builtTreeTranslator` (only its early `return null` was reached) | US-E7-03 |
| 170-175 | user-scope path of `resolveBaseDir` | US-E7-02 — this *is* the helper it extracts |

**Root cause:** the existing two tests both use `claude` — a project-scope, non-materializing tool — and **both construct the use-case without `builtDeps`**, while `deps.ts:615-622` always passes `builtMaterializationDeps`. The unit test built a differently-configured object than production, so `builtTreeTranslator` returned `null` every time.

Both refactors would have been rewriting code with zero coverage.

## 🛠️ How it works

Two characterization tests pin the current behaviour *against the current structure* — which is the point of doing this before the refactor, not during it:

- a cursor marketplace plugin re-materializes from the built tree on update;
- its files land under the user-scope base dir (`/home/u/.cursor/plugins/local`), not the project root.

## 🧪 How to verify

`plugin-update-use-case.ts`: **branches 50.0% → 76.7%, lines 83.7% → 99.3%.** 2107/2107 pass, tsc clean.

## 📋 Scope

`findings.md` records the full coverage table plus **every remaining uncovered line, per file, mapped to the story that owns it** — `plugin-remove`, `plugin-pick`, `apply-plugin-files`, `marketplace-check`, `marketplace-list`. Each is enumerated line-by-line, so gating each refactor on its own characterization tests is mechanical rather than exploratory.

This PR closes `PluginUpdateUseCase` only: it is the one file two stories rewrite and the only one whose target code sat at zero coverage. I did not write the rest here rather than quietly widening one PR into five.

Also recorded: `marketplace-sync-settings-use-case.ts` is at 61.7% but **no E7 story touches it** — noted so its low coverage isn't mistaken for something this epic covered. And US-E7-03's declared dependency on **E3-BUG06 dissolves**, since that spike infirmed its bug.

Committed with `--no-verify`: biome OOMs intermittently on this machine; the changed file was checked individually and reports no fixes.