### PR TITLE
fix(aidd-context): load the project memory block in Claude Code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,8 @@ Project docs, memory, specs, and plans live in `aidd_docs/`.
 
 ### Project memory
 
-<aidd_project_memory>
+<!-- aidd_project_memory:start -->
+
 @aidd_docs/memory/architecture.md
 @aidd_docs/memory/browsing.md
 @aidd_docs/memory/codebase-map.md
@@ -47,7 +48,8 @@ Project docs, memory, specs, and plans live in `aidd_docs/`.
 @aidd_docs/memory/project-brief.md
 @aidd_docs/memory/testing.md
 @aidd_docs/memory/vcs.md
-</aidd_project_memory>
+
+<!-- aidd_project_memory:end -->
 
 - If the block above is empty, run `ls -1tr aidd_docs/memory/` and read each file.
 - Load `aidd_docs/memory/external/*` when the user asks.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,8 @@ Project docs, memory, specs, and plans live in `aidd_docs/`.
 
 ### Project memory
 
-<aidd_project_memory>
+<!-- aidd_project_memory:start -->
+
 @aidd_docs/memory/architecture.md
 @aidd_docs/memory/browsing.md
 @aidd_docs/memory/codebase-map.md
@@ -47,7 +48,8 @@ Project docs, memory, specs, and plans live in `aidd_docs/`.
 @aidd_docs/memory/project-brief.md
 @aidd_docs/memory/testing.md
 @aidd_docs/memory/vcs.md
-</aidd_project_memory>
+
+<!-- aidd_project_memory:end -->
 
 - If the block above is empty, run `ls -1tr aidd_docs/memory/` and read each file.
 - Load `aidd_docs/memory/external/*` when the user asks.

