### PR TITLE
feat(aidd-pm): add evidence-bounded spike skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 ## Agentic framework for software engineers to produce 100% quality code with IA, agonistically.
 
 <p>
-  <!--counts:start--><kbd>7 plugins</kbd> · <kbd>40 skills</kbd> · <kbd>2 agents</kbd><!--counts:end--> · <kbd>MIT</kbd>
+  <!--counts:start--><kbd>7 plugins</kbd> · <kbd>41 skills</kbd> · <kbd>2 agents</kbd><!--counts:end--> · <kbd>MIT</kbd>
 </p>
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
@@ -249,9 +249,9 @@ Repo init, commits, pull / merge requests, release tags, issues.
 
 ### 📋 [aidd-pm](plugins/aidd-pm/README.md)
 
-`4 skills` · stable
+`5 skills` · stable
 
-Ticket info, user stories, PRD, spec drafting.
+Ticket info, user stories, PRD, spec drafting, spike investigations.
 
 </td>
 <td width="33%" valign="top">

--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -52,7 +52,7 @@ The development SDLC: plan, implement, assert, audit, review, test, refactor, de
 
 ## 📋 aidd-pm
 
-Product management: ticket retrieval, user stories, PRD, spec.
+Product management: ticket retrieval, user stories, PRD, spec, spikes.
 
 | Skill                     | Role                                                       | Actions                          |
 | ------------------------- | ---------------------------------------------------------- | -------------------------------- |
@@ -60,6 +60,7 @@ Product management: ticket retrieval, user stories, PRD, spec.
 | `02-user-stories`         | Prioritized, estimated INVEST user-story backlog           | `01-clarify-scope`, `02-split-epic`, `03-draft-stories`, `04-estimate-impact`, `05-prioritize`, `06-sync-tracker` |
 | `03-prd`                  | Generate a structured Product Requirements Document        | `01-prd`                         |
 | `04-spec`                 | Generate or refine a normalized project spec               | `01-build`, `02-refine`          |
+| `05-spike`                | Record or investigate a decision-blocking uncertainty      | `01-create`, `02-investigate`, `03-conclude` |
 
 ## 🪞 aidd-refine
 

--- a/plugins/aidd-pm/.claude-plugin/plugin.json
+++ b/plugins/aidd-pm/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "aidd-pm",
   "version": "2.2.1",
-  "description": "Product management: ticket-info, user-stories, prd, spec",
+  "description": "Product management: ticket-info, user-stories, prd, spec, spike",
   "author": {
     "name": "AI-Driven Dev",
     "url": "https://github.com/ai-driven-dev"
@@ -11,13 +11,15 @@
     "./skills/01-ticket-info",
     "./skills/02-user-stories",
     "./skills/03-prd",
-    "./skills/04-spec"
+    "./skills/04-spec",
+    "./skills/05-spike"
   ],
   "keywords": [
     "product-management",
     "user-stories",
     "prd",
     "specification",
+    "spikes",
     "tickets"
   ],
   "repository": "https://github.com/ai-driven-dev/framework",

--- a/plugins/aidd-pm/CATALOG.md
+++ b/plugins/aidd-pm/CATALOG.md
@@ -12,6 +12,7 @@ Auto-generated index of skills, agents, references and assets shipped by the `ai
   - [`skills/02-user-stories`](#skills02-user-stories)
   - [`skills/03-prd`](#skills03-prd)
   - [`skills/04-spec`](#skills04-spec)
+  - [`skills/05-spike`](#skills05-spike)
 
 ---
 
@@ -61,4 +62,19 @@ Auto-generated index of skills, agents, references and assets shipped by the `ai
 | `actions` | [02-refine.md](skills/04-spec/actions/02-refine.md) | - |
 | `assets` | [spec-template.md](skills/04-spec/assets/spec-template.md) | - |
 | `-` | [SKILL.md](skills/04-spec/SKILL.md) | `Generate or refine a spec, a feature's immutable contract, from a request, a PRD, or review findings. Use to draft or refine a spec. Do NOT use to write code, a full PRD, or change a locked spec.` |
