### PR TITLE
refactor(cli): resolve the plugin base dir in one place

### DIFF
--- a/cli/aidd_docs/tasks/2026_07/2026_07_28_e7-02-shared-plugin-base-dir/plan.md
+++ b/cli/aidd_docs/tasks/2026_07/2026_07_28_e7-02-shared-plugin-base-dir/plan.md
@@ -1,0 +1,149 @@
+---
+objective: Collapse 5 copies of resolveBaseDir and 2 copies of qualifiesForOpencodeMcpMerge into shared functions in plugin-helpers.ts without changing behavior.
+status: implemented
+---
+
+# US-E7-02: shared plugin base-dir helper
+
+## Background
+
+The ticket claimed 2 copies of `resolveBaseDir`. Reading the code found 5. All 5 were read
+in full and compared line by line before any extraction happened.
+
+## What the 5 copies actually were
+
+| # | File | Signature | Guard style | Homedir source | Pre-guard on installScope |
+|---|------|-----------|-------------|-----------------|----------------------------|
+| 1 | plugin-remove-use-case.ts:105 | `(toolId, projectRoot)` | `isAiTool` + `"plugins" in caps` | `homedir()` from node:os, called eagerly | yes: `if (installScope !== "user") return projectRoot` |
+| 2 | plugin-update-use-case.ts:168 | `(toolId, projectRoot)` | `isAiTool` + `"plugins" in caps` | `homedir()` from node:os, called eagerly | yes, same as #1 |
+| 3 | mode-b-flat-materialization-translator.ts:192 | `(plugins, projectRoot)` — takes the resolved `PluginsCapability` directly | none (capability already resolved by caller) | injected `this.homedir: () => string` | no — calls `resolvePluginsBaseDir` directly |
+| 4 | built-tree-materialization-translator.ts:127 | `(toolId, projectRoot)` | `isAiTool` only; casts `capabilities as { plugins: PluginsCapability }` with no presence check | injected `this.homedir: () => string` | no |
+| 5 | detect-plugin-drift-use-case.ts:53 | `(toolId, projectRoot)` | `tool === undefined \|\| !isAiTool(tool)`, then `plugins === undefined` | `homedir()` from node:os, called eagerly | no |
+
+`qualifiesForOpencodeMcpMerge` (plugin-remove-use-case.ts:76 and
+mode-b-flat-materialization-translator.ts:133) were verbatim identical: same body, same
+`Record<string, unknown>` parameter type, same reliance on `McpCapability` instanceof check
+and `plugins.mode === "flat"`.
+
+## Behavioral analysis
+
+- `PluginsCapability.resolvePluginsBaseDir(projectRoot, homedir)` (domain/capabilities/plugins-capability.ts:163)
+  already returns `projectRoot` unless `installScope === "user"` and a `userPluginsDir`
+  resolver was configured. So the `if (installScope !== "user") return projectRoot`
+  pre-guard present in copies #1 and #2 is redundant, not a behavioral difference — dropping
+  it changes nothing observable.
+- Copy #4 skipped the `"plugins" in caps` presence check and cast straight to
+  `{ plugins: PluginsCapability }`. This looked unsafe in isolation, but
+  `BuiltTreeMaterializationTranslator` is only ever constructed via `resolveTranslator()`
+  (plugin-translator-factory.ts), which itself is only called with a `PluginsCapability`
+  already resolved from that same toolId's config. The "plugins missing" branch in the
+  unified helper is dead code for this caller, not a change in reachable behavior.
+- Copy #5's `tool === undefined` check was dead code: `getToolConfig(toolId)` throws
+  `UnregisteredToolError` and never returns `undefined`. Dropped with no effect.
+- The homedir difference is real but not behaviorally significant to unify: 3 copies
+  call `homedir()` from `node:os` directly, 2 copies receive an injected
+  `() => string`. The shared helper takes `homedir: () => string` as a parameter so each
+  caller keeps passing what it already passed (either `nodeHomedir` from node:os, or its
+  own injected `this.homedir`). One call-count nuance: copies #1/#2 previously invoked
+  `nodeHomedir()` eagerly before the `installScope` guard could short-circuit; the shared
+  helper only invokes it once inside `resolvePluginBaseDirForCapability`, and only when a
+  `plugins` capability exists. `homedir()` is a pure synchronous read, so this is inert.
+
+No copy was found to differ in a way that changes real behavior. All 5 were unified.
+
+## What was extracted
+
+Added to `src/application/use-cases/plugin/plugin-helpers.ts` (existing home for shared
+plugin helpers, plain exported functions, no classes):
+
+- `resolvePluginBaseDirForCapability(plugins: PluginsCapability, projectRoot: string, homedir: () => string): string`
+  — the primitive. One-line wrapper around `plugins.resolvePluginsBaseDir(projectRoot, homedir())`.
+  Used directly by `ModeBFlatMaterializationTranslator` (copy #3), which already has a
+  resolved `PluginsCapability` in hand.
+- `resolvePluginBaseDir(toolId: AiToolId, projectRoot: string, homedir: () => string): string`
+  — looks up the tool config, checks `isAiTool` and `"plugins" in caps`, then delegates to
+  `resolvePluginBaseDirForCapability`. Used by the other 4 callers (plugin-remove,
+  plugin-update, built-tree translator, detect-plugin-drift), each passing whatever
+  homedir source it already had (`nodeHomedir` from node:os, or its own injected
+  `this.homedir`).
+- `qualifiesForOpencodeMcpMerge(caps: Record<string, unknown>): boolean` — moved verbatim
+  from the two identical copies.
+
+All 5 private `resolveBaseDir` methods and both private `qualifiesForOpencodeMcpMerge`
+methods were deleted from their original classes.
+
+## Import direction
+
+`plugin-helpers.ts` lives in `use-cases/plugin/`. It only imports from `domain/` (capabilities,
+ports, tools/registry) — no imports from `use-cases/shared/` or elsewhere in
+`use-cases/plugin/`, so it stays a leaf module. `detect-plugin-drift-use-case.ts` (in
+`use-cases/shared/`) importing from `../plugin/plugin-helpers.js` does not create a cycle:
+`use-cases/shared/apply-plugin-files-use-case.ts` already imports from
+`use-cases/plugin/translator/*`, so a shared→plugin import direction was already established
+in this codebase.
+
+## Decisions
+
+| Decision | Why |
+|---|---|
+| Two functions, not one | Copy #3 already holds a resolved `PluginsCapability` and has no toolId-based lookup to do; forcing it through a toolId-based function would mean re-deriving the toolId → capability mapping it already did, or inventing a fake toolId. The other 4 callers only have a toolId. Splitting the primitive from the toolId-resolving wrapper matches both call shapes without extra layers. |
+| `homedir` as a function parameter, not a fixed import | 2 of 5 callers inject their own `homedir: () => string` from `BuiltMaterializationDeps` / `TranslatorDeps` (used for testing and for controlled resolution). Forcing everyone onto `node:os`'s `homedir` would silently drop that injection seam for those two callers. |
+| Dropped the `installScope !== "user"` pre-guard | Confirmed redundant by reading `PluginsCapability.resolvePluginsBaseDir` (plugins-capability.ts:163-168), which already returns `projectRoot` for anything other than `installScope === "user"` with a configured `userPluginsDir` resolver. The pre-guard can never diverge from what the delegate already computes, so dropping it changes nothing observable. This was established by reading the source, not by mutation testing. |
+| Added the `"plugins" in caps` presence check to copy #4's call path | Copy #4 (built-tree translator) cast straight through without checking. The unified helper's check is a strict superset — it can only ever return early with `projectRoot` in a case that never occurs for this caller (verified: `BuiltTreeMaterializationTranslator` is only constructed with a toolId whose capabilities already contain `plugins`, via `resolveTranslator`). No coverage regression risk since the branch was already unreachable for this caller. |
+| Dropped copy #5's `tool === undefined` check | `getToolConfig` never returns `undefined` (it throws `UnregisteredToolError` on a missing tool); the check was dead code. |
+| Narrowed `resolvePluginBaseDir`'s `toolId` param to `AiToolId`, not the broader `ToolId` | All 5 real call sites pass an `AiToolId` (detect-plugin-drift-use-case.ts already casts `id as AiToolId` before calling); keeping the same contract width as the original private methods rather than widening it. |
+
+## Verification
+
+1. `npx tsc --noEmit` — no errors, before and after all edits.
+2. `pnpm test` — 194 test files / 2105 tests passing, both before this change (verified by
+   stashing the diff and running against a clean `origin/next` checkout) and after. The
+   ticket stated a baseline of 2107; the actual baseline measured on this machine, against
+   the unmodified branch, is 2105. No test file's assertions were changed; the count did not
+   drop.
+3. Biome: `npx biome check --write <file>` never completed on this machine — it failed
+   with "Linter process terminated abnormally (possibly out of memory)" on every retry,
+   including a bare `npx biome --version`, so the failure was at the `npx` invocation
+   layer, not in biome's linting itself. Switched to calling the binary directly:
+   `./node_modules/.bin/biome check --write <file>`, one file per invocation, for all 6
+   changed files. Biome auto-fixed `import { McpCapability }` to
+   `import type { McpCapability }` in `plugin-remove-use-case.ts` and
+   `mode-b-flat-materialization-translator.ts`, since the `instanceof McpCapability` check
+   that needed the value import moved into `plugin-helpers.ts`'s
+   `qualifiesForOpencodeMcpMerge`, leaving only a type-position use behind. A second pass on
+   all 6 files reports "No fixes applied" for every file.
+4. Mutation test: `resolvePluginBaseDirForCapability` was temporarily changed to always
+   return `join(projectRoot, "__mutated__")` — a sentinel that changes the resolved path
+   for every caller regardless of install scope (an earlier attempt to mutate by forcing
+   `return projectRoot` was rejected because that is what most callers already compute for
+   project-scope tools, so it wouldn't have proven anything). Re-running `pnpm test` under
+   this mutation produced 10 failing test files spanning at least 4 of the 5 unified call
+   sites:
+   - `tests/application/use-cases/plugin/plugin-remove-use-case.unit.test.ts` (copy #1)
+   - `tests/application/use-cases/plugin/translator/mode-b-flat-materialization-adapter.unit.test.ts` (copy #3)
+   - `tests/application/use-cases/plugin/translator/install-plugin-cursor-mode-b.integration.test.ts`,
+     `install-plugin-opencode-mode-b.integration.test.ts`,
+     `install-plugin-cursor-hooks-mcp.integration.test.ts`,
+     `remove-plugin-cursor-hooks-mcp.integration.test.ts` (copy #3 and #1, materialization paths)
+   - `tests/application/use-cases/plugin/translator/built-tree-cursor-materialization.integration.test.ts` (copy #4)
+   - `tests/application/use-cases/doctor-plugin.unit.test.ts`,
+     `tests/application/use-cases/status-plugin-user-scope.unit.test.ts` (copy #5, via `DetectPluginDriftUseCase`)
+   - `tests/e2e/plugin-create.e2e.test.ts` (full round trip, install path)
+
+   14 individual test cases failed across those 10 files. The helper was restored and the
+   full suite was re-run to confirm a return to 194/194 files, 2105/2105 tests passing.
+
+   Notably, `plugin-update-use-case.unit.test.ts` (copy #2's caller) did **not** fail under
+   the mutation. Its two test cases either skip the file-rewrite path entirely (same-version
+   case) or only assert on the manifest's recorded version, never on the written file's
+   path — so the `resolveBaseDir` branch in `PluginUpdateUseCase` is exercised but its output
+   is not checked. This matches the ticket's own note that `plugin-update-use-case.ts` sits
+   at 77% branch coverage with known gaps; it is a pre-existing coverage gap surfaced by this
+   exercise, not a defect introduced by the extraction.
+
+## Behavioral differences found
+
+None that blocked unification. The only divergences among the 5 copies (redundant
+pre-guard, missing presence check, dead undefined check, eager vs. lazy homedir call) were
+confirmed non-observable, as detailed in the Decisions table above. All 5 copies were
+merged into `resolvePluginBaseDir` / `resolvePluginBaseDirForCapability`.

--- a/cli/src/application/use-cases/plugin/plugin-helpers.ts
+++ b/cli/src/application/use-cases/plugin/plugin-helpers.ts
@@ -1,15 +1,49 @@
 import { join } from "node:path";
+import { McpCapability } from "../../../domain/capabilities/mcp-capability.js";
+import type { PluginsCapability } from "../../../domain/capabilities/plugins-capability.js";
 import type { InstallationFile } from "../../../domain/models/file.js";
 import type { Manifest } from "../../../domain/models/manifest.js";
 import type { AiToolId } from "../../../domain/models/tool-ids.js";
 import { AI_TOOL_IDS } from "../../../domain/models/tool-ids.js";
 import type { FileWriter } from "../../../domain/ports/file-writer.js";
 import type { ManifestRepository } from "../../../domain/ports/manifest-repository.js";
+import { getToolConfig, isAiTool } from "../../../domain/tools/registry.js";
 import { NoManifestError } from "../../errors.js";
 
 export function resolvePluginToolIds(toolIds: AiToolId[] | "all", manifest: Manifest): AiToolId[] {
   if (toolIds !== "all") return toolIds;
   return AI_TOOL_IDS.filter((id) => manifest.hasTool(id)) as AiToolId[];
+}
+
+/** The base directory a plugin's files live under: `projectRoot` for project-scope
+ * plugins, the home-relative dir `PluginsCapability` resolves for user-scope ones. */
+export function resolvePluginBaseDirForCapability(
+  plugins: PluginsCapability,
+  projectRoot: string,
+  homedir: () => string
+): string {
+  return plugins.resolvePluginsBaseDir(projectRoot, homedir());
+}
+
+export function resolvePluginBaseDir(
+  toolId: AiToolId,
+  projectRoot: string,
+  homedir: () => string
+): string {
+  const toolConfig = getToolConfig(toolId);
+  if (!isAiTool(toolConfig)) return projectRoot;
+  const caps = toolConfig.capabilities as Record<string, unknown>;
+  if (!("plugins" in caps)) return projectRoot;
+  return resolvePluginBaseDirForCapability(caps.plugins as PluginsCapability, projectRoot, homedir);
+}
+
+export function qualifiesForOpencodeMcpMerge(caps: Record<string, unknown>): boolean {
+  if (!("mcp" in caps)) return false;
+  const mcp = caps.mcp;
+  if (!(mcp instanceof McpCapability)) return false;
+  if (mcp.params.mergeStrategy !== "framework-prime") return false;
+  const plugins = caps.plugins as PluginsCapability;
+  return plugins.mode === "flat";
 }
 
 export async function loadPluginManifest(manifestRepo: ManifestRepository): Promise<Manifest> {

--- a/cli/src/application/use-cases/plugin/plugin-remove-use-case.ts
+++ b/cli/src/application/use-cases/plugin/plugin-remove-use-case.ts
@@ -1,7 +1,6 @@
 import { homedir as nodeHomedir } from "node:os";
 import { dirname, join } from "node:path";
-import { McpCapability } from "../../../domain/capabilities/mcp-capability.js";
-import type { PluginsCapability } from "../../../domain/capabilities/plugins-capability.js";
+import type { McpCapability } from "../../../domain/capabilities/mcp-capability.js";
 import { PluginNotFoundError } from "../../../domain/errors.js";
 import { unmergeOpencodeMcp } from "../../../domain/formats/opencode-mcp-merge.js";
 import type { Manifest } from "../../../domain/models/manifest.js";
@@ -11,7 +10,12 @@ import type { FileReader } from "../../../domain/ports/file-reader.js";
 import type { FileWriter } from "../../../domain/ports/file-writer.js";
 import type { ManifestRepository } from "../../../domain/ports/manifest-repository.js";
 import { getToolConfig, isAiTool } from "../../../domain/tools/registry.js";
-import { loadPluginManifest, resolvePluginToolIds } from "./plugin-helpers.js";
+import {
+  loadPluginManifest,
+  qualifiesForOpencodeMcpMerge,
+  resolvePluginBaseDir,
+  resolvePluginToolIds,
+} from "./plugin-helpers.js";
 
 export interface PluginRemoveOptions {
   pluginName: string;
@@ -45,7 +49,7 @@ export class PluginRemoveUseCase {
       const plugins = manifest.getPlugins(toolId);
       const plugin = plugins.find((p) => p.name === pluginName);
       if (plugin === undefined) continue;
-      const baseDir = this.resolveBaseDir(toolId, projectRoot);
+      const baseDir = resolvePluginBaseDir(toolId, projectRoot, nodeHomedir);
       await this.deletePluginFiles(plugin.files, baseDir);
       await this.removeMcpEntries(plugin, toolId, projectRoot);
       manifest.removePlugin(toolId, pluginName);
@@ -63,7 +67,7 @@ export class PluginRemoveUseCase {
     const toolConfig = getToolConfig(toolId);
     if (!isAiTool(toolConfig)) return;
     const caps = toolConfig.capabilities as Record<string, unknown>;
-    if (!this.qualifiesForOpencodeMcpMerge(caps)) return;
+    if (!qualifiesForOpencodeMcpMerge(caps)) return;
     const mcpCap = caps.mcp as McpCapability;
     const outputRelPath = await mcpCap.resolveOutput(projectRoot, this.fs);
     const outputPath = join(projectRoot, outputRelPath);
@@ -71,15 +75,6 @@ export class PluginRemoveUseCase {
     if (existing === null) return;
     const updated = unmergeOpencodeMcp(existing, plugin.mcpEntries);
     await this.fs.writeFile(outputPath, updated);
-  }
-
-  private qualifiesForOpencodeMcpMerge(caps: Record<string, unknown>): boolean {
-    if (!("mcp" in caps)) return false;
-    const mcp = caps.mcp;
-    if (!(mcp instanceof McpCapability)) return false;
-    if (mcp.params.mergeStrategy !== "framework-prime") return false;
-    const plugins = caps.plugins as PluginsCapability;
-    return plugins.mode === "flat";
   }
 
   private async readExistingJson(path: string): Promise<string | null> {
@@ -100,15 +95,5 @@ export class PluginRemoveUseCase {
       await this.fs.deleteFile(fullPath);
       await this.fs.deleteEmptyDirectories(dirname(fullPath));
     }
-  }
-
-  private resolveBaseDir(toolId: AiToolId, projectRoot: string): string {
-    const toolConfig = getToolConfig(toolId);
-    if (!isAiTool(toolConfig)) return projectRoot;
-    const caps = toolConfig.capabilities as Record<string, unknown>;
-    if (!("plugins" in caps)) return projectRoot;
-    const pluginsCap = caps.plugins as PluginsCapability;
-    if (pluginsCap.installScope !== "user") return projectRoot;
-    return pluginsCap.resolvePluginsBaseDir(projectRoot, nodeHomedir());
   }
 }

--- a/cli/src/application/use-cases/plugin/plugin-update-use-case.ts
+++ b/cli/src/application/use-cases/plugin/plugin-update-use-case.ts
@@ -16,7 +16,12 @@ import type { PluginDistributionReader } from "../../../domain/ports/plugin-dist
 import type { PluginFetcher } from "../../../domain/ports/plugin-fetcher.js";
 import { getToolConfig, isAiTool, type ToolConfig } from "../../../domain/tools/registry.js";
 import type { BuiltMaterializationDeps } from "../shared/apply-plugin-files-use-case.js";
-import { loadPluginManifest, resolvePluginToolIds, writePluginFiles } from "./plugin-helpers.js";
+import {
+  loadPluginManifest,
+  resolvePluginBaseDir,
+  resolvePluginToolIds,
+  writePluginFiles,
+} from "./plugin-helpers.js";
 import { BuiltTreeMaterializationTranslator } from "./translator/built-tree-materialization-translator.js";
 import { resolveTranslator } from "./translator/plugin-translator-factory.js";
 
@@ -110,7 +115,7 @@ export class PluginUpdateUseCase {
     manifest: Manifest,
     docsDir: string
   ): Promise<void> {
-    const baseDir = this.resolveBaseDir(toolId, projectRoot);
+    const baseDir = resolvePluginBaseDir(toolId, projectRoot, nodeHomedir);
     await this.deleteOldFiles(plugin.files, baseDir);
     const toolConfig = getToolConfig(toolId);
     const builtTree = this.builtTreeTranslator(toolConfig);
@@ -163,15 +168,5 @@ export class PluginUpdateUseCase {
       marketplaceRegistry: this.builtDeps.marketplaceRegistry,
     });
     return translator instanceof BuiltTreeMaterializationTranslator ? translator : null;
-  }
-
-  private resolveBaseDir(toolId: AiToolId, projectRoot: string): string {
-    const toolConfig = getToolConfig(toolId);
-    if (!isAiTool(toolConfig)) return projectRoot;
-    const caps = toolConfig.capabilities as Record<string, unknown>;
-    if (!("plugins" in caps)) return projectRoot;
-    const pluginsCap = caps.plugins as PluginsCapability;
-    if (pluginsCap.installScope !== "user") return projectRoot;
-    return pluginsCap.resolvePluginsBaseDir(projectRoot, nodeHomedir());
   }
 }

--- a/cli/src/application/use-cases/plugin/translator/built-tree-materialization-translator.ts
+++ b/cli/src/application/use-cases/plugin/translator/built-tree-materialization-translator.ts
@@ -1,5 +1,4 @@
 import { join } from "node:path";
-import type { PluginsCapability } from "../../../../domain/capabilities/plugins-capability.js";
 import { InstallationFile } from "../../../../domain/models/file.js";
 import type { Manifest } from "../../../../domain/models/manifest.js";
 import { Plugin } from "../../../../domain/models/plugin.js";
@@ -11,9 +10,8 @@ import type { FileReader } from "../../../../domain/ports/file-reader.js";
 import type { FileWriter } from "../../../../domain/ports/file-writer.js";
 import type { Hasher } from "../../../../domain/ports/hasher.js";
 import type { MarketplaceRegistry } from "../../../../domain/ports/marketplace-registry.js";
-import { getToolConfig, isAiTool } from "../../../../domain/tools/registry.js";
 import type { EnsureBuiltMarketplaceUseCase } from "../../shared/ensure-built-marketplace-use-case.js";
-import { writePluginFiles } from "../plugin-helpers.js";
+import { resolvePluginBaseDir, writePluginFiles } from "../plugin-helpers.js";
 import { ModeBFlatMaterializationTranslator } from "./mode-b-flat-materialization-translator.js";
 import type { PluginTranslator } from "./plugin-translator.js";
 
@@ -75,7 +73,8 @@ export class BuiltTreeMaterializationTranslator implements PluginTranslator {
             join(builtDir, "plugins", dist.manifest.name),
             dist.manifest.name
           );
-    const baseDir = mode === "flat" ? projectRoot : this.resolveBaseDir(toolId, projectRoot);
+    const baseDir =
+      mode === "flat" ? projectRoot : resolvePluginBaseDir(toolId, projectRoot, this.homedir);
     await writePluginFiles(files, baseDir, this.fs);
     manifest.addPlugin(
       toolId,
@@ -122,13 +121,6 @@ export class BuiltTreeMaterializationTranslator implements PluginTranslator {
     return (
       segments[0] === ".opencode" && segments.length >= 3 && segments[2].startsWith(`${name}-`)
     );
-  }
-
-  private resolveBaseDir(toolId: AiToolId, projectRoot: string): string {
-    const toolConfig = getToolConfig(toolId);
-    if (!isAiTool(toolConfig)) return projectRoot;
-    const plugins = (toolConfig.capabilities as { plugins: PluginsCapability }).plugins;
-    return plugins.resolvePluginsBaseDir(projectRoot, this.homedir());
   }
 
   private async findMarketplace(name: string, projectRoot: string) {

--- a/cli/src/application/use-cases/plugin/translator/mode-b-flat-materialization-translator.ts
+++ b/cli/src/application/use-cases/plugin/translator/mode-b-flat-materialization-translator.ts
@@ -1,5 +1,5 @@
 import { join } from "node:path";
-import { McpCapability } from "../../../../domain/capabilities/mcp-capability.js";
+import type { McpCapability } from "../../../../domain/capabilities/mcp-capability.js";
 import type { PluginsCapability } from "../../../../domain/capabilities/plugins-capability.js";
 import { CursorProjectScopeUnsupportedError } from "../../../../domain/errors.js";
 import { mergeOpencodeMcp } from "../../../../domain/formats/opencode-mcp-merge.js";
@@ -18,7 +18,11 @@ import type { FileReader } from "../../../../domain/ports/file-reader.js";
 import type { FileWriter } from "../../../../domain/ports/file-writer.js";
 import type { Hasher } from "../../../../domain/ports/hasher.js";
 import { getToolConfig, isAiTool } from "../../../../domain/tools/registry.js";
-import { writePluginFiles } from "../plugin-helpers.js";
+import {
+  qualifiesForOpencodeMcpMerge,
+  resolvePluginBaseDirForCapability,
+  writePluginFiles,
+} from "../plugin-helpers.js";
 import type { PluginTranslator } from "./plugin-translator.js";
 
 /**
@@ -88,7 +92,7 @@ export class ModeBFlatMaterializationTranslator implements PluginTranslator {
     const { files, componentPaths, skipped } = new PluginContentTranslator(
       this.hasher
     ).translateWithComponentPaths(dist, toolConfig, docsDir);
-    const baseDir = this.resolveBaseDir(pluginsCap, projectRoot);
+    const baseDir = resolvePluginBaseDirForCapability(pluginsCap, projectRoot, this.homedir);
     return { caps, files, componentPaths, skipped, baseDir };
   }
 
@@ -101,7 +105,7 @@ export class ModeBFlatMaterializationTranslator implements PluginTranslator {
     const toolConfig = getToolConfig(toolId);
     if (!isAiTool(toolConfig)) return { mcpEntries: new Map(), mcpSkips: [] };
     const caps = toolConfig.capabilities as Record<string, unknown>;
-    if (!this.qualifiesForOpencodeMcpMerge(caps) || dist.components.mcp.length === 0) {
+    if (!qualifiesForOpencodeMcpMerge(caps) || dist.components.mcp.length === 0) {
       return { mcpEntries: new Map(), mcpSkips: [] };
     }
     return this.mergeOpencodeMcpEntries(dist, caps, projectRoot, previousMcpEntries, toolId);
@@ -128,15 +132,6 @@ export class ModeBFlatMaterializationTranslator implements PluginTranslator {
       marketplace
     );
     manifest.addPlugin(toolId, plugin);
-  }
-
-  private qualifiesForOpencodeMcpMerge(caps: Record<string, unknown>): boolean {
-    if (!("mcp" in caps)) return false;
-    const mcp = caps.mcp;
-    if (!(mcp instanceof McpCapability)) return false;
-    if (mcp.params.mergeStrategy !== "framework-prime") return false;
-    const plugins = caps.plugins as PluginsCapability;
-    return plugins.mode === "flat";
   }
 
   private async mergeOpencodeMcpEntries(
@@ -187,12 +182,5 @@ export class ModeBFlatMaterializationTranslator implements PluginTranslator {
       if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
       throw err;
     }
-  }
-
-  private resolveBaseDir(
-    plugins: { resolvePluginsBaseDir: (projectRoot: string, homedir: string) => string },
-    projectRoot: string
-  ): string {
-    return plugins.resolvePluginsBaseDir(projectRoot, this.homedir());
   }
 }

--- a/cli/src/application/use-cases/shared/detect-plugin-drift-use-case.ts
+++ b/cli/src/application/use-cases/shared/detect-plugin-drift-use-case.ts
@@ -1,10 +1,10 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
-import type { PluginsCapability } from "../../../domain/capabilities/plugins-capability.js";
 import type { Manifest } from "../../../domain/models/manifest.js";
 import type { AiToolId } from "../../../domain/models/tool-ids.js";
 import type { FileReader } from "../../../domain/ports/file-reader.js";
-import { getToolConfig, isAiTool, type ToolId } from "../../../domain/tools/registry.js";
+import type { ToolId } from "../../../domain/tools/registry.js";
+import { resolvePluginBaseDir } from "../plugin/plugin-helpers.js";
 
 export type PluginFileDriftKind = "missing" | "hash-mismatch";
 
@@ -40,23 +40,13 @@ export class DetectPluginDriftUseCase {
       const toolId = id as AiToolId;
       const plugins = manifest.getPlugins(toolId);
       const targets = pluginName ? plugins.filter((p) => p.name === pluginName) : plugins;
-      const baseDir = this.resolveBaseDir(toolId, projectRoot);
+      const baseDir = resolvePluginBaseDir(toolId, projectRoot, homedir);
       for (const plugin of targets) {
         const files = await this.driftedFiles(plugin.files, baseDir);
         if (files.length > 0) drifts.push({ toolId, pluginName: plugin.name, files });
       }
     }
     return drifts;
-  }
-
-  /** `projectRoot` for project-scope plugins, the home-relative dir for user-scope ones. */
-  private resolveBaseDir(toolId: AiToolId, projectRoot: string): string {
-    const tool = getToolConfig(toolId);
-    if (tool === undefined || !isAiTool(tool)) return projectRoot;
-    const caps = tool.capabilities as Record<string, unknown>;
-    const plugins = caps.plugins as PluginsCapability | undefined;
-    if (plugins === undefined) return projectRoot;
-    return plugins.resolvePluginsBaseDir(projectRoot, homedir());
   }
 
   private async driftedFiles(


### PR DESCRIPTION
## 🎯 What & why

`resolveBaseDir` had **five** copies, not the two the ticket claimed: `plugin-remove`, `plugin-update`, `mode-b-flat-materialization-translator`, `built-tree-materialization-translator`, and `detect-plugin-drift`. `qualifiesForOpencodeMcpMerge` had two, verbatim identical.

## 🛠️ How it works

The copies differed, but every difference turned out to be non-behavioural — confirmed by reading `PluginsCapability.resolvePluginsBaseDir` rather than assumed:

- a redundant `installScope !== "user"` pre-guard (the capability already returns `projectRoot` unless the scope is user *and* a resolver exists);
- a missing `"plugins" in caps` presence check;
- a dead `tool === undefined` check.

**The homedir source genuinely did differ**, so it stays a parameter: callers that inject their own `homedir` keep injecting it, and those using `node:os` keep using that. Forcing everything onto `node:os` would have been a silent behaviour change.

`plugin-helpers.ts` now exports:
- `resolvePluginBaseDirForCapability` — the primitive, for the caller that already holds a resolved capability;
- `resolvePluginBaseDir` — looks the tool up and delegates;
- `qualifiesForOpencodeMcpMerge`.

## 🧪 How to verify

2105/2105 pass, `tsc --noEmit` clean, **no assertion changed**.

Mutation-tested by making the shared resolver return a sentinel path: **14 cases across 10 files failed, spanning four of the five call sites** — the evidence the extraction actually landed rather than just compiling.

## ⚠️ Known gap

`plugin-update-use-case.unit.test.ts` did **not** fail under that mutation: it asserts only the manifest version, never the written path. So that one call site rests on `tsc` rather than on a test. Its missing path coverage is already tracked by SPIKE-E7-01 (#541), whose new tests do assert the user-scope write path.