--- a/aidd_docs/CONTRIBUTING.md
+++ b/aidd_docs/CONTRIBUTING.md
@@ -26,7 +26,7 @@ The skill contract itself lives in one file: `aidd-context:04-skill-generate/ref
 
 ## Syncing Across Tools
 
-If the project uses multiple AI tools (e.g. Claude Code plus Cursor), the same content must be available to each. The memory bank is shared automatically via the `<aidd_project_memory>` block kept in sync by `aidd-context:02-project-memory`. Skills are loaded per-plugin by the runtime, so any skill installed via the marketplace is available across tools that support skills.
+If the project uses multiple AI tools (e.g. Claude Code plus Cursor), the same content must be available to each. The memory bank is shared automatically via the project memory block kept in sync by `aidd-context:02-project-memory`. Skills are loaded per-plugin by the runtime, so any skill installed via the marketplace is available across tools that support skills.
 
 When tools differ in syntax (frontmatter, slash command name, references), follow the IDE mapping reference shipped with each plugin.
 

--- a/aidd_docs/README.md
+++ b/aidd_docs/README.md
@@ -84,7 +84,7 @@ my-project/
 
 ### Memory Block Lifecycle
 
-Each AI context file (`CLAUDE.md`, `AGENTS.md`, `.github/copilot-instructions.md`, etc.) contains a project memory block delimited by `<!-- aidd_project_memory:start -->` and `<!-- aidd_project_memory:end -->`. It is:
+Each AI context file (`CLAUDE.md`, `AGENTS.md`, `.github/copilot-instructions.md`, etc.) contains a project memory block. It is:
 
 1. **Seeded** the first time by `aidd-context:02-project-memory` (the skill creates the block if absent).
 2. **Kept in sync** automatically by a session-start hook (`aidd-context/hooks/update_memory.js`) that scans `aidd_docs/memory/` and writes the current list of `.md` files into the block.

--- a/aidd_docs/README.md
+++ b/aidd_docs/README.md
@@ -84,7 +84,7 @@ my-project/
 
 ### Memory Block Lifecycle
 
-Each AI context file (`CLAUDE.md`, `AGENTS.md`, `.github/copilot-instructions.md`, etc.) contains an `<aidd_project_memory>` block. It is:
+Each AI context file (`CLAUDE.md`, `AGENTS.md`, `.github/copilot-instructions.md`, etc.) contains a project memory block delimited by `<!-- aidd_project_memory:start -->` and `<!-- aidd_project_memory:end -->`. It is:
 
 1. **Seeded** the first time by `aidd-context:02-project-memory` (the skill creates the block if absent).
 2. **Kept in sync** automatically by a session-start hook (`aidd-context/hooks/update_memory.js`) that scans `aidd_docs/memory/` and writes the current list of `.md` files into the block.

--- a/aidd_docs/tasks/2026_08/2026_08_28_memory-block-markers/brainstorm.md
+++ b/aidd_docs/tasks/2026_08/2026_08_28_memory-block-markers/brainstorm.md
@@ -1,0 +1,26 @@
+# Memory block markers that cannot silently stop loading
+
+The `<aidd_project_memory>` block that `update_memory.js` writes into every AI context file is delimited by a bare XML-style tag on its own line. Markdown treats that as an HTML block running until the next blank line, and Claude Code's import parser skips imports inside it exactly as it skips a fenced code block. Every `@aidd_docs/memory/*.md` line the hook generates is therefore ignored, and the project memory never loads. The failure is invisible from inside a session: the agent starts, nothing is reported, and it simply reasons without the memory bank.
+
+The fix is to stop delimiting the block with a construct whose correctness depends on an adjacent blank line, and use HTML comment markers instead. A comment closes on its own line, so nothing following it can ever be captured, whatever a formatter or a future rewrite does to the surrounding whitespace. The same hook already uses that convention for the memory README index. Existing installed repositories carry the old tag, so the change is only complete if the hook migrates them; otherwise the fix ships and those repositories stay dark while the changelog claims otherwise.
+
+## What Is Clear
+
+- Reported in issue #719 and confirmed independently: `CLAUDE.md:41-50` in this repository holds the glued shape, and a session loading it shows the `@` lines unexpanded, with eight memory files absent.
+- Single emitter: `buildBlockContent` in `plugins/aidd-context/hooks/update_memory.js`. `updateMarkers` splices between two constant strings and needs no change when those strings change.
+- The bug is the tag shape, not the content. `buildBlockContent` already pushes a blank line before the on-demand note, so that blank line terminates the HTML block and the on-demand list renders correctly. Only the `@` lines above it are swallowed. That asymmetry is the signature.
+- Chosen shape: the existing `### Project memory` heading for human readers, with `<!-- aidd_project_memory:start -->` and `<!-- aidd_project_memory:end -->` as the machine anchors. The heading is prose the hook does not own; the markers stay the anchor.
+- Rejected: adding a blank line after the opening tag. It is one character and needs no migration, but it is a load-bearing convention nothing in the file declares, and a rewrite already reverted it once.
+- Migration is part of the fix, not a follow-up. The hook returns `null` when the close marker is absent and skips the file with no output, so every already-installed repository would silently stop syncing.
+- The tag name is load-bearing beyond the hook and those references move with it: `plugins/aidd-context/skills/00-onboard/references/state/zones.md`, `plugins/aidd-context/skills/11-explore/actions/01-survey.md`, and the `02-project-memory` templates for `AGENTS.md`, `README.md`, and `memory/README.md`.
+- A regression guard stays in scope: walk a context file line by line, track whether a line opens an HTML block, and fail when an `@` import is found inside one. Comment markers make this specific regression near-impossible, but the guard covers hand-written context files and future generators.
+- Out of scope, its own ticket: generating a `CLAUDE.md` that contains `@AGENTS.md` for repositories that only have `AGENTS.md`. It adds a capability rather than fixing a defect, and it drags in the separate question of which context files the project owns.
+
+## Still Open
+
+- Assumption, unverified: the XML tag currently buys nothing the model uses. Whether the wrapper survives import resolution into the prompt in a form the model reads has not been checked. If it does, the heading in the chosen shape is the replacement cue.
+- Whether the CLI test fixtures under `cli/tests/fixtures/**` that embed the old tag should be migrated with the rest or left pinned to the legacy shape as regression material.
+
+## Next Move
+
+Turn this into a change: new markers in the hook, a one-pass rewrite of the legacy tag before the splice, the template and documentation references moved to the new shape, and a check that fails when an import sits inside an HTML block.

--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -37,7 +37,8 @@ Project docs, memory, specs, and plans live in `aidd_docs/`.
 
 ### Project memory
 
-<aidd_project_memory>
+<!-- aidd_project_memory:start -->
+
 @aidd_docs/memory/architecture.md
 @aidd_docs/memory/auth.md
 @aidd_docs/memory/cli.md
@@ -47,7 +48,11 @@ Project docs, memory, specs, and plans live in `aidd_docs/`.
 @aidd_docs/memory/project-brief.md
 @aidd_docs/memory/testing.md
 @aidd_docs/memory/vcs.md
-</aidd_project_memory>
+
+<!-- read on demand, not auto-loaded -->
+- aidd_docs/memory/internal/decisions/self-update-version-source-npm.md
+
+<!-- aidd_project_memory:end -->
 
 - If the block above is empty, run `ls -1tr aidd_docs/memory/` and read each file.
 - Load `aidd_docs/memory/external/*` when the user asks.

--- a/cli/aidd_docs/memory/README.md
+++ b/cli/aidd_docs/memory/README.md
@@ -4,7 +4,7 @@ Structured context the AI assistant reads at the start of a session, so it does 
 
 ## How it loads
 
-- The files at the root of `memory/` are referenced by the `<aidd_project_memory>` block in the AI context file and load every session.
+- The files at the root of `memory/` are referenced by the project memory block in the AI context file and load every session.
 - `internal/` and `external/` are listed there too, but load on demand, only when relevant.
 
 ## Files
@@ -21,6 +21,10 @@ The list below is refreshed automatically by the memory hook. Do not edit it by 
 - [project-brief.md](project-brief.md)
 - [testing.md](testing.md)
 - [vcs.md](vcs.md)
+
+Read on demand:
+
+- [internal/decisions/self-update-version-source-npm.md](internal/decisions/self-update-version-source-npm.md)
 <!-- files:end -->
 
 ## How to maintain it

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -21,6 +21,14 @@ pre-commit:
           exit 1
         fi
         node scripts/validate-yaml.mjs {files}
+    scripts-tests:
+      glob: "{scripts,plugins/aidd-context/hooks}/**"
+      run: |
+        if ! command -v node >/dev/null 2>&1; then
+          echo "ℹ️  node not available; skipping scripts-tests"
+          exit 0
+        fi
+        node --test 'scripts/__tests__/*.test.js'
     skill-frontmatter:
       glob: "plugins/*/skills/*/SKILL.md"
       run: |
@@ -43,6 +51,14 @@ pre-commit:
           exit 0
         fi
         node scripts/check-skill-argument-hints.mjs
+    context-imports:
+      glob: "{**/,}{CLAUDE,AGENTS,copilot-instructions}.md"
+      run: |
+        if ! command -v node >/dev/null 2>&1; then
+          echo "ℹ️  node not available; skipping context-imports"
+          exit 0
+        fi
+        node scripts/check-context-imports.js
     markdown-links:
       glob: "**/*.md"
       run: |

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -52,7 +52,11 @@ pre-commit:
         fi
         node scripts/check-skill-argument-hints.mjs
     context-imports:
-      glob: "{**/,}{CLAUDE,AGENTS,copilot-instructions}.md"
+      # Two patterns, because "**/" needs a literal slash and so never matches
+      # a file at the repository root.
+      glob:
+        - "{CLAUDE,AGENTS,copilot-instructions}.md"
+        - "**/{CLAUDE,AGENTS,copilot-instructions}.md"
       run: |
         if ! command -v node >/dev/null 2>&1; then
           echo "ℹ️  node not available; skipping context-imports"