+
+#### `skills/05-spike`
+
+| Group | File | Description |
+|-------|------|---|
+| `actions` | [01-create.md](skills/05-spike/actions/01-create.md) | - |
+| `actions` | [02-investigate.md](skills/05-spike/actions/02-investigate.md) | - |
+| `actions` | [03-conclude.md](skills/05-spike/actions/03-conclude.md) | - |
+| `assets` | [spike-template.md](skills/05-spike/assets/spike-template.md) | - |
+| `references` | [capabilities.md](skills/05-spike/references/capabilities.md) | - |
+| `references` | [investigation.md](skills/05-spike/references/investigation.md) | - |
+| `references` | [lifecycle.md](skills/05-spike/references/lifecycle.md) | - |
+| `references` | [persistence.md](skills/05-spike/references/persistence.md) | - |
+| `references` | [qualification.md](skills/05-spike/references/qualification.md) | - |
+| `-` | [SKILL.md](skills/05-spike/SKILL.md) | `Produces an evidence-bounded spike for an uncertainty blocking estimation, feasibility, or design. Use when the user wants to frame, investigate, resume, or conclude one. Not for general research or implementation.` |
 

--- a/plugins/aidd-pm/README.md
+++ b/plugins/aidd-pm/README.md
@@ -8,7 +8,7 @@ Product management plugin for the AI-Driven Development framework.
 
 First time? Install with `/plugin install aidd-pm@aidd-framework`, then run `aidd-pm:01-ticket-info`.
 
-Covers ticket information retrieval, user story creation, product requirement documents, and spec generation for downstream agents.
+Covers ticket retrieval, user stories, product requirements, specs, and bounded spike investigations.
 
 ## Skills
 
@@ -18,3 +18,4 @@ Covers ticket information retrieval, user story creation, product requirement do
 | [4.2] | [user-stories](skills/02-user-stories/SKILL.md) | Turn a feature or epic into a prioritized, estimated, INVEST-compliant user-story backlog. |
 | [4.3] | [prd](skills/03-prd/SKILL.md) | Generate a structured Product Requirements Document. |
 | [4.4] | [spec](skills/04-spec/SKILL.md) | Generate and refine a project spec from a free-form human request. The spec is the immutable target a planner consumes. |
+| [4.5] | [spike](skills/05-spike/SKILL.md) | Record or investigate an uncertainty that blocks estimation, feasibility, or design. |

--- a/plugins/aidd-pm/skills/02-user-stories/actions/04-estimate-impact.md
+++ b/plugins/aidd-pm/skills/02-user-stories/actions/04-estimate-impact.md
@@ -8,16 +8,19 @@ The drafted stories from `03-draft-stories`.
 
 ## Output
 
-Each story annotated with story points, its dependencies (named or confirmed absent), an impact rating of minor, major, or critic, and a one-line rationale for the impact.
+Each story annotated with its estimate or blocking spike, its dependencies, an impact rating of minor, major, or critic, and a one-line rationale for the impact.
 
 ## Process
 
-1. **Estimate effort.** Assign story points reflecting relative size. Flag any story too large to size and send it back to `02-split-epic`.
+1. **Estimate effort.** Assign story points reflecting relative size.
+   - Send a story that is too large to size back to `02-split-epic`.
+   - When an unknown blocks sizing, discover a capability that records or investigates it. Resume after resolution, or leave the story unsized with the spike as its dependency.
 2. **Rate impact.** Assign minor, major, or critic per the impact scale in `@../references/rating.md`.
 3. **Justify.** Write a one-line rationale for each impact rating.
 4. **Record.** Fill the estimation block in `@../assets/user-story-template.md` for each story.
 
 ## Test
 
-- Each story carries a numeric story-point value.
+- Each estimable story carries a numeric story-point value.
+- An unresolved story names its spike dependency and carries no invented points.
 - Each story carries an impact rating in {minor, major, critic} with a one-line rationale.

