### PR TITLE
docs(framework): close sdlc-anti-slop plan as implemented

### DIFF
--- a/aidd_docs/plans/2026_07_01-sdlc-anti-slop/phase-1.md
+++ b/aidd_docs/plans/2026_07_01-sdlc-anti-slop/phase-1.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: done
 ---
 
 # Instruction: Root rule, behavior over instructions

--- a/aidd_docs/plans/2026_07_01-sdlc-anti-slop/phase-2.md
+++ b/aidd_docs/plans/2026_07_01-sdlc-anti-slop/phase-2.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: done
 ---
 
 # Instruction: Gates single-home + SDLC assert step

--- a/aidd_docs/plans/2026_07_01-sdlc-anti-slop/phase-3.md
+++ b/aidd_docs/plans/2026_07_01-sdlc-anti-slop/phase-3.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: done
 ---
 
 # Instruction: Spec done-when as observable conditions

--- a/aidd_docs/plans/2026_07_01-sdlc-anti-slop/phase-4.md
+++ b/aidd_docs/plans/2026_07_01-sdlc-anti-slop/phase-4.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: done
 ---
 
 # Instruction: Plan + phases anti-slop

--- a/aidd_docs/plans/2026_07_01-sdlc-anti-slop/phase-5.md
+++ b/aidd_docs/plans/2026_07_01-sdlc-anti-slop/phase-5.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: done
 ---
 
 # Instruction: Review redesign, trace phases as checkboxes

--- a/aidd_docs/plans/2026_07_01-sdlc-anti-slop/plan.md
+++ b/aidd_docs/plans/2026_07_01-sdlc-anti-slop/plan.md
@@ -1,6 +1,6 @@
 ---
 objective: "SDLC artifacts stop emitting slop: every template section states what qualifies it and omits when nothing does, gates live only in /assert, the review traces the plan's phases as checkboxes."
-status: pending
+status: implemented
 ---
 
 # Plan: SDLC anti-slop hardening
@@ -37,7 +37,7 @@ Two axes were conflated. Separate them:
 | ------------- | --------------------------- |
 | `plugins/aidd-context/skills/04-skill-generate/references/skill-authoring.md` | Rules live as R1..Rn here; every generator reads it. Home for the Steinberger rule. |
 | `plugins/aidd-dev/skills/03-assert/SKILL.md` | Already the gate: "returns a pass or fail verdict", fix-loop until green. Runs the project's coding assertions. |
-| `plugins/aidd-dev/skills/00-sdlc/SKILL.md` | Chains spec→plan→implement→review→ship. No assert step: gates would drop if stripped from the plan. |
+| `plugins/aidd-orchestrator/skills/01-sdlc/` (moved from `aidd-dev/skills/00-sdlc`) | Deliver zone chains implement → assert → test → commit; Check zone owns review. Assert step present. |
 | `plugins/aidd-dev/skills/01-plan/assets/{plan,phase}-template.md` | Slot templates. `04-plan.md:17` already carries an omit idiom; phase wireframe carries `omit when no UI`. Inconsistent. |
 | `plugins/aidd-pm/skills/04-spec/assets/spec-template.md` | Done-when + optional-section suffix `(optional)` already present. |
 | `plugins/aidd-dev/skills/05-review/assets/review-template.md` | Prose + Follow-up section; functional axis traces criteria in a table, not the plan's phases. |


### PR DESCRIPTION
## 🎯 What & why

Close the `2026_07_01-sdlc-anti-slop` plan: every done-when it lists already holds in the repo, but the plan still read `status: pending`, so onboarding kept pinning it as the next dev-flow step.

## 🛠️ How it works

Status-only closure, no behavior change:

- [plan.md](aidd_docs/plans/2026_07_01-sdlc-anti-slop/plan.md) → `status: implemented`, phases 1-5 → `status: done`.
- Retargets the stale Resources row pointing at `plugins/aidd-dev/skills/00-sdlc/SKILL.md` (deleted) to `plugins/aidd-orchestrator/skills/01-sdlc/`, where the SDLC now lives.

The work itself landed elsewhere: the assert step shipped with the orchestrator move ([02-deliver.md](plugins/aidd-orchestrator/skills/01-sdlc/references/02-deliver.md) chains implement → assert → test → commit), and the template/review anti-slop shipped in 153ba42f.

## 🧪 How to verify

- `grep -H '^status:' aidd_docs/plans/2026_07_01-sdlc-anti-slop/*.md` → `implemented` + five `done`.
- Check each done-when in [plan.md](aidd_docs/plans/2026_07_01-sdlc-anti-slop/plan.md#L57) against: `skill-authoring.md` R11/R16, the spec/plan/phase/review templates, and `02-deliver.md`.

## ✅ I certify

- [ ] **I DO CERTIFY I READ EACH LINE OF THE PULL REQUEST BECAUSE I AM A SOFTWARE ENGINEER, NOT A AI PUPPY.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MuxwWHC68vNCFjZrSArBKK
