### PR TITLE
feat(aidd-context): add retrospective lens to learn

### DIFF
--- a/plugins/aidd-context/skills/10-learn/references/gather-protocol.md
+++ b/plugins/aidd-context/skills/10-learn/references/gather-protocol.md
@@ -17,6 +17,15 @@ Extract only durable project learning.
 | Signal outside the selected source's scope, even when noticed while reading | Drop |
 | Bug already fixed as part of the current change, unless the user explicitly asked to remember it as a decision | Drop |
 
+## Retrospective lens
+
+For completed work, ask before applying the signal filter:
+
+- What caused avoidable delay, rework, or confusion?
+- What should change next time?
+- What durable context was missing?
+- What should be removed, clarified, or automated?
+
 For each candidate, include:
 
 - Source label.


### PR DESCRIPTION
## 🎯 What & why

Adds four retrospective prompts so completed work surfaces durable causes of delay, rework, and confusion before filtering learnings.

## 🛠️ How it works

Keeps reflection inside `learn`, then reuses its existing durability filter and destination routing. No persistence logic is duplicated.

## 🧪 How to verify

- `node scripts/check-markdown-links.js --ignore cli/tests/fixtures --ignore cli/aidd_docs/tasks`
- `cd cli && pnpm knip:production`
- `cd cli && pnpm test`

## ✅ I certify

- [ ] **I DO CERTIFY I READ EACH LINE OF THE PULL REQUEST BECAUSE I AM A SOFTWARE ENGINEER, NOT A AI PUPPY.**