### PR TITLE
fix(framework): leave a fenced block alone when normalising Process steps

### DIFF
--- a/plugins/aidd-context/skills/01-bootstrap/actions/03-audit-candidates.md
+++ b/plugins/aidd-context/skills/01-bootstrap/actions/03-audit-candidates.md
@@ -16,9 +16,9 @@ The action 02 table augmented with a verdict column, plus a three-bullet rationa
 
    ```text
    Audit the following candidate stack for a SaaS project. Validate three dimensions:
-   - Tech compatibility: do the components integrate cleanly? Any deprecated combos?
-   - Ecosystem maturity: are the components stable (≥ 2 years prod-tested) and well-documented?
-   - Known gotchas: search recent (last 12 months) issues, blog posts, and discussions for blockers.
+   1. Tech compatibility: do the components integrate cleanly? Any deprecated combos?
+   2. Ecosystem maturity: are the components stable (≥ 2 years prod-tested) and well-documented?
+   3. Known gotchas: search recent (last 12 months) issues, blog posts, and discussions for blockers.
 
    Project context: <paste filled checklist blocks 1 to 3>
    Candidate: <paste candidate row from comparison table>

--- a/plugins/aidd-context/skills/04-skill-generate/references/skill-authoring.md
+++ b/plugins/aidd-context/skills/04-skill-generate/references/skill-authoring.md
@@ -21,7 +21,7 @@ The contract every generated skill satisfies. `skill-generate` obeys it too.
 ## An action
 
 - **R11.** Sections in this order: `## Input` when the action consumes something, then `## Output`, `## Process`, `## Test`. A section earns its content or is omitted, never invented or reordered.
-- **R12.** A `## Process` step opens with `**Label.**`, then one imperative sentence. A number is always a step run in order; a case, a branch, a loop back, or a constraint is a dash sub-item of the step it belongs to, never a number.
+- **R12.** A `## Process` step opens with `**Label.**`, then one imperative sentence. A number is always a step run in order; a case, a branch, a loop back, or a constraint is a dash sub-item of the step it belongs to, never a number. A fenced block is content the action emits, not structure: leave it as its consumer needs it.
 - **R13.** `## Test` is a `| Case | Pass |` table, each row observable by real execution, never a mock.
 
 ## A reference

--- a/plugins/aidd-dev/skills/10-todo/actions/01-todo.md
+++ b/plugins/aidd-dev/skills/10-todo/actions/01-todo.md
@@ -17,9 +17,9 @@ User's requirement.
 2. **Categorize.** Split the prompt into distinct, independent todos (category + task). Inline, no agent.
 3. **Launch.** Spawn one `executor` agent per todo, all in parallel (one message, multiple Task calls). Each agent prompt mandates, in order:
    ```markdown
-   - Refine the todo first: run a non-interactive refine capability if one is available (discovered at runtime, never a hardcoded plugin name); otherwise restate the todo clearly and resolve obvious ambiguity inline. Never block on the user.
-   - Implement the refined todo.
-   - Return a one-line output summary.
+   1. Refine the todo first: run a non-interactive refine capability if one is available (discovered at runtime, never a hardcoded plugin name); otherwise restate the todo clearly and resolve obvious ambiguity inline. Never block on the user.
+   2. Implement the refined todo.
+   3. Return a one-line output summary.
    ```
 4. **Report.** Print exactly one table, nothing else.
 


### PR DESCRIPTION
## 🎯 What & why

#601 merged one commit short. The dash normalisation it carried reached inside fenced blocks, where the content is not the action's structure but the literal text the action emits. Six lines were rewritten that had no business changing, and they are on `next` right now.

## 🛠️ How it works

[01-todo.md:18](plugins/aidd-dev/skills/10-todo/actions/01-todo.md#L18) reads `Each agent prompt mandates, in order:` and then quotes the prompt sent to every executor agent. #601 turned that ordered list into dashes, so the instruction and the list it introduces now contradict each other. [03-audit-candidates.md:17](plugins/aidd-context/skills/01-bootstrap/actions/03-audit-candidates.md#L17) quotes an audit brief the same way.

Both are restored to numbers. R12 gains the missing clause: a fenced block is content the action emits, not structure to normalise.

The other 19 lines #601 changed are correct and stay: 17 were lone sub-items with no order to lose, and of the five remaining groups, four are mutually exclusive cases and the fifth carries its order in the prose (`Stop searching as soon as the run is executable`).

## 🧪 How to verify

- `git show origin/next:plugins/aidd-dev/skills/10-todo/actions/01-todo.md | sed -n '19,23p'` shows the dashes under `mandates, in order`. This branch shows `1.` `2.` `3.`.
- No prose anywhere cites a sub-item by number, so nothing else referenced the changed markers.

## 🔗 Linked issue

Refs #564

## ✅ I certify

- [x] **I DO CERTIFY I READ EACH LINE OF THE PULL REQUEST BECAUSE I AM A SOFTWARE ENGINEER, NOT A AI PUPPY.**