--- a/plugins/aidd-pm/skills/05-spike/SKILL.md
+++ b/plugins/aidd-pm/skills/05-spike/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: 05-spike
+description: Produces an evidence-bounded spike for an uncertainty blocking estimation, feasibility, or design. Use when the user wants to frame, investigate, resume, or conclude one. Not for general research or implementation.
+argument-hint: question | spike
+---
+
+# Spike
+
+```mermaid
+---
+title: Spike flow
+---
+flowchart LR
+  Question([question])
+  Create[create]
+  Open([open])
+  Spike([spike])
+  Investigate[investigate]
+  Conclude[conclude]
+
+  Question --> Create
+  Create -- "save for later" --> Open
+  Create -- "investigate now" --> Investigate
+  Spike --> Investigate
+  Investigate --> Conclude
+```
+
+## Actions
+
+Run the flow above. Read only the next action's file before running it.
+
+| Action      | Does                                  |
+| ----------- | ------------------------------------- |
+| create      | qualify and persist                    |
+| investigate | collect evidence                       |
+| conclude    | write outcome and sync parents         |
+
+## Transversal rules
+
+- Require approval before spike creation or parent changes.
+- Follow approved route and bounds; ask when either is absent.
+- Preserve edits, evidence, and links.
+- Touch only the spike and approved related artifacts.

--- a/plugins/aidd-pm/skills/05-spike/actions/01-create.md
+++ b/plugins/aidd-pm/skills/05-spike/actions/01-create.md
@@ -1,0 +1,30 @@
+# 01 - Create
+
+Qualify and persist an open spike without forcing investigation.
+
+## Input
+
+A question and any related need, backlog item, initiative, or decision.
+
+## Output
+
+A spike reference, or the reason no spike is needed.
+
+## Process
+
+1. **Require.** If no unknown is present, ask for one and wait.
+2. **Clarify.** Only if the question or decision is unclear, apply [capabilities](../references/capabilities.md).
+3. **Qualify.** Apply [qualification](../references/qualification.md).
+4. **Place.** Apply [persistence](../references/persistence.md) and follow its result.
+5. **Route.** Resolve `save for later` or `investigate now`.
+6. **Confirm.** For a new spike, show the question, parents, decision, bounds, and route.
+7. **Write.** For a new spike, fill only earned fields and sections of [spike template](../assets/spike-template.md). A keep-open spike stops after `Bounds`.
+
+## Test
+
+| Case | Observable |
+| --- | --- |
+| Missing question, decision, or approval | Spike file count is unchanged |
+| Approved routed spike | One linked, bounded `open` file exists without unearned content |
+| Existing match | The existing artifact is reused and spike file count is unchanged |
+| Missing route | No spike is created and the choice is requested |

--- a/plugins/aidd-pm/skills/05-spike/actions/02-investigate.md
+++ b/plugins/aidd-pm/skills/05-spike/actions/02-investigate.md
@@ -1,0 +1,25 @@
+# 02 - Investigate
+
+Collect only the evidence that can change the blocked decision.
+
+## Input
+
+A spike eligible for investigation, by id, URL, or path.
+
+## Output
+
+Evidence and an outcome status.
+
+## Process
+
+1. **Activate.** Resolve one spike and transition it to `in-progress` when allowed by [lifecycle](../references/lifecycle.md).
+2. **Investigate.** Apply [investigation](../references/investigation.md) with matching [capabilities](../references/capabilities.md).
+
+## Test
+
+| Case | Observable |
+| --- | --- |
+| Terminal spike | No attempt is appended |
+| Attempts | Each records method, evidence, and result; retries differ |
+| Unapproved path | Evidence is kept; status is unchanged; user is asked |
+| Output | Evidence and a lifecycle status return; history remains; only the spike changes |

--- a/plugins/aidd-pm/skills/05-spike/actions/03-conclude.md
+++ b/plugins/aidd-pm/skills/05-spike/actions/03-conclude.md
@@ -1,0 +1,26 @@
+# 03 - Conclude
+
+Write the investigation outcome and reconnect it to the backlog.
+
+## Input
+
+The spike, its evidence, and the outcome status.
+
+## Output
+
+A concluded spike with coherent parent links and any approved backlog update.
+
+## Process
+
+1. **Write.** Complete the earned outcome and follow-up fields in [spike template](../assets/spike-template.md).
+2. **Propose.** Show the outcome and exact parent or backlog changes.
+3. **Sync.** Apply [persistence](../references/persistence.md).
+4. **Continue.** Only if the user asks, apply [capabilities](../references/capabilities.md) to the approved follow-up.
+
+## Test
+
+| Case | Observable |
+| --- | --- |
+| Outcome | Status is lifecycle-valid and `Outcome` plus `Follow-up` are present |
+| Parent update not approved | Parent and backlog content are unchanged |
+| Parent update approved | Exact changes and reciprocal links exist; only approved artifacts change |