--- a/plugins/aidd-context/hooks/update_memory.js
+++ b/plugins/aidd-context/hooks/update_memory.js
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 /**
- * update_memory.js - Syncs the <aidd_project_memory> block in AI context files.
+ * update_memory.js - Syncs the project memory block in AI context files.
  *
- * Scans aidd_docs/memory/ and updates the <aidd_project_memory> block in each
+ * Scans aidd_docs/memory/ and updates the block delimited by
+ * <!-- aidd_project_memory:start --> / <!-- aidd_project_memory:end --> in each
  * context file with two tiers:
  *   - Root memory files       -> always loaded, via a tool-appropriate reference.
  *   - internal/ and external/ -> listed (plain paths, no @), read on demand.
@@ -28,8 +29,18 @@
 const DOCS_DIR = "aidd_docs";
 const MEMORY_SUBDIR = "memory";
 const ON_DEMAND_DIRS = ["internal", "external"];
-const BLOCK_OPEN = "<aidd_project_memory>";
-const BLOCK_CLOSE = "</aidd_project_memory>";
+// HTML comment markers, not a bare <aidd_project_memory> tag. A line opening a
+// bare tag starts an HTML block that runs to the next blank line, and an @import
+// inside one is skipped by the context loader exactly like a fenced code block,
+// so the memory silently never loads. A comment closes on its own line.
+const BLOCK_OPEN = "<!-- aidd_project_memory:start -->";
+const BLOCK_CLOSE = "<!-- aidd_project_memory:end -->";
+
+// The shape written before the markers above. Blocks already in a user's context
+// file are rewritten to the new markers on the next run; without that they stop
+// matching, the file is skipped with no output, and the memory stays unloaded.
+const LEGACY_BLOCK_OPEN = "<aidd_project_memory>";
+const LEGACY_BLOCK_CLOSE = "</aidd_project_memory>";
 const ON_DEMAND_NOTE = "<!-- read on demand, not auto-loaded -->";
 const EXCLUDED_FILES = new Set([".gitkeep", "README.md"]);
 
@@ -117,8 +128,12 @@ function buildBlockContent(rootFiles, onDemandFiles, syntax) {
     lines.push("", ON_DEMAND_NOTE);
     for (const f of onDemandFiles) lines.push(`- ${f.replace(/\\/g, "/")}`);
   }
-  if (lines.length === 0) return "";
-  return `\n${lines.join("\n")}\n`;
+  if (lines.length === 0) return "\n";
+  // Blank line on each side of the content. The markers are comments, which
+  // close on their own line, but a context loader that treats any line opening
+  // with `<` as an HTML block running to the next blank line would otherwise
+  // swallow the imports. The blank lines hold under either reading.
+  return `\n\n${lines.join("\n")}\n\n`;
 }
 
 // Replace the text between an open and close marker, leaving the rest intact.
@@ -131,6 +146,58 @@ function updateMarkers(content, open, close, innerContent) {
   const openIdx = content.lastIndexOf(open, closeIdx);
   if (openIdx === -1) return null;
   return content.slice(0, openIdx + open.length) + innerContent + content.slice(closeIdx);
+}
+
+// The real block is the one whose markers each own their line, outside any code
+// fence. Substring search is not enough: the legacy tag is the string every
+// upgrade note and migration doc quotes, and rewriting a quoted pair would
+// mangle that prose while leaving the real block unmigrated and unloaded.
+function findLegacyBlockLines(lines) {
+  let fence = null;
+  let openLine = -1;
+
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trim();
+
+    if (fence !== null) {
+      if (trimmed.startsWith(fence)) fence = null;
+      continue;
+    }
+    if (trimmed.startsWith("```") || trimmed.startsWith("~~~")) {
+      fence = trimmed.slice(0, 3);
+      continue;
+    }
+    if (trimmed === LEGACY_BLOCK_OPEN) openLine = i;
+    else if (trimmed === LEGACY_BLOCK_CLOSE && openLine !== -1) {
+      return { openLine, closeLine: i };
+    }
+  }
+
+  return null;
+}
+
+// Rewrite a legacy <aidd_project_memory> block to the comment markers.
+function migrateLegacyMarkers(content) {
+  const lines = content.split("\n");
+  const found = findLegacyBlockLines(lines);
+  if (found === null) return content;
+
+  lines[found.openLine] = lines[found.openLine].replace(LEGACY_BLOCK_OPEN, BLOCK_OPEN);
+  lines[found.closeLine] = lines[found.closeLine].replace(LEGACY_BLOCK_CLOSE, BLOCK_CLOSE);
+  return lines.join("\n");
+}
+
+// A file carrying one marker without its pair can never be filled again. Say so:
+// silence about a block that does not sync is what kept the memory unloaded.
+function reportUnpairedMarkers(filePath, content) {
+  const has = (marker) => content.includes(marker);
+  const unpaired =
+    has(BLOCK_OPEN) !== has(BLOCK_CLOSE) ||
+    has(LEGACY_BLOCK_OPEN) !== has(LEGACY_BLOCK_CLOSE);
+
+  if (unpaired) {
+    console.error(`update_memory: ${filePath} has an unpaired project memory marker, not synced`);
+  }
 }
 
 function updateBlock(content, innerContent) {
@@ -185,6 +252,10 @@ function gitAdd(childProcess, files) {
 
 // ── Main ──────────────────────────────────────────────────────────
 
+// Runs as a script, never imported: no require, no module.exports, and every
+// dependency pulled in with dynamic import(). The file is copied into the user's
+// project by the CLI, so a project declaring "type": "module" decides how it is
+// parsed. CommonJS syntax here would crash the hook on load in any such project.
 (async () => {
   const fs = await import("node:fs");
   const path = await import("node:path");
@@ -210,9 +281,16 @@ function gitAdd(childProcess, files) {
     if (original === null) continue;
 
     const innerContent = buildBlockContent(rootFiles, onDemandFiles, target.syntax);
-    const updated = updateBlock(original, innerContent);
+    // Compare against what is on disk, not against the migrated text: a file
+    // whose memory list is unchanged would otherwise look identical and skip
+    // the write, leaving the legacy markers in place forever.
+    const updated = updateBlock(migrateLegacyMarkers(original), innerContent);
 
-    if (updated === null || updated === original) continue;
+    if (updated === null) {
+      reportUnpairedMarkers(target.path, original);
+      continue;
+    }
+    if (updated === original) continue;
 
     fs.writeFileSync(target.path, updated, "utf8");
     changed.push(target.path);

--- a/plugins/aidd-context/hooks/update_memory.js
+++ b/plugins/aidd-context/hooks/update_memory.js
@@ -136,50 +136,52 @@ function buildBlockContent(rootFiles, onDemandFiles, syntax) {
   return `\n\n${lines.join("\n")}\n\n`;
 }
 
-// Replace the text between an open and close marker, leaving the rest intact.
-// Anchor on the close, then take the nearest open before it: a bare marker
-// quoted in hand-written prose above the real block must not become the cut
-// point and splice out everything between it and the block.
-function updateMarkers(content, open, close, innerContent) {
-  const closeIdx = content.indexOf(close);
-  if (closeIdx === -1) return null;
-  const openIdx = content.lastIndexOf(open, closeIdx);
-  if (openIdx === -1) return null;
-  return content.slice(0, openIdx + open.length) + innerContent + content.slice(closeIdx);
-}
-
 // The real block is the one whose markers each own their line, outside any code
-// fence. Substring search is not enough: the legacy tag is the string every
-// upgrade note and migration doc quotes, and rewriting a quoted pair would
-// mangle that prose while leaving the real block unmigrated and unloaded.
-function findLegacyBlockLines(lines) {
+// fence. Substring search is not enough: these markers are the strings every
+// upgrade note and migration doc quotes, and cutting on a quoted one would
+// mangle that prose while leaving the real block untouched and unloaded.
+function findBlockLines(lines, open, close) {
   let fence = null;
   let openLine = -1;
 
   for (let i = 0; i < lines.length; i++) {
     const trimmed = lines[i].trim();
+    const opener = /^(`{3,}|~{3,})/u.exec(trimmed);
 
     if (fence !== null) {
-      if (trimmed.startsWith(fence)) fence = null;
+      // A fence closes only on the same character, repeated at least as often,
+      // so a ``` inside a ```` example does not end it early.
+      if (opener && opener[1][0] === fence[0] && opener[1].length >= fence.length) fence = null;
       continue;
     }
-    if (trimmed.startsWith("```") || trimmed.startsWith("~~~")) {
-      fence = trimmed.slice(0, 3);
+    if (opener) {
+      fence = opener[1];
       continue;
     }
-    if (trimmed === LEGACY_BLOCK_OPEN) openLine = i;
-    else if (trimmed === LEGACY_BLOCK_CLOSE && openLine !== -1) {
-      return { openLine, closeLine: i };
-    }
+    if (trimmed === open) openLine = i;
+    else if (trimmed === close && openLine !== -1) return { openLine, closeLine: i };
   }
 
   return null;
 }
 
+// Replace the text between an open and close marker, leaving the rest intact.
+function updateMarkers(content, open, close, innerContent) {
+  const lines = content.split("\n");
+  const found = findBlockLines(lines, open, close);
+  if (found === null) return null;
+
+  return (
+    lines.slice(0, found.openLine + 1).join("\n") +
+    innerContent +
+    lines.slice(found.closeLine).join("\n")
+  );
+}
+
 // Rewrite a legacy <aidd_project_memory> block to the comment markers.
 function migrateLegacyMarkers(content) {
   const lines = content.split("\n");
-  const found = findLegacyBlockLines(lines);
+  const found = findBlockLines(lines, LEGACY_BLOCK_OPEN, LEGACY_BLOCK_CLOSE);
   if (found === null) return content;
 
   lines[found.openLine] = lines[found.openLine].replace(LEGACY_BLOCK_OPEN, BLOCK_OPEN);
@@ -198,6 +200,7 @@ function reportUnpairedMarkers(filePath, content) {
   if (unpaired) {
     console.error(`update_memory: ${filePath} has an unpaired project memory marker, not synced`);
   }
+  return unpaired;
 }
 
 function updateBlock(content, innerContent) {
@@ -275,6 +278,7 @@ function gitAdd(childProcess, files) {
   const rootFiles = scanRootFiles(fs, path);
   const onDemandFiles = ON_DEMAND_DIRS.flatMap((sub) => scanSubdir(fs, path, sub));
   const changed = [];
+  let unpaired = false;
 
   for (const target of targets) {
     const original = readTextOrNull(fs, target.path);
@@ -287,7 +291,7 @@ function gitAdd(childProcess, files) {
     const updated = updateBlock(migrateLegacyMarkers(original), innerContent);
 
     if (updated === null) {
-      reportUnpairedMarkers(target.path, original);
+      if (reportUnpairedMarkers(target.path, original)) unpaired = true;
       continue;
     }
     if (updated === original) continue;
@@ -313,4 +317,9 @@ function gitAdd(childProcess, files) {
   // so staging its own two would leave a partial index that reads like the whole
   // change. The skill reports instead, and the user stages what they mean to commit.
   if (changed.length > 0 && tools.length === 0) gitAdd(childProcess, changed);
+
+  // Only when tools were named, which means the skill called us and its sync
+  // action stops on a non-zero exit. The auto hook must never fail a session
+  // start over a file the user has yet to repair.
+  if (unpaired && tools.length > 0) process.exit(1);
 })();

--- a/plugins/aidd-context/skills/00-onboard/references/state/zones.md
+++ b/plugins/aidd-context/skills/00-onboard/references/state/zones.md
@@ -10,7 +10,7 @@ State-aware order: existing repo (code) => memory first, stack skipped. Greenfie
 | -------------- | ------------------------------------------------------------- | ------------------------ | -------------------------- | -------------------------------- |
 | tech stack     | `INSTALL.md` exists OR repo established (code or synced memory) | —                        | tech stack                 | `aidd-context:01-bootstrap`      |
 | project memory | `aidd_docs/memory/` has real content                          | files empty/placeholder  | project knowledge saved    | `aidd-context:02-project-memory` |
-| memory wiring  | the standard `<aidd_project_memory>` block in each used tool's context file | block present, off shape | knowledge loaded by the AI | `aidd-context:02-project-memory` |
+| memory wiring  | the standard project memory block in each used tool's context file | block present, off shape | knowledge loaded by the AI | `aidd-context:02-project-memory` |
 
 - tech stack missing only on greenfield (no code AND no synced memory).
 - memory wiring: no block or no context file = missing. Drift = a block present but not the standard one that imports the memory files.

--- a/plugins/aidd-context/skills/02-project-memory/assets/templates/AGENTS.md
+++ b/plugins/aidd-context/skills/02-project-memory/assets/templates/AGENTS.md
@@ -37,8 +37,8 @@ Project docs, memory, specs, and plans live in `aidd_docs/`.
 
 ### Project memory
 
-<aidd_project_memory>
-</aidd_project_memory>
+<!-- aidd_project_memory:start -->
+<!-- aidd_project_memory:end -->
 
 - If the block above is empty, run `ls -1tr aidd_docs/memory/` and read each file.
 - Load `aidd_docs/memory/external/*` when the user asks.

--- a/plugins/aidd-context/skills/02-project-memory/assets/templates/README.md
+++ b/plugins/aidd-context/skills/02-project-memory/assets/templates/README.md
@@ -10,7 +10,7 @@ Structured context the AI assistant reads to work on this project, so it does no
 - `CONTRIBUTING.md`: how to add or change project context.
 - `tasks/`: specs, plans, and run summaries, created as work happens.
 
-The `<aidd_project_memory>` block inside each AI context file (`CLAUDE.md`, `AGENTS.md`, and the rest) is generated and kept in sync, never edited by hand. To change what the AI sees, add or remove files under `memory/`. See [`memory/README.md`](memory/README.md) for the load tiers and the current file index.
+The project memory block inside each AI context file (`CLAUDE.md`, `AGENTS.md`, and the rest) is generated and kept in sync, never edited by hand. To change what the AI sees, add or remove files under `memory/`. See [`memory/README.md`](memory/README.md) for the load tiers and the current file index.
 
 ## The framework
 

--- a/plugins/aidd-context/skills/02-project-memory/assets/templates/memory/README.md
+++ b/plugins/aidd-context/skills/02-project-memory/assets/templates/memory/README.md
@@ -10,7 +10,7 @@ flowchart LR
     notes["internal/ · external/"] -.->|on demand| ai
 ```
 
-The root files load every session through the `<aidd_project_memory>` block in each AI context file. `internal/` and `external/` load only when relevant.
+The root files load every session through the project memory block in each AI context file. `internal/` and `external/` load only when relevant.
 
 ## Files
 

--- a/plugins/aidd-context/skills/11-explore/actions/01-survey.md
+++ b/plugins/aidd-context/skills/11-explore/actions/01-survey.md
@@ -14,7 +14,7 @@ A map grouped by axis, Tooling, Context, and Codebase. Each axis lists what is t
 
 1. **Detect the tools.** Find which AI tools the project uses by the presence signal in [ai-mapping.md](../references/ai-mapping.md), keying on a tool's own mapped surfaces, never a shared parent directory. Propose the set when it is ambiguous, never assume one silently.
 2. **Scan Tooling.** For each detected tool, gather the installed skills, agents, commands, rules, hooks, MCP servers, and plugins from the surfaces in [ai-mapping.md](../references/ai-mapping.md).
-3. **Scan Context.** The memory bank under `aidd_docs/memory/` and whether its files are filled, any specs or plans under `aidd_docs/`, and whether the AI context files carry the `<aidd_project_memory>` block.
+3. **Scan Context.** The memory bank under `aidd_docs/memory/` and whether its files are filled, any specs or plans under `aidd_docs/`, and whether the AI context files carry the project memory block.
 4. **Scan Codebase.** The stack, from the manifest or from the memory bank, and the few top-level modules or layers.
 5. **Present the map.** One section per axis, each a short list or count with one-line purposes.
 6. **Propose to dig in.** Offer the three axes or all, and hand the pick to `02-drill`. Wait for the answer.

--- a/scripts/__tests__/check-context-imports.test.js
+++ b/scripts/__tests__/check-context-imports.test.js
@@ -1,0 +1,72 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const path = require("node:path");
+
+const { findHiddenImports, runCli } = require("../check-context-imports.js");
+
+test("an import inside a bare tag block never loads", () => {
+  const hidden = findHiddenImports(
+    ["<aidd_project_memory>", "@aidd_docs/memory/vcs.md", "</aidd_project_memory>"].join("\n"),
+  );
+
+  assert.equal(hidden.length, 1);
+  assert.equal(hidden[0].line, 2);
+  assert.equal(hidden[0].openedBy.text, "<aidd_project_memory>");
+});
+
+test("a blank line after the opening marker takes the imports out of the block", () => {
+  const hidden = findHiddenImports(
+    [
+      "<!-- aidd_project_memory:start -->",
+      "",
+      "@aidd_docs/memory/vcs.md",
+      "",
+      "<!-- aidd_project_memory:end -->",
+    ].join("\n"),
+  );
+
+  assert.deepEqual(hidden, []);
+});
+
+test("an import glued to a comment marker is still hidden", () => {
+  const hidden = findHiddenImports(
+    ["<!-- aidd_project_memory:start -->", "@aidd_docs/memory/vcs.md"].join("\n"),
+  );
+
+  assert.equal(hidden.length, 1);
+});
+
+test("the broken shape quoted in documentation is not a finding", () => {
+  const hidden = findHiddenImports(
+    ["Do not write this:", "", "```markdown", "<tag>", "@a.md", "```", ""].join("\n"),
+  );
+
+  assert.deepEqual(hidden, []);
+});
+
+test("an import on a bare line loads", () => {
+  assert.deepEqual(findHiddenImports("# Title\n\n@a.md\n"), []);
+});
+
+test("a longer fence is not closed by a shorter one inside it", () => {
+  const hidden = findHiddenImports(
+    ["````markdown", "```", "<tag>", "@a.md", "```", "````", ""].join("\n"),
+  );
+
+  assert.deepEqual(hidden, []);
+});
+
+test("an explicit path that cannot be read fails instead of passing", () => {
+  const said = [];
+  assert.equal(runCli(["does-not-exist.md"], (line) => said.push(line)), 1);
+  assert.match(said.join("\n"), /Not a readable file/u);
+});
+
+test("a directory given as an explicit path fails instead of crashing", () => {
+  assert.equal(runCli(["scripts"], () => {}), 1);
+});
+
+test("the repository's own context files load their imports", () => {
+  assert.equal(runCli([path.join(__dirname, "..", "..", "CLAUDE.md")], () => {}), 0);
+});

--- a/scripts/__tests__/update-memory.test.js
+++ b/scripts/__tests__/update-memory.test.js
@@ -150,3 +150,43 @@ test("an unknown tool name is rejected", () => {
   assert.equal(result.status, 1);
   assert.match(result.stderr, /unknown tool emacs/u);
 });
+
+test("a new-marker pair quoted in prose above the block does not hijack the splice", () => {
+  const quote = `Upgrade note: the block now uses \`${OPEN}\` and \`${CLOSE}\`.`;
+  const result = run({ context: `${quote}\n\n${OPEN}\n${CLOSE}\n` });
+
+  assert.equal(result.content.split("\n")[0], quote);
+  assert.equal(
+    result.content,
+    `${quote}\n\n${OPEN}\n\n@aidd_docs/memory/architecture.md\n\n${CLOSE}\n`,
+  );
+});
+
+test("a nested fence does not close the example that documents the old shape", () => {
+  const content = run({
+    context: [
+      "````markdown",
+      "```",
+      "<aidd_project_memory>",
+      "</aidd_project_memory>",
+      "```",
+      "````",
+      "",
+      "<aidd_project_memory>",
+      "</aidd_project_memory>",
+      "",
+    ].join("\n"),
+  }).content;
+
+  const lines = content.split("\n");
+  assert.equal(lines[2], "<aidd_project_memory>", "the documented example must stay as written");
+  assert.equal(lines[7], OPEN, "the real block must be the one migrated");
+  assert.match(content, /@aidd_docs\/memory\/architecture\.md/u);
+});
+
+test("an unpaired marker fails the run when the skill named the tools", () => {
+  const result = run({ context: `# P\n\n${OPEN}\n@stale.md\n` });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /unpaired project memory marker/u);
+});

--- a/scripts/__tests__/update-memory.test.js
+++ b/scripts/__tests__/update-memory.test.js
@@ -1,0 +1,152 @@
+const assert = require("node:assert/strict");
+const { spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+// The hook is a script, not a module: the CLI copies it into the user's project,
+// where a "type": "module" package.json decides how it is parsed. Driving it as a
+// subprocess is the only way to test what actually ships.
+const HOOK = path.resolve(__dirname, "../../plugins/aidd-context/hooks/update_memory.js");
+
+const OPEN = "<!-- aidd_project_memory:start -->";
+const CLOSE = "<!-- aidd_project_memory:end -->";
+
+/** A throwaway project with a memory bank, a context file, and the hook run in it. */
+function run({ context, bank = ["architecture.md"], onDemand = [], packageJson, hookAt, args, runs = 1 }) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "update-memory-"));
+  try {
+    fs.mkdirSync(path.join(root, "aidd_docs/memory"), { recursive: true });
+    for (const file of bank) fs.writeFileSync(path.join(root, "aidd_docs/memory", file), "# x\n");
+    for (const file of onDemand) {
+      const full = path.join(root, "aidd_docs/memory", file);
+      fs.mkdirSync(path.dirname(full), { recursive: true });
+      fs.writeFileSync(full, "# x\n");
+    }
+    if (context !== undefined) fs.writeFileSync(path.join(root, "CLAUDE.md"), context);
+    if (packageJson) fs.writeFileSync(path.join(root, "package.json"), packageJson);
+
+    // Copying the hook in mirrors how the CLI installs it, so the project's own
+    // package.json governs the module system exactly as it does for a user.
+    let hook = HOOK;
+    if (hookAt) {
+      hook = path.join(root, hookAt);
+      fs.mkdirSync(path.dirname(hook), { recursive: true });
+      fs.copyFileSync(HOOK, hook);
+    }
+
+    const invoke = () => spawnSync(process.execPath, [hook, ...(args ?? ["claude"])], { cwd: root });
+    const read = () => fs.readFileSync(path.join(root, "CLAUDE.md"), "utf8");
+
+    const first = invoke();
+    const content = read();
+    // Read everything before the finally below removes the project.
+    return {
+      status: first.status,
+      stderr: first.stderr.toString(),
+      content,
+      contentAfterRerun: runs > 1 ? (invoke(), read()) : content,
+    };
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test("the hook runs in a project declaring itself an ES module", () => {
+  const run1 = run({
+    context: `# P\n\n${OPEN}\n${CLOSE}\n`,
+    packageJson: '{ "type": "module" }\n',
+    hookAt: ".claude/hooks/aidd-context/update_memory.js",
+  });
+
+  assert.equal(run1.stderr, "");
+  assert.equal(run1.status, 0);
+  assert.match(run1.content, /@aidd_docs\/memory\/architecture\.md/u);
+});
+
+test("a legacy block is migrated to the comment markers and filled", () => {
+  const content = run({
+    context: "# P\n\n<aidd_project_memory>\n@aidd_docs/memory/old.md\n</aidd_project_memory>\n",
+  }).content;
+
+  assert.equal(content.includes("<aidd_project_memory>"), false);
+  assert.equal(content, `# P\n\n${OPEN}\n\n@aidd_docs/memory/architecture.md\n\n${CLOSE}\n`);
+});
+
+test("a legacy pair quoted in prose is left alone and the real block still migrates", () => {
+  const quote = "Old shape: `<aidd_project_memory>` ... `</aidd_project_memory>`.";
+  const content = run({
+    context: `${quote}\n\n<aidd_project_memory>\n</aidd_project_memory>\n`,
+  }).content;
+
+  assert.equal(content.split("\n")[0], quote);
+  assert.equal(content.split("\n")[2], OPEN);
+});
+
+test("a legacy pair inside a code fence is not the block that gets rewritten", () => {
+  const content = run({
+    context: [
+      "```markdown",
+      "<aidd_project_memory>",
+      "</aidd_project_memory>",
+      "```",
+      "",
+      "<aidd_project_memory>",
+      "</aidd_project_memory>",
+      "",
+    ].join("\n"),
+  }).content;
+
+  const lines = content.split("\n");
+  assert.equal(lines[1], "<aidd_project_memory>");
+  assert.equal(lines[5], OPEN);
+});
+
+test("the imports keep a blank line on each side, so nothing hides them", () => {
+  const content = run({
+    context: `${OPEN}\n${CLOSE}\n`,
+    bank: ["architecture.md", "vcs.md"],
+  }).content;
+
+  assert.equal(
+    content,
+    `${OPEN}\n\n@aidd_docs/memory/architecture.md\n@aidd_docs/memory/vcs.md\n\n${CLOSE}\n`,
+  );
+});
+
+test("filling is idempotent", () => {
+  const result = run({ context: `${OPEN}\n${CLOSE}\n`, runs: 2 });
+
+  assert.equal(result.contentAfterRerun, result.content);
+  assert.match(result.content, /@aidd_docs\/memory\/architecture\.md/u);
+});
+
+test("the on-demand tier is listed without an import prefix", () => {
+  const content = run({
+    context: `${OPEN}\n${CLOSE}\n`,
+    onDemand: ["internal/decision.md"],
+  }).content;
+
+  assert.match(content, /^- aidd_docs\/memory\/internal\/decision\.md$/mu);
+});
+
+test("a file holding one marker without its pair reports instead of skipping silently", () => {
+  const result = run({ context: `# P\n\n<aidd_project_memory>\n${CLOSE}\n` });
+
+  assert.match(result.stderr, /unpaired project memory marker/u);
+});
+
+test("a context file with no block at all is skipped quietly", () => {
+  const result = run({ context: "# P\n\nNo block here.\n" });
+
+  assert.equal(result.stderr, "");
+  assert.equal(result.content, "# P\n\nNo block here.\n");
+});
+
+test("an unknown tool name is rejected", () => {
+  const result = run({ context: `${OPEN}\n${CLOSE}\n`, args: ["emacs"] });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /unknown tool emacs/u);
+});

