### PR TITLE
fix(ci): unbreak the framework-local checks after the kanban move

### DIFF
--- a/aidd_docs/tasks/2026_07/2026_07_31_kanban-into-framework/plan.md
+++ b/aidd_docs/tasks/2026_07/2026_07_31_kanban-into-framework/plan.md
@@ -47,6 +47,10 @@ A fourth fix came from the pre-push hook rather than from CI. `knip` reported `c
 
 This silences a real check for exactly those four: if kanban ever stops using one, nothing will say so. The CI knip job is `continue-on-error: true`, so only the local pre-push hook enforces it, and it now passes.
 
+Two more surfaced only once the change landed on `next`, because the `Validate` workflow runs the framework-local lefthook jobs that the PR checks do not. The `json-validity` job parses every JSON file as strict JSON, so the explanatory `//` comments added to `cli/tsconfig.json` broke it — TypeScript accepts JSONC, this repository does not. And the `cli-typecheck` job type-checks the CLI, which now spans `kanban/src`, without ever installing that folder. Its glob is now `{cli,kanban}/**` and it installs kanban when `kanban/node_modules` is missing.
+
+The lesson for anything else that reaches across the two folders: green PR checks are not the whole pipeline. Replay `npx lefthook run pre-commit --all-files` from a tree where `kanban/node_modules` does not exist.
+
 ### Phase 3 — Exercise it on real projects (done)
 
 Run against `framework` (67 documents), `cli` (164), `kairos-app` (259) and `breathflow` (10), table view and interactive view, the latter under a real pty at 190x45. Full write-up in [`findings.md`](./findings.md).

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -7,7 +7,6 @@
     "types": ["node"],
     "jsx": "react-jsx",
     "outDir": "dist",
-    // The kanban source folder is a sibling, so the type-check program spans both directories.
     "rootDir": "..",
     "strict": true,
     "esModuleInterop": true,

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -88,8 +88,12 @@ pre-commit:
       glob: "cli/**"
       run: cd cli && pnpm lint
     cli-typecheck:
-      glob: "cli/**"
-      run: cd cli && pnpm typecheck
+      # The CLI type-checks `kanban/` too, so that folder's dependencies must be
+      # resolvable. Install them only when they are missing, to keep the hook fast.
+      glob: "{cli,kanban}/**"
+      run: |
+        [ -d kanban/node_modules ] || (cd kanban && pnpm install --frozen-lockfile)
+        cd cli && pnpm typecheck
 
 pre-push:
   commands:


### PR DESCRIPTION
## 🎯 What & why

`next` is red after #573. Two framework-local lefthook jobs fail, and neither runs on PR checks, so both only appeared after the merge.

## 🛠️ How it works

- **`json-validity`** parses every JSON file as strict JSON. #573 added explanatory `//` comments to `cli/tsconfig.json`; TypeScript accepts JSONC, this repository does not. Comments removed, the reasoning moved to the task plan.
- **`cli-typecheck`** type-checks the CLI, whose program now spans `../kanban/src`, but never installed that folder — the same `TS7006` / `react/jsx-runtime` wall the CI jobs were already patched for. Its glob becomes `{cli,kanban}/**` and it installs kanban's dependencies when `kanban/node_modules` is missing, so the local hook stays fast.

## 🧪 How to verify

```
rm -rf kanban/node_modules
npx lefthook run pre-commit --all-files
```

Nine jobs, all green, from the same starting state as CI.

## ⚠️ Heads-up

Green PR checks are not the whole pipeline: `Validate` runs framework-local hooks that `cli CI` does not. Anything else reaching across `cli/` and `kanban/` should be replayed with `lefthook run pre-commit --all-files` from a tree where `kanban/node_modules` does not exist.
