### PR TITLE
chore(release): drop the 5.8.0 pin and attribute the breaking change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 ## [5.8.0](https://github.com/ai-driven-dev/framework/compare/v5.7.1...v5.8.0) (2026-08-14)
 
 
-### ⚠ BREAKING CHANGES
+### Notes
 
-* **refine:** `aidd-refine:03-condense` is removed, and the skills after it are renumbered: `04-shadow-areas` becomes `03-shadow-areas`, and `05-fact-check` becomes `04-fact-check`. Any pinned reference to the old names must be updated. The plugin no longer ships a hooks directory.
+* **refine:** removing `aidd-refine:03-condense` and renumbering the skills after it is a breaking change of the `aidd-refine` plugin, released as [aidd-refine 3.0.0](https://github.com/ai-driven-dev/framework/releases/tag/aidd-refine-v3.0.0). The marketplace itself carries no breaking change in this release.
 
 ### Features
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -15,7 +15,6 @@
   ],
   "packages": {
     ".": {
-      "release-as": "5.8.0",
       "extra-files": [
         {
           "type": "json",


### PR DESCRIPTION
Follow-up to #639 / #640, both required before the next release cycle.

- **Drop `"release-as": "5.8.0"`.** It forced this cycle's umbrella version. `v5.8.0` is published, so leaving the pin in place would make every later run reproduce 5.8.0.
- **Requalify the umbrella changelog.** The `⚠ BREAKING CHANGES` banner on the 5.8.0 section describes the removal of `aidd-refine:03-condense`, which breaks the `aidd-refine` plugin (released as 3.0.0), not the marketplace. A minor release whose notes open on a breaking-change banner reads as a mistake. The historical sections are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)