### PR TITLE
ci: align codeql autobuild pin to v4.37.6 and group actions bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,12 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
+    # One PR per run for all action bumps, so multi-action repos like
+    # github/codeql-action can never land partially and drift their pins apart.
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     commit-message:
       prefix: "ci"
       include: "scope"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,7 +37,7 @@ jobs:
           queries: security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/autobuild@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6


### PR DESCRIPTION
## 🎯 What & why

Autobuild stayed pinned at v4.37.4 after dependabot bumped init/analyze to v4.37.6 in separate PRs (#579; the init bump landed earlier). Aligns the autobuild pin, and adds a dependabot `groups` entry so all github-actions bumps arrive as one PR — multi-action repos like `github/codeql-action` can no longer land partially and drift their pins apart.

## 🧪 How to verify

All three `github/codeql-action/*` uses in `codeql.yml` point to `5595cca # v4.37.6`.

## 🔗 Linked issue

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)