### PR TITLE
fix(orchestrator): backlog decide waits, apply forwards next step

### DIFF
--- a/plugins/aidd-orchestrator/skills/02-backlog/actions/06-decide.md
+++ b/plugins/aidd-orchestrator/skills/02-backlog/actions/06-decide.md
@@ -14,7 +14,7 @@ An authorized change set, requested revisions, or no change.
 
 1. **Reconcile.** Merge duplicate proposals and surface contradictions.
 2. **Impact.** Show every artifact, field, transition, relation, and reason that would change.
-3. **Authorize.** Use bounded autonomous authority or invite correction, rejection, or approval in one open question.
+3. **Authorize.** Apply bounded autonomous authority, or ask one open question for correction, rejection, or approval and wait for the reply before the change set is frozen.
 4. **Freeze.** Allow no unlisted mutation.
 
 ## Test
@@ -26,3 +26,4 @@ An authorized change set, requested revisions, or no change.
 | Interactive approval | every mutation has identity, owner, before, after, and evidence |
 | Bounded autonomy | only pre-authorized mutations remain |
 | No authority | workspace unchanged |
+| Open question | apply does not start before the reply arrives |

--- a/plugins/aidd-orchestrator/skills/02-backlog/actions/07-apply.md
+++ b/plugins/aidd-orchestrator/skills/02-backlog/actions/07-apply.md
@@ -13,7 +13,7 @@ Change receipts from the artifact owners.
 ## Process
 
 1. **Group.** Group mutations by owning capability without changing their order.
-2. **Delegate.** Pass each capability only its authorized mutations and evidence.
+2. **Delegate.** Call each capability's own persist action with its authorized mutations, the evidence, and the authority already granted, so it writes, reports, and offers its next step without re-asking approval.
 3. **Record.** Collect each stable identity, `before -> after` delta, affected relations, and verification result.
 4. **Stop.** On any rejected or failed mutation, preserve completed work and return the unresolved entry.
 
@@ -26,3 +26,5 @@ Change receipts from the artifact owners.
 | Failure | unresolved mutation returned; no silent skip |
 | Partial graph | incoherence between two mutations is not treated as a failure |
 | Result | exactly one receipt per authorized create or update |
+| Re-ask | the capability's own approval question never appears; decide's authority already covers it |
+| Next step | the capability's own next-step offer reaches the user before the run ends |


### PR DESCRIPTION
## 🎯 What & why

Creating an artifact (e.g. an Epic) through `aidd-orchestrator:02-backlog` saved silently: no wait for approval before the write, and no next-step offer after it — because `07-apply` never stated whether it invoked the owning capability's persist action in full.

## 🛠️ How it works

- [`06-decide.md`](plugins/aidd-orchestrator/skills/02-backlog/actions/06-decide.md) step 3 (`Authorize`) now explicitly waits for the reply before freezing the change set, matching `01-inspect`/`02-triage`'s existing pattern.
- [`07-apply.md`](plugins/aidd-orchestrator/skills/02-backlog/actions/07-apply.md) step 2 (`Delegate`) now states it calls the capability's own persist action with the authority already granted, so it writes, reports, and offers its next step without re-asking approval.

No cross-plugin link added — skills never link outside themselves (per the just-merged skill contract, `plugins/aidd-context/skills/04-skill-generate/references/skill-authoring.md`). The wording is capability-agnostic, so it applies uniformly to every owning capability without naming any of them.

## 🧪 How to verify

Headless, via `claude -p` against a temp project with `02-backlog` and each owning capability installed under a unique name. 7 scenarios passed across all 5 capabilities:

| Capability | Scenario | Result |
| --- | --- | --- |
| Epic | create, interactive | waits, 0 file written |
| Epic | create, bounded autonomous | writes + offers to slice into Stories, no re-ask |
| Epic | transition only | transitions, no re-ask |
| Story | review (dangling relation) | no write, names the dangling relation |
| Task | create, bounded autonomous | writes, no re-ask |
| Defect | create, interactive | waits, 0 file written |
| Spike | conclude, bounded autonomous | writes `status: resolved`, no re-ask |

Harness kept local to the session (cross-plugin, not part of `scripts/skill-eval.mjs`'s scope), not included in this PR.

## ⚠️ Heads-up

None.

## ✅ I certify

- [ ] **I DO CERTIFY I READ EACH LINE OF THE PULL REQUEST BECAUSE I AM A SOFTWARE ENGINEER, NOT A AI PUPPY.**
