### PR TITLE
chore(framework): refresh the project memory reading list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,10 +41,12 @@ Project docs, memory, specs, and plans live in `aidd_docs/`.
 <!-- aidd_project_memory:start -->
 
 @aidd_docs/memory/architecture.md
-@aidd_docs/memory/browsing.md
+@aidd_docs/memory/backlog.md
+@aidd_docs/memory/cli.md
 @aidd_docs/memory/codebase-map.md
 @aidd_docs/memory/coding-assertions.md
 @aidd_docs/memory/deployment.md
+@aidd_docs/memory/ecosystem.md
 @aidd_docs/memory/project-brief.md
 @aidd_docs/memory/testing.md
 @aidd_docs/memory/vcs.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,10 +41,12 @@ Project docs, memory, specs, and plans live in `aidd_docs/`.
 <!-- aidd_project_memory:start -->
 
 @aidd_docs/memory/architecture.md
-@aidd_docs/memory/browsing.md
+@aidd_docs/memory/backlog.md
+@aidd_docs/memory/cli.md
 @aidd_docs/memory/codebase-map.md
 @aidd_docs/memory/coding-assertions.md
 @aidd_docs/memory/deployment.md
+@aidd_docs/memory/ecosystem.md
 @aidd_docs/memory/project-brief.md
 @aidd_docs/memory/testing.md
 @aidd_docs/memory/vcs.md

--- a/aidd_docs/memory/backlog.md
+++ b/aidd_docs/memory/backlog.md
@@ -1,0 +1,44 @@
+# Backlog
+
+## Supports
+
+| Support | Authority for | Role |
+| --- | --- | --- |
+| GitHub Issues | the work items, their type and their scope | where a change is agreed before a branch exists |
+| AIDD Roadmap board (org project 8) | order, status, and what ships next | the single source of truth for the roadmap |
+| Milestones | themes | a theme with a Thursday due date; no milestone means backlog |
+| GitHub Discussions | ideas and their upvotes | where an idea is weighed before it becomes an issue |
+| `aidd_docs/` task documents | the local plans, specs and reviews behind an issue | read by `aidd kanban`, never a substitute for the issue |
+
+## Representation
+
+| Artifact | Support | Native representation |
+| --- | --- | --- |
+| Feature | GitHub Issues | issue type `Feature`, form 🌱 Quick Contribution |
+| Bug | GitHub Issues | issue type `Bug`, form 🐛 Bug Report |
+| Task | GitHub Issues | issue type `Task`, form 📋 Detailed Contribution |
+| Theme | Milestones | one milestone, due on a Thursday |
+| Idea | GitHub Discussions | a discussion, ranked by 👍 |
+
+The form stamps the type; nobody sets it by hand. Labels categorize nothing: one exists only when a bot or a human reads it, and `.github/labels.yml` is their source of truth.
+
+## Workflow
+
+| Support | Native status | Meaning |
+| --- | --- | --- |
+| Roadmap board | Todo | agreed, not started |
+| Roadmap board | In review | a pull request is open |
+| Roadmap board | Done | merged |
+
+The board is moved by hand, by a human or an agent through `gh`. No workflow advances it.
+
+## Planning
+
+- Priority: set by a community vote, mechanism in `GOVERNANCE.md`.
+- Iteration: weekly, a milestone per theme due on a Thursday.
+- Milestone: closed automatically once all its issues are, by `.github/workflows/close-finished-milestones.yml`.
+
+## Relations
+
+- An issue's branch and pull request carry the routing: the branch prefix decides the target, per `vcs.md`.
+- A `aidd_docs/` task folder is grouped by its parent document (`plan.md`, then `master-plan.md`, then `spec.md`), and a sub-document's status never moves that parent.

--- a/aidd_docs/memory/browsing.md
+++ b/aidd_docs/memory/browsing.md
@@ -1,5 +1,0 @@
-# Browser Setup
-
-- **Browsing Tool**: Playwright MCP (configured in `.playwright-mcp/`)
-- **Starting URL**: None — framework has no web UI; used for testing downstream projects
-- **Authentication**: N/A

--- a/aidd_docs/memory/cli.md
+++ b/aidd_docs/memory/cli.md
@@ -1,0 +1,24 @@
+# CLI
+
+The `aidd` binary, built from `cli/` and published to npm.
+
+## Commands
+
+- `setup`, `ai`, `ide`: install and refresh AI tool configurations in a target project.
+- `framework`: build a target-native distribution of this repo (`--target <tool>`, `--out`, `--flat`). The release workflow calls it at a pinned version, so a CLI release never silently changes framework dist output.
+- `plugin`, `marketplace`: add, list, search, update and remove plugins and the marketplaces they come from.
+- `kanban`: render `aidd_docs/` task frontmatter as status columns, interactive or `list --json`. Source lives in `kanban/`, bundled from source at build time.
+- `auth`, `status`, `doctor`, `clean`, `restore`, `update`, `self-update`: credentials, diagnosis, and upkeep.
+
+## Interface
+
+- Commands register on one `commander` program in `cli/src/cli.ts`; each has its own file under `application/commands/`.
+- `--verbose` is global. Read the surface from `aidd --help`, never from a copy.
+- Only commands already paying for network I/O carry the update check, listed as `ONLINE_COMMAND_PATHS` in `cli/src/cli.ts`.
+- `framework build` refuses to run when `--out` sits inside `--source`.
+
+## Distribution
+
+- `bin.aidd` points at `dist/cli.js`, bundled by `tsup` under a bundle size budget the build enforces (`bundleBudgetKB`).
+- Published to npm by OIDC trusted publishing when release-please releases the `cli` path. The GitHub Packages push runs first and is best-effort: it never fails the job.
+- `kanban/` never imports from `cli/`: everything it needs arrives through `KanbanCommandDeps` at registration.

--- a/aidd_docs/memory/ecosystem.md
+++ b/aidd_docs/memory/ecosystem.md
@@ -1,0 +1,27 @@
+# Ecosystem
+
+```mermaid
+flowchart LR
+  Human([Human])
+  Agent([Agent])
+  App([App])
+  GitHub["GitHub · vcs.md"]
+  Board["Roadmap project board · backlog.md"]
+  Npm["npm registry"]
+  Packages["GitHub Packages"]
+  Discord["Discord · human only"]
+  ReleasePlease["release-please"]
+  Dependabot["Dependabot"]
+
+  Agent -- cli --> GitHub
+  Agent -- cli --> Board
+  Human -- cli --> Board
+  App -- http --> GitHub
+  App -- http --> Npm
+  Human -- web --> Discord
+
+  Dependabot -- "dependency update PR" --> GitHub
+  ReleasePlease -- "merge on main" --> GitHub
+  GitHub -- "release created" --> Npm
+  GitHub -- "release created" --> Packages
+```


### PR DESCRIPTION
The memory bank gained `backlog.md`, `cli.md` and `ecosystem.md`, and lost `browsing.md`. The reading lists in `AGENTS.md` and `CLAUDE.md` still named the file that is gone — which `markdown-links` flags as a broken local path — and never named the three that arrived. The comment markers introduced by #721 are untouched; only the entries between them change.

The three new bank files ship with it, since the list references them.

The `pnpm-workspace.yaml` fix for pnpm 11's build-script prompt was in this branch and has been dropped: a `pnpm-workspace.yaml` at the root turns the repo into a pnpm workspace, which redirects `cli/`'s install to the root and leaves `cli/node_modules` missing (`sh: 1: biome: not found` in CI). It needs a different fix, tracked separately.