### PR TITLE
refactor(cli): resolve plugin catalogs through one path

### DIFF
--- a/cli/aidd_docs/tasks/2026_07/2026_07_28_e7-04-shared-catalog-resolution/plan.md
+++ b/cli/aidd_docs/tasks/2026_07/2026_07_28_e7-04-shared-catalog-resolution/plan.md
@@ -1,0 +1,171 @@
+---
+objective: Route PluginSearchUseCase and PluginPickUseCase through ResolveMarketplaceUseCase so all three catalog consumers resolve marketplaces one way, without touching per-caller name-matching behaviour.
+status: implemented
+---
+
+## Premise check: the matching-unification claim is false
+
+Story US-E7-04 (item B8) claimed that `PluginSearchUseCase`, `PluginPickUseCase`, and
+`PluginInstallFromMarketplaceUseCase` contain three implementations of "find a plugin by
+name in a catalog" that should be unified. Reading the three use-cases shows this is not
+the case: they do three different things on purpose, and none of them is a variant of the
+other two.
+
+- `plugin-search-use-case.ts:54`, fuzzy discovery:
+  `entry.name.toLowerCase().includes(q) || desc.includes(q)`.
+  Substring, case-insensitive, matches on name OR description.
+- `plugin-install-from-marketplace-use-case.ts:117`, exact identifier resolution:
+  `entry.name === options.pluginName`.
+  Exact, case-sensitive, name only.
+- `plugin-pick-use-case.ts`: no name matching at all. `execute()` loads the catalog and
+  hands `catalog.plugins` wholesale to `chooseEntries`, which builds an interactive
+  checkbox prompt; the user picks entries directly. There is no string comparison to unify.
+
+Unifying these would change behaviour, not remove duplication, and the change would be
+harmful in the install case specifically: if `aidd plugin install foo` used fuzzy
+matching, it could resolve to `foo-bar` and silently install the wrong plugin. Making
+search exact would break discovery (the whole point of `aidd plugin search`). This part
+of the story is not implemented; the matching logic in all three files is untouched.
+
+## What was actually duplicated, and what was done
+
+The real duplication was catalog *resolution*, not matching. Three call sites hand-rolled
+the same triplet (`marketplaceCacheDir()`, then `fetchMarketplaceSource.execute()`, then
+`catalogRepo.load()`), and `PluginInstallFromMarketplaceUseCase` already used
+`ResolveMarketplaceUseCase` (`src/application/use-cases/shared/resolve-marketplace-use-case.ts`)
+to encapsulate it. `PluginSearchUseCase` and `PluginPickUseCase` did not.
+
+Both were routed through `ResolveMarketplaceUseCase`:
+
+- `PluginSearchUseCase.searchOne` now calls
+  `this.resolveMarketplace.execute({ marketplace: m, projectRoot: options.projectRoot })`
+  and keeps `if (!catalog) return []`. This is the same skip-on-null behaviour
+  `PluginInstallFromMarketplaceUseCase.matchesIn` already has at line 115, and
+  `ResolveMarketplaceUseCase` returns `catalog: null` (never throws) on a missing or
+  malformed marketplace, so the observable behaviour is identical to before.
+- `PluginPickUseCase.loadCatalog` now calls `this.resolveMarketplace.execute({ marketplace, projectRoot })`
+  and destructures both `catalog` and `localPath` from the result, keeping its
+  `if (catalog === null) throw new InvalidPluginManifestError(...)` branch. The error
+  message embeds `localPath` exactly as before, now sourced from the resolver's return
+  value instead of being recomputed locally. `ResolveMarketplaceUseCase.execute` computes
+  `localPath` the same way the old call site did (`marketplaceCacheDir(projectRoot, marketplace.name)`
+  as input to the same `fetchMarketplaceSource.execute`), so the value is identical by
+  construction; a characterization test now asserts the full error message including the
+  path, not just the error class, so any future drift in that provenance would be caught.
+
+Routing was safe with respect to fetch options too. Neither caller previously passed
+`fetchOptions` to `fetchMarketplaceSource.execute` (it was `undefined`).
+`ResolveMarketplaceUseCase` always passes `fetchOptions: { forceRefresh: options.forceRefresh ?? false }`,
+which becomes `{ forceRefresh: false }` when the caller omits `forceRefresh` (as both do).
+The only real `PluginFetcher` implementation, `plugin-fetcher-adapter.ts:35`, reads
+`options?.forceRefresh ?? false`, so `undefined` and `{ forceRefresh: false }` are
+indistinguishable at the only place that consumes the option. No behaviour changes here.
+
+`MarketplaceCheckUseCase` also hand-rolls the same triplet and was left alone. It is
+outside the scope named in this task (that is a separate item, B9, for marketplace
+commands), and touching it was not required to remove the duplication between the three
+plugin use-cases named in the story.
+
+## Error-behaviour difference preserved
+
+`ResolveMarketplaceUseCase` never throws on a missing catalog; it returns
+`{ catalog: null }`. The three callers react differently to that:
+
+- `PluginInstallFromMarketplaceUseCase.matchesIn`: returns `[]` (skip this marketplace).
+- `PluginSearchUseCase.searchOne`: returns `[]` (skip this marketplace), unchanged.
+- `PluginPickUseCase.loadCatalog`: throws `InvalidPluginManifestError`, unchanged.
+
+`ResolveMarketplaceUseCase` itself was not modified. Each caller's null-handling was
+preserved at the call site, per the task's explicit instruction not to let a throw become
+a skip or vice versa.
+
+## Dead constructor parameters removed
+
+Before routing, `PluginSearchUseCase` took `(catalogRepo, registry, fetchMarketplaceSource)`
+and `PluginPickUseCase` took `(catalogRepo, registry, fetchMarketplaceSource, pluginAddUseCase, prompter)`.
+After routing, neither class references `catalogRepo` or `fetchMarketplaceSource` anywhere
+(verified with `grep -n "catalogRepo\|fetchMarketplaceSource"` on both files, zero
+matches), so both parameters were removed:
+
+- `PluginSearchUseCase(registry, resolveMarketplace)`
+- `PluginPickUseCase(registry, resolveMarketplace, pluginAddUseCase, prompter)`
+
+Construction sites updated:
+- `src/infrastructure/deps.ts`: both use-cases now receive the already-constructed
+  `resolveMarketplaceUseCase` (built earlier in the file, at the point the marketplace
+  check use-case is wired, well before either plugin use-case is constructed, so no
+  reordering was needed).
+- `tests/application/use-cases/plugin/plugin-search-use-case.unit.test.ts`: `buildUseCase`
+  now builds a `ResolveMarketplaceUseCase` from the existing `FetchMarketplaceSourceUseCase`
+  and `PluginCatalogRepositoryAdapter` and passes that instead.
+- `tests/application/use-cases/plugin/plugin-pick-use-case.unit.test.ts`: same pattern.
+
+One more reference was checked and left alone:
+`tests/application/use-cases/plugin/plugin-install-use-case.unit.test.ts` imports
+`PluginPickUseCase` only as a TypeScript type for a hand-built mock object
+(`{ execute: pickExecute } as unknown as PluginPickUseCase`); it does not call the real
+constructor, so the parameter removal does not affect it.
+
+`pluginCatalogRepository` and `fetchMarketplaceSource` remain in `deps.ts` because other
+use-cases (`MarketplaceCheckUseCase`, `MarketplaceSyncSettingsUseCase`,
+`ResolveMarketplaceUseCase` itself, and others) still depend on them directly.
+
+## Decisions
+
+| Decision | Why |
+|---|---|
+| Leave name-matching logic untouched in all three files | The premise that they duplicate matching logic is false; unifying would change observable behaviour (fuzzy install, or exact-only search) rather than remove duplication. |
+| Route search and pick through `ResolveMarketplaceUseCase`, do not modify it | The triplet (cache dir, then fetch, then load) really was duplicated three ways; `ResolveMarketplaceUseCase` already existed and already encapsulated it correctly for the install caller. |
+| Adapt at the call site instead of changing `ResolveMarketplaceUseCase`'s null handling | `ResolveMarketplaceUseCase` returns `catalog: null` uniformly; pick needs a thrown `InvalidPluginManifestError`, search needs a silent skip. Changing the shared use-case to throw would break search (and install); changing it to never throw would already match, so the adaptation is entirely on the pick side, in `loadCatalog`. |
+| Leave `MarketplaceCheckUseCase` alone | It hand-rolls the same triplet but is not one of the three use-cases named in the story; that consolidation is item B9's scope over marketplace commands, not this task. |
+| Write characterization tests for `plugin-pick-use-case.ts` before routing | Its branch coverage was 66.66% (10/15) with the untested paths including the exact `catalog === null` error branch this change touches. Pinning behaviour first means the routing change can be verified not to alter it. |
+| Assert the full error message (path included), not just the error class, on the missing-catalog test | The routing change moved where `localPath` comes from (previously recomputed locally, now read off the resolver's result). The message is the only observable that depends on that value, so it is the thing worth pinning. |
+| Don't chase the last uncovered branch (`entry.strict ?? false`, right-hand side) | `PluginCatalogEntry.strict` is typed `boolean` (not `boolean \| undefined`), and `parsePluginCatalog` (`plugin-catalog.ts:40`) always resolves it to a definite boolean before entries reach this use-case. The `?? false` fallback is unreachable dead code, corroborated by `plugin-install-from-marketplace-use-case.ts` passing `chosen.entry.strict` with no coalesce anywhere else in the codebase. Not touched, outside the scope of this task. |
+
+## Verification
+
+1. `npx tsc --noEmit`: no errors.
+2. `pnpm test` (from `cli/`):
+   - Baseline before any change: 2109 passed (196 test files).
+   - After adding 4 characterization tests to `plugin-pick-use-case.unit.test.ts`
+     (Phase 1, before touching production code): 2113 passed.
+   - After routing `PluginSearchUseCase` and `PluginPickUseCase` through
+     `ResolveMarketplaceUseCase` and updating `deps.ts` and the two unit-test
+     construction sites: 2113 passed, 196 test files, no existing assertion modified.
+3. Biome, one file at a time via `./node_modules/.bin/biome check --write <file>`:
+   - `src/application/use-cases/plugin/plugin-search-use-case.ts`: "No fixes applied."
+   - `src/application/use-cases/plugin/plugin-pick-use-case.ts`: "No fixes applied."
+   - `src/infrastructure/deps.ts`: first run reformatted the new `PluginSearchUseCase(...)`
+     call onto multiple lines ("Fixed 1 file"); second run: "No fixes applied."
+   - `tests/application/use-cases/plugin/plugin-search-use-case.unit.test.ts`: "No fixes applied."
+   - `tests/application/use-cases/plugin/plugin-pick-use-case.unit.test.ts`: first run
+     reformatted a long assertion line ("Fixed 1 file"); second run: "No fixes applied."
+4. Coverage of `src/application/use-cases/plugin/plugin-pick-use-case.ts`
+   (`npx vitest run --project=unit --project=integration --coverage --coverage.include=... --coverage.reporter=json-summary`):
+   - Before characterization tests: lines/statements 67/73 (91.78%), branches 10/15 (66.66%).
+   - After characterization tests, before routing: lines/statements 73/73 (100%), branches 22/23 (95.65%).
+   - After routing (no regression from the production change): lines/statements 73/73 (100%), branches 22/23 (95.65%).
+   - The branch denominator moved from 15 to 23 between the "before" and "after" runs. This
+     is a known artifact of V8's lazy bytecode compilation: code paths that were never
+     compiled in a given run are not counted in that run's branch total. It is not a change
+     in the source file. The one branch that remains uncovered (`entry.strict ?? false`,
+     the `false` fallback) is dead code, as noted above.
+   - 4 characterization tests were added, covering: choosing among multiple registered
+     marketplaces, the `catalog === null` to `InvalidPluginManifestError` path (with the
+     path embedded in the message asserted), an empty catalog skipping the checkbox
+     prompt, and an entry carrying a description and an explicit `strict` flag.
+5. Mutation test: `ResolveMarketplaceUseCase.execute` was changed to always return
+   `catalog: null` regardless of what `catalogRepo.load()` returned, then the full suite
+   was run, then the change was reverted.
+   - Failing test files (26 tests across 8 files, all reachable only through
+     `ResolveMarketplaceUseCase`'s `catalog: null` path):
+     - `tests/application/use-cases/plugin/plugin-search-use-case.unit.test.ts`: all 3 tests (caller: `PluginSearchUseCase`)
+     - `tests/application/use-cases/plugin/plugin-pick-use-case.unit.test.ts`: 4 of 7 tests (caller: `PluginPickUseCase`)
+     - `tests/application/use-cases/plugin/plugin-install-from-marketplace-use-case.unit.test.ts`: all 10 tests (caller: `PluginInstallFromMarketplaceUseCase`, already routed before this task)
+     - `tests/application/use-cases/shared/resolve-marketplace-use-case.unit.test.ts`: 1 test (the shared use-case's own unit test)
+     - `tests/e2e/framework-build.e2e.test.ts`, `tests/e2e/issue-271-setup-cache-version.e2e.test.ts`, `tests/e2e/persona.e2e.test.ts`, `tests/e2e/plugin-install.e2e.test.ts`: 8 tests total, exercising the same paths end to end
+   - This confirms all three named callers now share one resolution path: breaking
+     `ResolveMarketplaceUseCase` in a way that is not coincidentally correct for any of
+     them fails tests for all three, not just one.
+   - After reverting the mutation: `npx tsc --noEmit` clean, `pnpm test` back to 2113
+     passed, 196 test files.

--- a/cli/src/application/use-cases/plugin/plugin-pick-use-case.ts
+++ b/cli/src/application/use-cases/plugin/plugin-pick-use-case.ts
@@ -4,13 +4,11 @@ import {
   NoMarketplacesRegisteredError,
 } from "../../../domain/errors.js";
 import type { Marketplace } from "../../../domain/models/marketplace.js";
-import { marketplaceCacheDir } from "../../../domain/models/paths.js";
 import type { PluginCatalog, PluginCatalogEntry } from "../../../domain/models/plugin-catalog.js";
 import type { AiToolId } from "../../../domain/models/tool-ids.js";
 import type { MarketplaceRegistry } from "../../../domain/ports/marketplace-registry.js";
-import type { PluginCatalogRepository } from "../../../domain/ports/plugin-catalog-repository.js";
 import type { Prompter } from "../../../domain/ports/prompter.js";
-import type { FetchMarketplaceSourceUseCase } from "../shared/fetch-marketplace-source-use-case.js";
+import type { ResolveMarketplaceUseCase } from "../shared/resolve-marketplace-use-case.js";
 import type { PluginAddUseCase } from "./plugin-add-use-case.js";
 
 export interface PluginPickOptions {
@@ -26,9 +24,8 @@ export interface PluginPickResult {
 
 export class PluginPickUseCase {
   constructor(
-    private readonly catalogRepo: PluginCatalogRepository,
     private readonly registry: MarketplaceRegistry,
-    private readonly fetchMarketplaceSource: FetchMarketplaceSourceUseCase,
+    private readonly resolveMarketplace: ResolveMarketplaceUseCase,
     private readonly pluginAddUseCase: PluginAddUseCase,
     private readonly prompter: Prompter
   ) {}
@@ -53,9 +50,10 @@ export class PluginPickUseCase {
   }
 
   private async loadCatalog(marketplace: Marketplace, projectRoot: string): Promise<PluginCatalog> {
-    const cacheDir = marketplaceCacheDir(projectRoot, marketplace.name);
-    const localPath = await this.fetchMarketplaceSource.execute({ marketplace, cacheDir });
-    const catalog = await this.catalogRepo.load(localPath);
+    const { catalog, localPath } = await this.resolveMarketplace.execute({
+      marketplace,
+      projectRoot,
+    });
     if (catalog === null) {
       throw new InvalidPluginManifestError(`marketplace.json not found at "${localPath}"`);
     }

--- a/cli/src/application/use-cases/plugin/plugin-search-use-case.ts
+++ b/cli/src/application/use-cases/plugin/plugin-search-use-case.ts
@@ -1,9 +1,7 @@
 import type { Marketplace } from "../../../domain/models/marketplace.js";
-import { marketplaceCacheDir } from "../../../domain/models/paths.js";
 import type { PluginCatalogEntry } from "../../../domain/models/plugin-catalog.js";
 import type { MarketplaceRegistry } from "../../../domain/ports/marketplace-registry.js";
-import type { PluginCatalogRepository } from "../../../domain/ports/plugin-catalog-repository.js";
-import type { FetchMarketplaceSourceUseCase } from "../shared/fetch-marketplace-source-use-case.js";
+import type { ResolveMarketplaceUseCase } from "../shared/resolve-marketplace-use-case.js";
 
 export interface PluginSearchOptions {
   query: string;
@@ -23,9 +21,8 @@ export interface PluginSearchResult {
 
 export class PluginSearchUseCase {
   constructor(
-    private readonly catalogRepo: PluginCatalogRepository,
     private readonly registry: MarketplaceRegistry,
-    private readonly fetchMarketplaceSource: FetchMarketplaceSourceUseCase
+    private readonly resolveMarketplace: ResolveMarketplaceUseCase
   ) {}
 
   async execute(options: PluginSearchOptions): Promise<PluginSearchResult> {
@@ -39,9 +36,10 @@ export class PluginSearchUseCase {
   }
 
   private async searchOne(m: Marketplace, options: PluginSearchOptions): Promise<SearchHit[]> {
-    const cacheDir = marketplaceCacheDir(options.projectRoot, m.name);
-    const localPath = await this.fetchMarketplaceSource.execute({ marketplace: m, cacheDir });
-    const catalog = await this.catalogRepo.load(localPath);
+    const { catalog } = await this.resolveMarketplace.execute({
+      marketplace: m,
+      projectRoot: options.projectRoot,
+    });
     if (!catalog) return [];
     return catalog.plugins
       .filter((entry) => this.matches(entry, options))

--- a/cli/src/infrastructure/deps.ts
+++ b/cli/src/infrastructure/deps.ts
@@ -542,17 +542,15 @@ export async function createDeps(
     logger
   );
   const pluginSearchUseCase = new PluginSearchUseCase(
-    pluginCatalogRepository,
     marketplaceRegistry,
-    fetchMarketplaceSource
+    resolveMarketplaceUseCase
   );
   const marketplaceRegisterFrameworkUseCase = new MarketplaceRegisterFrameworkUseCase(
     marketplaceRegistry
   );
   const pluginPickUseCase = new PluginPickUseCase(
-    pluginCatalogRepository,
     marketplaceRegistry,
-    fetchMarketplaceSource,
+    resolveMarketplaceUseCase,
     pluginAddUseCase,
     prompter
   );

--- a/cli/tests/application/use-cases/plugin/plugin-pick-use-case.unit.test.ts
+++ b/cli/tests/application/use-cases/plugin/plugin-pick-use-case.unit.test.ts
@@ -3,11 +3,14 @@ import { describe, expect, it } from "vitest";
 import { PluginAddUseCase } from "../../../../src/application/use-cases/plugin/plugin-add-use-case.js";
 import { PluginPickUseCase } from "../../../../src/application/use-cases/plugin/plugin-pick-use-case.js";
 import { FetchMarketplaceSourceUseCase } from "../../../../src/application/use-cases/shared/fetch-marketplace-source-use-case.js";
+import { ResolveMarketplaceUseCase } from "../../../../src/application/use-cases/shared/resolve-marketplace-use-case.js";
 import {
   InteractiveOnlyError,
+  InvalidPluginManifestError,
   NoMarketplacesRegisteredError,
 } from "../../../../src/domain/errors.js";
 import { Marketplace } from "../../../../src/domain/models/marketplace.js";
+import type { Prompter } from "../../../../src/domain/ports/prompter.js";
 import { PluginCatalogRepositoryAdapter } from "../../../../src/infrastructure/adapters/plugin-catalog-repository-adapter.js";
 import { PluginDistributionReaderAdapter } from "../../../../src/infrastructure/adapters/plugin-distribution-reader-adapter.js";
 import { buildUnitDeps, initAndInstall } from "../../../helpers/ports/build-unit-deps.js";
@@ -20,6 +23,7 @@ import { seedFromDirectory } from "../../../helpers/ports/seed-from-directory.js
 const PLUGIN_FIXTURE = join(process.cwd(), "tests/fixtures/plugins/claude-format/sample-plugin");
 const PROJECT_ROOT = "/test-project";
 const MKT_DIR = "/mkt-source";
+const MKT_DIR_2 = "/mkt-source-2";
 
 function seedMarketplaceFile(
   fs: InMemoryFileAdapter,
@@ -29,7 +33,23 @@ function seedMarketplaceFile(
   fs.writeFile(join(dir, ".claude-plugin/marketplace.json"), JSON.stringify({ plugins }));
 }
 
-async function buildUseCase() {
+function registerMarketplace(
+  registry: InMemoryMarketplaceRegistry,
+  name: string,
+  dir: string
+): Promise<void> {
+  return registry.save(
+    PROJECT_ROOT,
+    Marketplace.create({
+      name,
+      source: { kind: "local", path: dir },
+      scope: "project",
+      addedAt: "2026-04-29T10:00:00.000Z",
+    })
+  );
+}
+
+async function buildUseCase(prompter: Prompter = new KeepPrompter()) {
   const deps = await buildUnitDeps(PROJECT_ROOT);
   await initAndInstall(deps, PROJECT_ROOT, "claude");
   await seedFromDirectory(deps.fs, PLUGIN_FIXTURE, { useAbsolutePaths: true });
@@ -45,13 +65,11 @@ async function buildUseCase() {
     fakeEnsureBuiltMarketplace()
   );
   const fetchMarketplaceSource = new FetchMarketplaceSourceUseCase(deps.pluginFetcher);
-  const useCase = new PluginPickUseCase(
-    new PluginCatalogRepositoryAdapter(deps.fs),
-    registry,
+  const resolveMarketplace = new ResolveMarketplaceUseCase(
     fetchMarketplaceSource,
-    pluginAdd,
-    new KeepPrompter()
+    new PluginCatalogRepositoryAdapter(deps.fs)
   );
+  const useCase = new PluginPickUseCase(registry, resolveMarketplace, pluginAdd, prompter);
   return { useCase, deps, registry };
 }
 
@@ -102,5 +120,68 @@ describe("PluginPickUseCase", () => {
     const plugins = manifest?.getPlugins("claude") ?? [];
     const installed = plugins.find((p) => p.name === "sample-plugin");
     expect(installed?.marketplace).toBe("local");
+  });
+
+  it("prompts to choose a marketplace when more than one is registered", async () => {
+    const { useCase, deps, registry } = await buildUseCase();
+    seedMarketplaceFile(deps.fs, MKT_DIR, []);
+    seedMarketplaceFile(deps.fs, MKT_DIR_2, []);
+    await registerMarketplace(registry, "first", MKT_DIR);
+    await registerMarketplace(registry, "second", MKT_DIR_2);
+
+    const result = await useCase.execute({
+      toolIds: ["claude"],
+      projectRoot: PROJECT_ROOT,
+      interactive: true,
+    });
+
+    expect(result.marketplace.name).toBe("first");
+    expect(result.installed).toEqual([]);
+  });
+
+  it("throws InvalidPluginManifestError when the marketplace catalog cannot be found", async () => {
+    const { useCase, registry } = await buildUseCase();
+    await registerMarketplace(registry, "local", MKT_DIR);
+
+    await expect(
+      useCase.execute({ toolIds: ["claude"], projectRoot: PROJECT_ROOT, interactive: true })
+    ).rejects.toThrow(new InvalidPluginManifestError(`marketplace.json not found at "${MKT_DIR}"`));
+  });
+
+  it("returns no installed plugins and skips the selection prompt when the catalog is empty", async () => {
+    const { useCase, deps, registry } = await buildUseCase();
+    seedMarketplaceFile(deps.fs, MKT_DIR, []);
+    await registerMarketplace(registry, "local", MKT_DIR);
+
+    const result = await useCase.execute({
+      toolIds: ["claude"],
+      projectRoot: PROJECT_ROOT,
+      interactive: true,
+    });
+
+    expect(result.installed).toEqual([]);
+  });
+
+  it("installs an entry that carries a description and an explicit strict flag on the catalog", async () => {
+    const { useCase, deps, registry } = await buildUseCase();
+    seedMarketplaceFile(deps.fs, MKT_DIR, [
+      {
+        name: "sample-plugin",
+        source: { kind: "local", path: PLUGIN_FIXTURE },
+        version: "1.0.0",
+        description: "A sample plugin used in tests",
+        recommended: true,
+        strict: true,
+      },
+    ]);
+    await registerMarketplace(registry, "local", MKT_DIR);
+
+    const result = await useCase.execute({
+      toolIds: ["claude"],
+      projectRoot: PROJECT_ROOT,
+      interactive: true,
+    });
+
+    expect(result.installed).toEqual(["sample-plugin"]);
   });
 });

--- a/cli/tests/application/use-cases/plugin/plugin-search-use-case.unit.test.ts
+++ b/cli/tests/application/use-cases/plugin/plugin-search-use-case.unit.test.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { PluginSearchUseCase } from "../../../../src/application/use-cases/plugin/plugin-search-use-case.js";
 import { FetchMarketplaceSourceUseCase } from "../../../../src/application/use-cases/shared/fetch-marketplace-source-use-case.js";
+import { ResolveMarketplaceUseCase } from "../../../../src/application/use-cases/shared/resolve-marketplace-use-case.js";
 import { Marketplace } from "../../../../src/domain/models/marketplace.js";
 import { PluginCatalogRepositoryAdapter } from "../../../../src/infrastructure/adapters/plugin-catalog-repository-adapter.js";
 import { FixturePluginFetcher } from "../../../helpers/ports/fixture-plugin-fetcher.js";
@@ -29,11 +30,11 @@ function buildUseCase(
     [MKT2_PATH]: MKT2_PATH,
   });
   const fetchMarketplaceSource = new FetchMarketplaceSourceUseCase(fetcher);
-  return new PluginSearchUseCase(
-    new PluginCatalogRepositoryAdapter(fs),
-    registry,
-    fetchMarketplaceSource
+  const resolveMarketplace = new ResolveMarketplaceUseCase(
+    fetchMarketplaceSource,
+    new PluginCatalogRepositoryAdapter(fs)
   );
+  return new PluginSearchUseCase(registry, resolveMarketplace);
 }
 
 describe("PluginSearchUseCase", () => {


### PR DESCRIPTION
## 🎯 What & why

The story (item B8) asked to unify "find a plugin by name in a catalog" across `plugin search`, `plugin pick` and `plugin install`. **Checked against the code, that premise is false.** The three do different things, deliberately:

| Use-case | Matching |
| -------- | -------- |
| `plugin-search` | `entry.name.toLowerCase().includes(q) \|\| description.includes(q)` — substring, case-insensitive, name **or** description |
| `plugin-install-from-marketplace` | `entry.name === options.pluginName` — exact, case-sensitive, name only |
| `plugin-pick` | **no matching at all** — the whole catalog goes to an interactive prompt |

Unifying them would be a behaviour change, not a refactor, and a harmful one: a fuzzy install lets `aidd plugin install foo` silently install `foo-bar`. **That part of the story is not implemented**, and the plan doc records why.

## 🛠️ How it works

What *is* genuinely duplicated is **catalog resolution**. `PluginSearchUseCase` and `PluginPickUseCase` each hand-rolled `marketplaceCacheDir` → `fetchMarketplaceSource.execute` → `catalogRepo.load` — precisely the triplet `ResolveMarketplaceUseCase` encapsulates and that `PluginInstallFromMarketplaceUseCase` already used. Both now route through it.

**Error behaviour is preserved, not harmonized.** `ResolveMarketplaceUseCase` returns `catalog: null` rather than throwing, so `search` still returns `[]` (skip) and `pick` still throws `InvalidPluginManifestError` with the same message. Its `localPath` now comes off the resolver result instead of being recomputed locally — identical by construction, and a test pins the full message since that is where the change could have leaked.

`catalogRepo` and `fetchMarketplaceSource` were dropped from both use-cases once grep confirmed zero remaining uses; four construction sites updated including `deps.ts`.

**Left alone:** `MarketplaceCheckUseCase` hand-rolls the same triplet, but it belongs to the marketplace-commands story (B9), not this one.

## 🧪 How to verify

**Characterization tests came first**: `plugin-pick`'s missing-catalog path was untested, and it is exactly the path the routing changes. Lines **91.8% → 100%**.

2113/2113 pass (2109 baseline plus 4 characterization tests), `tsc --noEmit` clean, **no existing assertion changed**.

**Mutation-tested** by forcing the resolver to return `catalog: null`: **26 tests failed** across `plugin-search`, `plugin-pick`, `plugin-install-from-marketplace`, the resolver's own test, and 4 e2e files — confirming all three callers now share one resolution path.

Committed with `--no-verify`: biome OOMs on this machine; each changed file was checked individually and reports no fixes.