--- a/plugins/aidd-pm/skills/05-spike/assets/spike-template.md
+++ b/plugins/aidd-pm/skills/05-spike/assets/spike-template.md
@@ -1,0 +1,31 @@
+# Spike: <title>
+
+- Status: <status>
+- Parents: <ids, URLs, or paths>
+- Related spikes: <ids, URLs, or paths>
+- Unblocks: <decision or estimate>
+
+## Question
+
+<one answerable question>
+
+## Bounds
+
+- Evidence needed: <evidence>
+- Stop when: <condition>
+
+## Investigation
+
+| Attempt | Evidence | Result |
+| ------- | -------- | ------ |
+| <method> | <source> | <result> |
+
+## Outcome
+
+- Result: <answer, blocker, inconclusive reason, or cancellation reason>
+- Confidence: <level and reason>
+- Remaining uncertainty: <none or concise list>
+
+## Follow-up
+
+<parent change or next capability>

--- a/plugins/aidd-pm/skills/05-spike/references/capabilities.md
+++ b/plugins/aidd-pm/skills/05-spike/references/capabilities.md
@@ -1,0 +1,12 @@
+# Capabilities
+
+Find capabilities by outcome. Invoke named skills; never copy or simulate them.
+
+| Need | Use | Required result |
+| ---- | --- | --------------- |
+| unclear question or decision | skill `brainstorm` | a confirmed question and decision |
+| material factual claim | skill `fact-check` | verdicts with sources |
+| high-impact conclusion | skill `challenge` | findings against the question, bounds, and evidence |
+| executable evidence | matching skill or tool | a documented result from isolated, disposable work |
+| unblocked parent | matching backlog skill | re-estimate, refine, redesign, or accept risk |
+| no match | nothing | report the gap |

--- a/plugins/aidd-pm/skills/05-spike/references/investigation.md
+++ b/plugins/aidd-pm/skills/05-spike/references/investigation.md
@@ -1,0 +1,39 @@
+# Investigation
+
+Bound research by decisive evidence, not elapsed time.
+
+```mermaid
+---
+title: Spike investigation
+---
+flowchart TD
+  Frame["Name decisive evidence, actionable condition, and blockers"]
+  Attempt["Take cheapest decisive path"]
+  Record["Record method, source, and result"]
+  Check{"Unverified or unchallenged?"}
+  Verify["Apply the selected capability"]
+  Outcome{"Resolved, blocked, or cancelled?"}
+  Path{"Viable evidence path?"}
+  Bounds{"Next path within approved bounds?"}
+  Ask["Ask to extend bounds or stop"]
+  Inconclusive["Return inconclusive"]
+  Done["Return evidence and status"]
+
+  Frame --> Attempt
+  Attempt --> Record
+  Record --> Check
+  Check -- yes --> Verify
+  Verify --> Record
+  Check -- no --> Outcome
+  Outcome -- yes --> Done
+  Outcome -- no --> Path
+  Path -- no --> Inconclusive
+  Path -- yes --> Bounds
+  Bounds -- yes --> Attempt
+  Bounds -- no --> Ask
+  Ask -- extend --> Frame
+  Ask -- stop --> Inconclusive
+```
+
+- Change the hypothesis, input, or method before retrying.
+- Ask whether to extend or stop before changing status when a viable path exceeds bounds.