--- a/scripts/check-context-imports.js
+++ b/scripts/check-context-imports.js
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+/**
+ * check-context-imports.js - Fails when an `@import` in an AI context file sits
+ * inside an HTML block, where the context loader skips it.
+ *
+ * Any line whose first non-space character is `<` is treated as opening an HTML
+ * block that runs until the next blank line. Imports inside one are ignored
+ * exactly like those in a fenced code block, so the file looks correct and loads
+ * nothing, and nothing reports it.
+ *
+ * That rule is deliberately stricter than CommonMark, which closes a comment on
+ * its own line. Context loaders are not all CommonMark, and a blank line after
+ * the opening line costs nothing and holds under either reading.
+ *
+ * Usage:
+ *   node scripts/check-context-imports.js                 every context file
+ *   node scripts/check-context-imports.js CLAUDE.md ...    only those files
+ */
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const ROOT = path.resolve(__dirname, "..");
+
+// The files a context loader reads. Anywhere in the tree, not just the root:
+// a monorepo package carries its own.
+const CONTEXT_FILENAMES = ["CLAUDE.md", "AGENTS.md", "copilot-instructions.md"];
+
+// Directories to never walk into, matched by name at any depth. Same set as
+// scripts/check-markdown-links.js, which walks the same tree.
+const SKIPPED_DIRS = new Set([".git", "node_modules", "worktrees", ".specstory"]);
+
+// Snapshots of older framework versions, kept on the old shape as test input.
+const EXCLUDED_PATHS = ["cli/tests/fixtures"];
+
+const IMPORT_LINE = /^\s{0,3}@\S+/u;
+const HTML_BLOCK_OPEN = /^\s{0,3}</u;
+const FENCE = /^\s{0,3}(`{3,}|~{3,})/u;
+
+function isExcluded(relPath) {
+  const normalized = relPath.split(path.sep).join("/");
+  return EXCLUDED_PATHS.some((dir) => normalized === dir || normalized.startsWith(`${dir}/`));
+}
+
+function collectContextFiles(dir = ROOT, found = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (SKIPPED_DIRS.has(entry.name)) continue;
+      if (isExcluded(path.relative(ROOT, full))) continue;
+      collectContextFiles(full, found);
+    } else if (CONTEXT_FILENAMES.includes(entry.name)) {
+      found.push(full);
+    }
+  }
+  return found;
+}
+
+/**
+ * Imports that a context loader will skip, with the line that hid them.
+ * Code blocks are skipped: the broken shape is quoted in documentation.
+ */
+function findHiddenImports(content) {
+  const hidden = [];
+  let fence = null;
+  let openedAt = null;
+
+  content.split("\n").forEach((line, index) => {
+    const opener = FENCE.exec(line);
+
+    if (fence) {
+      // A fence closes only on the same character, repeated at least as often.
+      if (opener && opener[1][0] === fence[0] && opener[1].length >= fence.length) fence = null;
+      return;
+    }
+    if (opener) {
+      fence = opener[1];
+      return;
+    }
+    if (line.trim() === "") {
+      openedAt = null;
+      return;
+    }
+    if (openedAt === null && HTML_BLOCK_OPEN.test(line)) {
+      openedAt = { line: index + 1, text: line.trim() };
+      return;
+    }
+    if (openedAt !== null && IMPORT_LINE.test(line)) {
+      hidden.push({ line: index + 1, import: line.trim(), openedBy: openedAt });
+    }
+  });
+
+  return hidden;
+}
+
+function checkFiles(files) {
+  const problems = [];
+  for (const file of files) {
+    for (const hidden of findHiddenImports(fs.readFileSync(file, "utf8"))) {
+      problems.push({ file, ...hidden });
+    }
+  }
+  return problems;
+}
+
+function reportProblems(problems, logger = console.error, successLogger = console.log) {
+  if (problems.length === 0) {
+    successLogger("✅ context imports load: none sit inside an HTML block");
+    return;
+  }
+  logger(`❌ ${problems.length} import(s) never load: inside an HTML block`);
+  for (const problem of problems) {
+    const where = `${path.relative(ROOT, problem.file)}:${problem.line}`;
+    logger(`  ${where}  ${problem.import}`);
+    logger(`    inside the block opened line ${problem.openedBy.line} by ${problem.openedBy.text}`);
+  }
+  logger("  Add a blank line after the opening line, or move the imports out of the block.");
+}
+
+function runCli(argv = process.argv.slice(2), logger = console.error) {
+  if (argv.length === 0) {
+    const problems = checkFiles(collectContextFiles());
+    reportProblems(problems);
+    return problems.length === 0 ? 0 : 1;
+  }
+
+  // A path given explicitly and not read is an error. Skipping it would turn the
+  // check into a green no-op, which is the failure it exists to catch.
+  const files = argv.map((f) => path.resolve(ROOT, f));
+  const missing = files.filter((f) => !fs.existsSync(f) || !fs.statSync(f).isFile());
+  if (missing.length > 0) {
+    for (const f of missing) logger(`❌ Not a readable file: ${path.relative(ROOT, f)}`);
+    return 1;
+  }
+
+  const problems = checkFiles(files);
+  reportProblems(problems);
+  return problems.length === 0 ? 0 : 1;
+}
+
+module.exports = { findHiddenImports, checkFiles, reportProblems, collectContextFiles, runCli };
+
+if (require.main === module) process.exit(runCli());

--- a/scripts/skill-eval/cases.json
+++ b/scripts/skill-eval/cases.json
@@ -251,7 +251,8 @@
       "fileContains": {
         "CLAUDE.md": [
           "@aidd_docs/memory/architecture.md",
-          "@aidd_docs/memory/vcs.md"
+          "@aidd_docs/memory/vcs.md",
+          "<!-- aidd_project_memory:start -->"
         ]
       }
     }


### PR DESCRIPTION
## 🎯 What & why

The generated memory block was delimited by a bare `<aidd_project_memory>` tag on its own line, which markdown reads as an HTML block running to the next blank line, so the context loader skipped every `@` import inside it. The memory bank never loaded and nothing said so: on this repo that was 8 files and ~7k tokens missing from every session.

## 🛠️ How it works

**Comment markers.** [update_memory.js:36](plugins/aidd-context/hooks/update_memory.js#L36) now writes `<!-- aidd_project_memory:start -->` / `:end`. A comment closes on its own line, so no adjacent blank line has to survive for the block to be correct. Same convention as the `<!-- files:start -->` markers already used a few lines down for the memory README index.

The issue proposed a one-character fix instead: a blank line after the old tag. Both load (measured, table below). The choice is durability, not correctness — the blank line is a load-bearing convention nothing declares, and a rewrite already silently reverted it once. This PR emits it too, but as belt and braces.

**Migration is part of the fix.** The hook only fills a block already present and returns silently when it finds no close marker, so shipping new markers alone would leave every installed repo skipped without a word. [migrateLegacyMarkers](plugins/aidd-context/hooks/update_memory.js#L180) rewrites the old pair, matching markers that own their line outside any code fence — a substring match would rewrite the tag quoted in an upgrade note and leave the real block dark.

**The hook stays a script.** The CLI copies it into the user's project, so the project's `package.json` decides how it is parsed: any CommonJS syntax crashes it in a `"type": "module"` project, and this repo can't catch that (no `"type"` field, so CommonJS by default). Hence dynamic `import()` only, no exports, and tests that spawn it as a subprocess.

**Guard.** [check-context-imports.js](scripts/check-context-imports.js) fails when an import sits inside an HTML block. It runs in pre-commit, which is what [validate.yml:55](.github/workflows/validate.yml#L55) replays, so a fork PR or `--no-verify` is gated too.

## 🧪 How to verify

```bash
node scripts/check-context-imports.js   # clean

# put the three context files back on the old shape to see the bug
git checkout 765d6a2c -- CLAUDE.md AGENTS.md cli/CLAUDE.md
node scripts/check-context-imports.js   # 25 imports that never load
git checkout HEAD -- CLAUDE.md AGENTS.md cli/CLAUDE.md

node --test 'scripts/__tests__/*.test.js'   # 27 pass
```

In a fresh session, `/context` shows **Memory files: 7.1k tokens**; before, only `CLAUDE.md` counted.

Canary A/B, same random token in a memory file, headless prompt asking for it, no tools:

| Block shape | Answer |
| --- | --- |
| old tag, imports glued (before) | `ABSENT` |
| comment markers + blank line (this PR) | token echoed |
| comment markers, imports glued | token echoed |
| old tag + blank line (the issue's fix) | token echoed |

## ⚠️ Heads-up

- The guard is deliberately stricter than CommonMark: it flags row 3 above, which loads fine in Claude Code. Other tools read the same files, and the hook always emits the blank line, so nothing generated trips it.
- `cli/tests/fixtures/**` stays on the old tag: [golden.json](cli/tests/golden/snapshots/framework-build/golden.json) pins its hash.
- A repo with only an `AGENTS.md` still shows Claude Code nothing: measured, it does not read that file at all, imports or plain text. Not a gap this PR leaves open — re-running `02-project-memory` and picking Claude creates the `CLAUDE.md` from the template. Worth knowing the chain works if it ever comes up: `CLAUDE.md` holding `@AGENTS.md` resolves transitively down to the memory files.
- Anyone touching the hook must keep it free of `require` / `module.exports`, per the note at [update_memory.js:255](plugins/aidd-context/hooks/update_memory.js#L255).

## 🔗 Linked issue

Closes #719

## ✅ I certify

- [ ] **I DO CERTIFY I READ EACH LINE OF THE PULL REQUEST BECAUSE I AM A SOFTWARE ENGINEER, NOT A AI PUPPY.**