--- a/plugins/aidd-pm/skills/05-spike/references/lifecycle.md
+++ b/plugins/aidd-pm/skills/05-spike/references/lifecycle.md
@@ -1,0 +1,10 @@
+# Lifecycle
+
+| Status | Meaning | May move to |
+| ------ | ------- | ----------- |
+| `open` | framed only | `in-progress`, `cancelled` |
+| `in-progress` | collecting evidence | `blocked`, `resolved`, `inconclusive`, `cancelled` |
+| `blocked` | dependency stops the next check | `in-progress`, `cancelled` |
+| `resolved` | decision settled, including proven impossibility | terminal |
+| `inconclusive` | investigation stopped without an answer | `in-progress` with a new path |
+| `cancelled` | decision gone | terminal |

--- a/plugins/aidd-pm/skills/05-spike/references/persistence.md
+++ b/plugins/aidd-pm/skills/05-spike/references/persistence.md
@@ -1,0 +1,17 @@
+# Persistence
+
+| Situation | Result |
+| --- | --- |
+| Parents span supports | Ask for one target |
+| Parent support exists | Use that support |
+| No parent artifact exists | Use the configured backlog |
+| No target exists | Ask for one |
+| Valid completed match in the target | Reuse it |
+| Same open question in the target | Resume it |
+| New spike | Create one dedicated tracker item or Markdown document |
+| Reciprocal links are supported | Link every parent |
+| Blocked work | Make the spike its predecessor |
+| Question changed | Create a new spike and link the previous one |
+
+- Never mirror across supports.
+- Assign neither user value nor arbitrary estimates.

--- a/plugins/aidd-pm/skills/05-spike/references/qualification.md
+++ b/plugins/aidd-pm/skills/05-spike/references/qualification.md
@@ -1,0 +1,14 @@
+# Qualification
+
+A spike is one bounded question that unblocks a consequential decision.
+
+| Situation | Result |
+| --- | --- |
+| Cannot change estimation, feasibility, design, decomposition, or material-risk handling | No spike |
+| No need, backlog item, initiative, or named decision | No spike |
+| Answerable in the current exchange | Answer directly |
+| Routine implementation or general research | No spike |
+| Bounds cannot settle the full question | Revise them |
+| Independent questions | Split them |
+| Question shared by several parents | One spike with every parent |
+| Otherwise | Create it |

--- a/scripts/sync-skill-argument-hints.mjs
+++ b/scripts/sync-skill-argument-hints.mjs
@@ -95,7 +95,7 @@ function syncArgumentHint(content, hint) {
 // Skills whose argument-hint is written by hand, because it names the user's
 // entrypoint or cases rather than one token per action. The hook leaves these
 // untouched. This is the base pattern for a pipeline or case-based router.
-const MANUAL_ARGUMENT_HINT = new Set(["01-brainstorm", "02-project-memory", "04-skill-generate"]);
+const MANUAL_ARGUMENT_HINT = new Set(["01-brainstorm", "02-project-memory", "04-skill-generate", "05-spike"]);
 
 const stale = [];
 for (const dir of await skillDirs()) {


### PR DESCRIPTION
## 🎯 What & why

Adds a dedicated spike artifact to frame, investigate, resume, and conclude uncertainty that blocks estimation, feasibility, or design.

## 🛠️ How it works

The light router loads one of three actions: create and place the spike, investigate decision-changing evidence, then conclude and synchronize approved backlog changes. Investigation uses explicit evidence and exit bounds instead of elapsed time, preserving useful work while returning out-of-bounds choices to the user.

## 🧪 How to verify

- `node scripts/sync-skill-argument-hints.mjs --check`
- `node scripts/check-markdown-links.js --ignore cli/tests/fixtures --ignore cli/aidd_docs/tasks`
- `node scripts/validate-json.mjs plugins/aidd-pm/.claude-plugin/plugin.json`
- `cd cli && pnpm test`
- Exercise create-for-later, end-to-end, resume, out-of-bounds, duplicate, changed-question, terminal, and challenge routes.

## ⚠️ Heads-up

The issue says “timeboxed”; the agreed design bounds investigation by decisive evidence and exit conditions, not duration.

## 🔗 Linked issue

Closes #412

## ✅ I certify

- [x] **I DO CERTIFY I READ EACH LINE OF THE PULL REQUEST BECAUSE I AM A SOFTWARE ENGINEER, NOT A AI PUPPY.**
