### PR TITLE
chore(framework): reshape the memory bank to its own templates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,16 +40,16 @@ Project docs, memory, specs, and plans live in `aidd_docs/`.
 
 <!-- aidd_project_memory:start -->
 
-@aidd_docs/memory/architecture.md
-@aidd_docs/memory/backlog.md
-@aidd_docs/memory/cli.md
-@aidd_docs/memory/codebase-map.md
-@aidd_docs/memory/coding-assertions.md
-@aidd_docs/memory/deployment.md
-@aidd_docs/memory/ecosystem.md
-@aidd_docs/memory/project-brief.md
-@aidd_docs/memory/testing.md
-@aidd_docs/memory/vcs.md
+[aidd_docs/memory/architecture.md](aidd_docs/memory/architecture.md)
+[aidd_docs/memory/backlog.md](aidd_docs/memory/backlog.md)
+[aidd_docs/memory/cli.md](aidd_docs/memory/cli.md)
+[aidd_docs/memory/codebase-map.md](aidd_docs/memory/codebase-map.md)
+[aidd_docs/memory/coding-assertions.md](aidd_docs/memory/coding-assertions.md)
+[aidd_docs/memory/deployment.md](aidd_docs/memory/deployment.md)
+[aidd_docs/memory/ecosystem.md](aidd_docs/memory/ecosystem.md)
+[aidd_docs/memory/project-brief.md](aidd_docs/memory/project-brief.md)
+[aidd_docs/memory/testing.md](aidd_docs/memory/testing.md)
+[aidd_docs/memory/vcs.md](aidd_docs/memory/vcs.md)
 
 <!-- aidd_project_memory:end -->
 

--- a/aidd_docs/memory/README.md
+++ b/aidd_docs/memory/README.md
@@ -1,0 +1,43 @@
+# memory/ - Project Memory
+
+Structured context the AI assistant reads at the start of a session, so it does not rediscover the project each time.
+
+## How it loads
+
+```mermaid
+flowchart LR
+    bank["memory/*.md"] -->|every session| ai(["AI context"])
+    notes["internal/ · external/"] -.->|on demand| ai
+```
+
+The root files load every session through the project memory block in each AI context file. `internal/` and `external/` load only when relevant.
+
+## Files
+
+Refreshed automatically by the memory hook. Do not edit by hand.
+
+<!-- files:start -->
+- [architecture.md](architecture.md)
+- [backlog.md](backlog.md)
+- [cli.md](cli.md)
+- [codebase-map.md](codebase-map.md)
+- [coding-assertions.md](coding-assertions.md)
+- [deployment.md](deployment.md)
+- [ecosystem.md](ecosystem.md)
+- [project-brief.md](project-brief.md)
+- [testing.md](testing.md)
+- [vcs.md](vcs.md)
+<!-- files:end -->
+
+## Maintaining it
+
+The AI writes and refreshes these files. When you edit one by hand:
+
+- One file per concern (architecture, database, vcs, ...).
+- Capture the macro and the non-derivable. Point to the code, never copy it.
+- Current state only, kept small. No personal notes, no future TODOs.
+
+## Subdirectories
+
+- `internal/`: AIDD workflow traces (the capability profile, audit notes, learn captures).
+- `external/`: external references the project pulls in (specs, design docs).

--- a/aidd_docs/memory/architecture.md
+++ b/aidd_docs/memory/architecture.md
@@ -2,37 +2,45 @@
 
 The macro technical shape: the stack, how the pieces fit, and the decisions behind them. Point to the code, do not restate it.
 
+> CLI internals (layers, domain models, install flows, adapters) live in [`cli/aidd_docs/memory/architecture.md`](../../cli/aidd_docs/memory/architecture.md).
+
 ## Stack
 
-- Markdown is the product. Skills, agents, rules and memory templates are interpreted by an LLM at runtime; there is no framework runtime to execute them.
-- Node.js `>=22.12` with pnpm, for the two TypeScript workspaces that deliver the markdown: `cli/` (the `aidd` binary) and `kanban/` (bundled into it at build time).
-- Commander for the CLI surface, Ink and React for the terminal views, `gray-matter` for task frontmatter, `smol-toml` and `js-yaml` for the tool configuration formats.
+| Part | What |
+| --- | --- |
+| Product | markdown — skills, agents, rules, templates. No framework runtime; an LLM interprets them. |
+| Delivery | Node `>=22.12`, pnpm. `cli/` (the `aidd` binary) and `kanban/` (bundled into it from source). |
+| Manifest | `.claude-plugin/marketplace.json`, 7 plugins, versioned per plugin. |
 
 ## How it fits together
 
 ```mermaid
 flowchart LR
-    Manifest[".claude-plugin/marketplace.json"] -->|lists| Plugins["plugins/ · 7 packages"]
+    Manifest[".claude-plugin/marketplace.json"] -->|lists| Plugins["plugins/ · 7"]
     Plugins -->|ships| Surfaces["skills · agents · commands · hooks · rules"]
-    CLI["cli/ · the aidd binary"] -->|reads| Manifest
-    CLI -->|installs| Target["a project's AI tool directory"]
+    CLI["cli/ · aidd"] -->|reads| Manifest
+    CLI -->|installs| Target["a project's AI tool dir"]
     Kanban["kanban/"] -->|bundled from source| CLI
     Editor["AI coding tool"] -->|invokes| Surfaces
 ```
 
-The CLI is a workspace of this repo, not an outside consumer: `cli/` and `kanban/` are type-checked, tested and released here.
+`cli/` and `kanban/` are workspaces of this repo, not outside consumers: type-checked, tested and released here.
 
 ## Key decisions
 
-- **Knowledge and execution are separated by a firewall.** Knowledge plugins produce artifacts you read; they never write or run application source. The full concern-to-plugin taxonomy is canonical in [`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md).
-- **Concern decides placement, not existence.** A missing capability goes to the plugin whose concern owns it, and the caller delegates. It is never reimplemented in the calling plugin because the right home lacks it today.
-- **A skill is a router.** Its `SKILL.md` dispatches to local actions or, for an orchestrator, to numbered reference protocols. The router is the only place a capability is addressed by name.
-- **Recipe skills discover providers at runtime** by description matching, never by hardcoding a sibling. Only agent permission lists and orchestration references name a provider, since those are auditable responsibility maps.
-- **Both TypeScript workspaces layer `domain/`, `application/`, `infrastructure/`**, dependencies pointing inward. `kanban/` never imports from `cli/`; the host injects everything through `KanbanCommandDeps` (`kanban/src/presentation/kanban-deps.ts`).
+| Decision | Why |
+| --- | --- |
+| Knowledge and execution separated by a firewall | knowledge plugins produce artifacts you read, never write or run application source |
+| Concern decides placement, not existence | a missing capability goes to the plugin whose concern owns it; the caller delegates |
+| A skill is a router | `SKILL.md` dispatches to actions or protocols; the only place a capability is addressed by name |
+| Recipe skills discover providers at runtime | by description matching. Only agent permission lists and orchestration references name a provider |
+| `kanban/` never imports `cli/` | the host injects through `KanbanCommandDeps` (`kanban/src/presentation/kanban-deps.ts`) |
+
+The concern-to-plugin taxonomy is canonical in [`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md).
 
 ## Gotchas
 
-- **A plugin never contains its own tests.** The build copies `hooks/` recursively into every user project, so a test folder there would ship to them. Tests for a bundled script live in `scripts/__tests__/`.
-- **A skill never links outside itself.** The same tree ships flat, with the skill folder renamed `<plugin>-<skill>`, and as a marketplace, so no relative path survives both. A bundled script is named plugin-relative in backticks, never linked.
-- **Bundled hooks run Node**, so a user without `node` on their `PATH` gets no memory refresh.
-- **The CLI reaches into `kanban/src/` by relative path**, so `kanban/`'s dependencies must be installed before any `cli` typecheck, test or build.
+- A plugin never contains its own tests — `hooks/` ships recursively into user projects.
+- A skill never links outside itself: the tree ships both flat and as a marketplace, so no relative path survives both.
+- Bundled hooks run Node. No `node` on `PATH`, no memory refresh.
+- `cli/` reaches into `kanban/src/` by relative path, so `kanban/`'s deps must be installed before any `cli` typecheck, test or build.

--- a/aidd_docs/memory/architecture.md
+++ b/aidd_docs/memory/architecture.md
@@ -1,69 +1,38 @@
 # Architecture
 
-## Language/Framework
+The macro technical shape: the stack, how the pieces fit, and the decisions behind them. Point to the code, do not restate it.
 
-```json
-{
-  "runtime": "Node.js 20",
-  "primary_format": "Markdown (skills, agents, rules, memory)",
-  "package_manager": "pnpm",
-  "devDependencies": ["@commitlint/cli", "@commitlint/config-conventional", "lefthook"]
-}
-```
+## Stack
 
-```mermaid
-flowchart LR
-    Marketplace[".claude-plugin/marketplace.json"] --> Plugins["plugins/"]
-    Plugins --> Context["aidd-context"]
-    Plugins --> Dev["aidd-dev"]
-    Plugins --> VCS["aidd-vcs"]
-    Plugins --> PM["aidd-pm"]
-    Plugins --> Refine["aidd-refine"]
-    Plugins --> Orchestrator["aidd-orchestrator"]
-    CLI["@ai-driven-dev/cli"] -- installs --> Plugins
-```
+- Markdown is the product. Skills, agents, rules and memory templates are interpreted by an LLM at runtime; there is no framework runtime to execute them.
+- Node.js `>=22.12` with pnpm, for the two TypeScript workspaces that deliver the markdown: `cli/` (the `aidd` binary) and `kanban/` (bundled into it at build time).
+- Commander for the CLI surface, Ink and React for the terminal views, `gray-matter` for task frontmatter, `smol-toml` and `js-yaml` for the tool configuration formats.
 
-### Naming Conventions
-
-- **Plugins**: `aidd-<domain>` — kebab-case
-- **Skills**: `NN-slug/SKILL.md` — numbered prefix + kebab-case slug
-- **Actions**: `NN-action-name.md` — numbered, kebab-case
-- **Agents**: `name.md` — flat, kebab-case
-- **Rules**: `N-name.md` — numbered, kebab-case
-- **Memory files**: `topic.md` — kebab-case noun
-
-## Plugin Structure
-
-Each plugin follows this layout:
-
-```mermaid
-flowchart TD
-    Plugin["plugins/aidd-X/"] --> ClaudePlugin[".claude-plugin/plugin.json"]
-    Plugin --> Skills["skills/NN-name/"]
-    Plugin --> Agents["agents/"]
-    Skills --> SkillMd["SKILL.md"]
-    Skills --> Actions["actions/NN-action.md"]
-    Skills --> Assets["assets/"]
-```
-
-## Services Communication
-
-### CLI to Marketplace
+## How it fits together
 
 ```mermaid
 flowchart LR
-    User["Developer"] -- "aidd plugin add" --> CLI["@ai-driven-dev/cli"]
-    CLI -- reads --> Marketplace[".claude-plugin/marketplace.json"]
-    CLI -- copies --> TargetRepo["target repo's AI tool dir"]
+    Manifest[".claude-plugin/marketplace.json"] -->|lists| Plugins["plugins/ · 7 packages"]
+    Plugins -->|ships| Surfaces["skills · agents · commands · hooks · rules"]
+    CLI["cli/ · the aidd binary"] -->|reads| Manifest
+    CLI -->|installs| Target["a project's AI tool directory"]
+    Kanban["kanban/"] -->|bundled from source| CLI
+    Editor["AI coding tool"] -->|invokes| Surfaces
 ```
 
-### External Services
+The CLI is a workspace of this repo, not an outside consumer: `cli/` and `kanban/` are type-checked, tested and released here.
 
-#### GitHub Package Registry
+## Key decisions
 
-```mermaid
-flowchart LR
-    CI["GitHub Actions"] -- publishes --> NPM["npm.pkg.github.com/@ai-driven-dev/cli"]
-    CI -- creates --> Release["GitHub Release + assets"]
-    BuildScript["scripts/build-dist.sh"] -- generates --> Dist["plugin dist archives"]
-```
+- **Knowledge and execution are separated by a firewall.** Knowledge plugins produce artifacts you read; they never write or run application source. The full concern-to-plugin taxonomy is canonical in [`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md).
+- **Concern decides placement, not existence.** A missing capability goes to the plugin whose concern owns it, and the caller delegates. It is never reimplemented in the calling plugin because the right home lacks it today.
+- **A skill is a router.** Its `SKILL.md` dispatches to local actions or, for an orchestrator, to numbered reference protocols. The router is the only place a capability is addressed by name.
+- **Recipe skills discover providers at runtime** by description matching, never by hardcoding a sibling. Only agent permission lists and orchestration references name a provider, since those are auditable responsibility maps.
+- **Both TypeScript workspaces layer `domain/`, `application/`, `infrastructure/`**, dependencies pointing inward. `kanban/` never imports from `cli/`; the host injects everything through `KanbanCommandDeps` (`kanban/src/presentation/kanban-deps.ts`).
+
+## Gotchas
+
+- **A plugin never contains its own tests.** The build copies `hooks/` recursively into every user project, so a test folder there would ship to them. Tests for a bundled script live in `scripts/__tests__/`.
+- **A skill never links outside itself.** The same tree ships flat, with the skill folder renamed `<plugin>-<skill>`, and as a marketplace, so no relative path survives both. A bundled script is named plugin-relative in backticks, never linked.
+- **Bundled hooks run Node**, so a user without `node` on their `PATH` gets no memory refresh.
+- **The CLI reaches into `kanban/src/` by relative path**, so `kanban/`'s dependencies must be installed before any `cli` typecheck, test or build.

--- a/aidd_docs/memory/cli.md
+++ b/aidd_docs/memory/cli.md
@@ -1,24 +1,24 @@
 # CLI
 
-The `aidd` binary, built from `cli/` and published to npm.
+The `aidd` binary, built from `cli/` and published to npm as `@ai-driven-dev/cli`.
+
+> `cli/` carries its own `CLAUDE.md` and memory bank. Command detail, interface and internals: [`cli/aidd_docs/memory/cli.md`](../../cli/aidd_docs/memory/cli.md).
 
 ## Commands
 
-- `setup`, `ai`, `ide`: install and refresh AI tool configurations in a target project.
-- `framework`: build a target-native distribution of this repo (`--target <tool>`, `--out`, `--flat`). The release workflow calls it at a pinned version, so a CLI release never silently changes framework dist output.
-- `plugin`, `marketplace`: add, list, search, update and remove plugins and the marketplaces they come from.
-- `kanban`: render `aidd_docs/` task frontmatter as status columns, interactive or `list --json`. Source lives in `kanban/`, bundled from source at build time.
-- `auth`, `status`, `doctor`, `clean`, `restore`, `update`, `self-update`: credentials, diagnosis, and upkeep.
+| Group | Does |
+| --- | --- |
+| `setup`, `ai`, `ide` | install and refresh AI tool configurations in a target project |
+| `plugin`, `marketplace` | add, list, search, update, remove plugins and their marketplaces |
+| `framework build` | build a target-native distribution of this repo. CI calls it at a pinned version |
+| `kanban` | render `aidd_docs/` task frontmatter as a board |
+| `auth`, `status`, `doctor`, `clean`, `restore`, `update`, `self-update` | credentials, diagnosis, upkeep |
 
 ## Interface
 
-- Commands register on one `commander` program in `cli/src/cli.ts`; each has its own file under `application/commands/`.
-- `--verbose` is global. Read the surface from `aidd --help`, never from a copy.
-- Only commands already paying for network I/O carry the update check, listed as `ONLINE_COMMAND_PATHS` in `cli/src/cli.ts`.
-- `framework build` refuses to run when `--out` sits inside `--source`.
+- Node `>=22.12`, ESM, Commander. Ink and React for the interactive views.
+- `kanban/` is bundled from source at build time, so its deps must resolve before any `cli` job.
 
 ## Distribution
 
-- `bin.aidd` points at `dist/cli.js`, bundled by `tsup` under a bundle size budget the build enforces (`bundleBudgetKB`).
-- Published to npm by OIDC trusted publishing when release-please releases the `cli` path. The GitHub Packages push runs first and is best-effort: it never fails the job.
-- `kanban/` never imports from `cli/`: everything it needs arrives through `KanbanCommandDeps` at registration.
+npm, through OIDC trusted publishing, no token. `publish-cli` runs when release-please releases the `cli` path.

--- a/aidd_docs/memory/codebase-map.md
+++ b/aidd_docs/memory/codebase-map.md
@@ -1,24 +1,37 @@
-# Codebase Structure
+# Codebase Map
+
+The macro layout: the top-level areas and what each holds. A map to navigate, not the full tree.
 
 ```mermaid
 flowchart TD
-    Root["framework/"] --> ClaudePlugin[".claude-plugin/ (marketplace manifest)"]
-    Root --> Plugins["plugins/ (6 plugin packages)"]
-    Root --> Scripts["scripts/ (build & distribution)"]
-    Root --> GH[".github/ (CI workflows, issue templates)"]
-    Root --> AiddDocs["aidd_docs/ (memory bank, guidelines)"]
-    Root --> DotClaude[".claude/ (rules, settings, tasks)"]
-
-    Plugins --> AiddContext["aidd-context"]
-    Plugins --> AiddDev["aidd-dev"]
-    Plugins --> AiddVCS["aidd-vcs"]
-    Plugins --> AiddPM["aidd-pm"]
-    Plugins --> AiddRefine["aidd-refine"]
-    Plugins --> AiddOrchestrator["aidd-orchestrator"]
-
-    AiddContext --> CtxSkills["skills/ (onboard, bootstrap, project-memory, context-generate, mermaid, learn, discovery)"]
-    AiddContext --> CtxHooks["hooks/update_memory.js"]
-    AiddDev --> DevSkills["skills/ (01-plan, 02-implement, 03-assert, 04-audit, 05-review, 06-test, 07-refactor, 08-debug, 09-for-sure, 10-todo)"]
-    AiddDev --> DevAgents["agents/ (executor, checker)"]
-    AiddOrchestrator --> OrchestratorSkills["skills/ (00-async-dev, 01-sdlc, 02-backlog)"]
+    Root["framework/"] --> Plugins["plugins/"]
+    Root --> Cli["cli/"]
+    Root --> Kanban["kanban/"]
+    Root --> Scripts["scripts/"]
+    Root --> Docs["docs/"]
+    Root --> AiddDocs["aidd_docs/"]
+    Root --> Manifest[".claude-plugin/"]
+    Root --> GH[".github/"]
 ```
+
+## Areas
+
+- `plugins/`: the product. One directory per plugin, each holding `skills/`, and optionally `agents/`, `commands/`, `hooks/` and `rules/`. The anatomy is in [`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md).
+- `cli/`: the `aidd` binary, TypeScript, layered `domain/` · `application/` · `infrastructure/`.
+- `kanban/`: the task board, same layering plus `presentation/`. Bundled into the CLI from source, never published on its own.
+- `scripts/`: the repository's own checks and generators, run by lefthook and CI. Their tests live in `scripts/__tests__/`.
+- `docs/`: the durable documentation a contributor reads — architecture, plugin authoring, glossary, maintainer runbook.
+- `aidd_docs/`: this memory bank, plus the task documents (plans, specs, reviews) that `aidd kanban` reads.
+- `.claude-plugin/`: `marketplace.json`, the version manifest listing every plugin.
+- `.github/`: workflows, issue templates and rulesets.
+
+## Entry points
+
+- `cli/src/cli.ts`: the binary's entry, published as `dist/cli.js` under the `aidd` bin name.
+- `plugins/<plugin>/skills/<NN>-<name>/SKILL.md`: where an AI tool enters a workflow.
+- `plugins/aidd-context/hooks/update_memory.js`: runs on `SessionStart` to refresh the memory block in each AI context file.
+
+## Packages
+
+- `cli` (`@ai-driven-dev/cli`): published to npm, the only released package.
+- `kanban`: private, compiled into the CLI. It depends on npm packages only, never on `cli/`.

--- a/aidd_docs/memory/codebase-map.md
+++ b/aidd_docs/memory/codebase-map.md
@@ -2,6 +2,8 @@
 
 The macro layout: the top-level areas and what each holds. A map to navigate, not the full tree.
 
+> Where things live inside the CLI is in [`cli/aidd_docs/memory/codebase-map.md`](../../cli/aidd_docs/memory/codebase-map.md).
+
 ```mermaid
 flowchart TD
     Root["framework/"] --> Plugins["plugins/"]
@@ -16,22 +18,28 @@ flowchart TD
 
 ## Areas
 
-- `plugins/`: the product. One directory per plugin, each holding `skills/`, and optionally `agents/`, `commands/`, `hooks/` and `rules/`. The anatomy is in [`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md).
-- `cli/`: the `aidd` binary, TypeScript, layered `domain/` · `application/` · `infrastructure/`.
-- `kanban/`: the task board, same layering plus `presentation/`. Bundled into the CLI from source, never published on its own.
-- `scripts/`: the repository's own checks and generators, run by lefthook and CI. Their tests live in `scripts/__tests__/`.
-- `docs/`: the durable documentation a contributor reads — architecture, plugin authoring, glossary, maintainer runbook.
-- `aidd_docs/`: this memory bank, plus the task documents (plans, specs, reviews) that `aidd kanban` reads.
-- `.claude-plugin/`: `marketplace.json`, the version manifest listing every plugin.
-- `.github/`: workflows, issue templates and rulesets.
+| Path | Holds |
+| --- | --- |
+| `plugins/` | the product — one dir per plugin, each with `skills/`, optionally `agents/`, `commands/`, `hooks/`, `rules/` |
+| `cli/` | the `aidd` binary. Has its own memory bank and `CLAUDE.md` |
+| `kanban/` | the task board, bundled into the CLI, never published alone |
+| `scripts/` | repository checks and generators, run by lefthook and CI. Tests in `scripts/__tests__/` |
+| `docs/` | durable docs — architecture, plugin authoring, glossary, maintainer runbook |
+| `aidd_docs/` | this memory bank, plus task documents read by `aidd kanban` |
+| `.claude-plugin/` | `marketplace.json`, the version manifest |
+| `.github/` | workflows, issue templates, rulesets |
 
 ## Entry points
 
-- `cli/src/cli.ts`: the binary's entry, published as `dist/cli.js` under the `aidd` bin name.
-- `plugins/<plugin>/skills/<NN>-<name>/SKILL.md`: where an AI tool enters a workflow.
-- `plugins/aidd-context/hooks/update_memory.js`: runs on `SessionStart` to refresh the memory block in each AI context file.
+| Entry | Path |
+| --- | --- |
+| Binary | `cli/src/cli.ts` → `dist/cli.js`, bin name `aidd` |
+| Workflow | `plugins/<plugin>/skills/<NN>-<name>/SKILL.md` |
+| Memory refresh | `plugins/aidd-context/hooks/update_memory.js`, on `SessionStart` |
 
 ## Packages
 
-- `cli` (`@ai-driven-dev/cli`): published to npm, the only released package.
-- `kanban`: private, compiled into the CLI. It depends on npm packages only, never on `cli/`.
+| Package | Released |
+| --- | --- |
+| `cli` (`@ai-driven-dev/cli`) | npm, the only published package |
+| `kanban` | private, compiled into the CLI. Depends on npm packages only, never on `cli/` |

--- a/aidd_docs/memory/coding-assertions.md
+++ b/aidd_docs/memory/coding-assertions.md
@@ -2,25 +2,23 @@
 
 The checks that must pass for code to count as done. Minimal, run after every change.
 
-## Before commit
+> CLI-specific completion criteria: [`cli/aidd_docs/memory/coding-assertions.md`](../../cli/aidd_docs/memory/coding-assertions.md).
 
-The fast gate, wired in `lefthook.yml`.
+## Before commit
 
 | Order | Command | Checks |
 | ----- | ------- | ------ |
-| 1 | `pnpm exec lefthook run pre-commit` | JSON and YAML validity, skill frontmatter and argument hints, context imports, markdown links, `scripts/` tests, then `cli lint` and `cli typecheck` when `cli/` or `kanban/` changed |
-| 2 | `pnpm exec commitlint --edit` | The commit message against `commitlint.config.cjs` |
+| 1 | `pnpm exec lefthook run pre-commit` | JSON and YAML validity, skill frontmatter and argument hints, context imports, markdown links, `scripts/` tests; `cli lint` and `cli typecheck` when `cli/` or `kanban/` changed |
+| 2 | `pnpm exec commitlint --edit` | the message against `commitlint.config.cjs` |
 
-The same hook also regenerates each plugin's `CATALOG.md` and the README counts, and stages them.
+Same hook regenerates each plugin's `CATALOG.md` and the README counts, and stages them.
 
 ## Before push
 
-The heavier gate.
-
 | Order | Command | Checks |
 | ----- | ------- | ------ |
-| 1 | `pnpm exec lefthook run pre-push` | `cli knip:production` then the full `cli` suite, when `cli/` changed |
+| 1 | `pnpm exec lefthook run pre-push` | `cli knip:production`, then the full `cli` suite, when `cli/` changed |
 
 ## Behavior
 
-A feature is done only when every gate above is green. If a fix is needed, spawn one agent per failing assertion (typecheck, tests, rules violated on a category) rather than one agent for all of them.
+Done means every gate green. On failure, one agent per failing assertion — typecheck, tests, rules — not one agent for all.

--- a/aidd_docs/memory/coding-assertions.md
+++ b/aidd_docs/memory/coding-assertions.md
@@ -1,21 +1,26 @@
-# Coding Guidelines
+# Coding Assertions
 
-> Those rules must be minimal because they MUST be checked after EVERY CODE GENERATION.
+The checks that must pass for code to count as done. Minimal, run after every change.
 
-## Requirements to complete a feature
+## Before commit
 
-**A feature is really completed if ALL of the above are satisfied: if not, iterate to fix all until all are green.**
+The fast gate, wired in `lefthook.yml`.
 
-## Commands to run
+| Order | Command | Checks |
+| ----- | ------- | ------ |
+| 1 | `pnpm exec lefthook run pre-commit` | JSON and YAML validity, skill frontmatter and argument hints, context imports, markdown links, `scripts/` tests, then `cli lint` and `cli typecheck` when `cli/` or `kanban/` changed |
+| 2 | `pnpm exec commitlint --edit` | The commit message against `commitlint.config.cjs` |
 
-### Before commit
+The same hook also regenerates each plugin's `CATALOG.md` and the README counts, and stages them.
 
-| Order | Command | Description |
-| ----- | ------- | ----------- |
-| 1 | `pnpm exec commitlint --edit` | Validate commit message against conventional commit spec |
+## Before push
 
-### Before push
+The heavier gate.
 
-| Order | Command | Description |
-| ----- | ------- | ----------- |
-| 1 | `pnpm exec lefthook run pre-push` | Run parent repo hooks (delegates to parent lefthook.yml) |
+| Order | Command | Checks |
+| ----- | ------- | ------ |
+| 1 | `pnpm exec lefthook run pre-push` | `cli knip:production` then the full `cli` suite, when `cli/` changed |
+
+## Behavior
+
+A feature is done only when every gate above is green. If a fix is needed, spawn one agent per failing assertion (typecheck, tests, rules violated on a category) rather than one agent for all of them.

--- a/aidd_docs/memory/deployment.md
+++ b/aidd_docs/memory/deployment.md
@@ -1,41 +1,53 @@
 # Deployment
 
-## CI/CD Pipeline
+Where the project runs and how it ships: CI/CD, environments, and release.
 
-### GitHub Actions (`ci.yml`)
+## Pipeline
 
-- **Steps**:
-  1. `commitlint`: validate commit messages on PRs (skipped for release-please branches)
-  2. `release-please`: auto-create release PRs and GitHub releases on push to `main`
-  3. `build-and-attach`: run only on release; builds plugin dist archives and attaches them to the GitHub release
+| Workflow | Runs |
+| --- | --- |
+| `ci.yml` | commitlint on PRs, release-please on `main`, then the release jobs below |
+| `cli-ci.yml` | typecheck, lint, test, build with its bundle budget, and knip on `cli/` |
+| `validate.yml` | the plugin and marketplace manifests against their schemas |
+| `codeql.yml` | code scanning |
+| `promote.yml` | opens the `next` to `main` promote PR and merge auto-merges it |
+| `back-merge.yml` | brings `main` back into `next` after each release |
+| `dependabot-auto-merge.yml` | merges dependency PRs that pass |
+| `close-finished-milestones.yml` | closes a milestone once its issues are |
 
-- **Deployment Triggers**:
-  - Automated: push to `main` triggers release-please; release creation triggers build-and-attach
-  - Manual: none
-
-## Deployment Process
-
-- **Release steps**:
-  1. Merge PR to `main` with conventional commits
-  2. `release-please` opens a release PR bumping versions in `marketplace.json` and per-plugin `plugin.json`
-  3. Merging the release PR triggers `build-and-attach`
-  4. `scripts/build-dist.sh` builds per-plugin distribution archives
-  5. Archives and source tarball attached to the GitHub release asset
-
-## Infrastructure
-
-## Project Structure
-
-```plaintext
-framework/
-  plugins/         ← plugin source (one dir per plugin)
-  scripts/         ← build-dist.sh, aidd.sh
-  .claude-plugin/  ← marketplace.json (version manifest)
-  .github/
-    workflows/     ← ci.yml, add-to-project.yml
+```mermaid
+flowchart LR
+    Promote["promote.yml · next to main"] --> Push["push on main"]
+    Push --> RP["release-please · Release PR"]
+    RP --> Release["release published · tags"]
+    Release --> Build["build & publish jobs"]
+    Release --> Back["back-merge.yml · main to next"]
 ```
 
-## URLs
+Triggered automatically by a push to `main`; `promote.yml` is the only manual entry, to send `next` to `main` outside the weekly cadence.
 
-- **Repository**: https://github.com/ai-driven-dev/aidd (monorepo, `framework/` subdirectory)
-- **Package registry**: https://npm.pkg.github.com/@ai-driven-dev/cli
+## Environments
+
+None. No server, no container, no infrastructure as code: what ships are release assets and published packages.
+
+- Repository: <https://github.com/ai-driven-dev/framework>
+- npm: `@ai-driven-dev/cli`, published through OIDC trusted publishing, no token.
+- GitHub Packages and GitHub Releases for the archives.
+
+## Release
+
+The branch model is in `vcs.md`, the cadence and the two safety rules in [`RELEASE.md`](../../RELEASE.md). What happens on a release:
+
+1. release-please opens the Release PR, bumping `marketplace.json` and each `plugin.json`. CI auto-merges it with the bot App token, so `main` never holds merged but unversioned code.
+2. Merging it creates the release and its tags. Versioning is per plugin, `include-component-in-tag: true`, tags shaped `<plugin>-v<semver>`.
+3. The release triggers the build jobs: `build-and-attach` (a clean marketplace bundle), `build-per-tool` (nine target-native distributions, each built by the CLI at a **pinned** version so a CLI release never silently changes the output), `build-plugin` (one archive per released plugin path), and `publish-cli`.
+4. Every archive is staged outside the repo tree and uploaded with `gh release upload --clobber`.
+5. `back-merge.yml` folds `main` back into `next` so the changelog, manifest and versions do not drift.
+
+`kanban/`'s dependencies install before any `cli` job, since the CLI bundles that folder from source.
+
+Config: `release-please-config.json`, manifest: `.release-please-manifest.json`.
+
+## Monitoring
+
+None. Failures surface as a red workflow run; `back-merge.yml` opens a tracking issue when it cannot push, so a drift is never silent.

--- a/aidd_docs/memory/deployment.md
+++ b/aidd_docs/memory/deployment.md
@@ -2,52 +2,54 @@
 
 Where the project runs and how it ships: CI/CD, environments, and release.
 
+> CLI build, publish and self-update detail: [`cli/aidd_docs/memory/deployment.md`](../../cli/aidd_docs/memory/deployment.md).
+
 ## Pipeline
 
 | Workflow | Runs |
 | --- | --- |
-| `ci.yml` | commitlint on PRs, release-please on `main`, then the release jobs below |
-| `cli-ci.yml` | typecheck, lint, test, build with its bundle budget, and knip on `cli/` |
-| `validate.yml` | the plugin and marketplace manifests against their schemas |
+| `ci.yml` | commitlint on PRs, release-please on `main`, then the release jobs |
+| `cli-ci.yml` | typecheck, lint, test, build with its bundle budget, knip on `cli/` |
+| `validate.yml` | plugin and marketplace manifests against their schemas |
 | `codeql.yml` | code scanning |
-| `promote.yml` | opens the `next` to `main` promote PR and merge auto-merges it |
-| `back-merge.yml` | brings `main` back into `next` after each release |
+| `promote.yml` | opens the `next` to `main` promote PR, merge auto-merge |
+| `back-merge.yml` | folds `main` back into `next` after each release |
 | `dependabot-auto-merge.yml` | merges dependency PRs that pass |
 | `close-finished-milestones.yml` | closes a milestone once its issues are |
 
 ```mermaid
 flowchart LR
-    Promote["promote.yml · next to main"] --> Push["push on main"]
-    Push --> RP["release-please · Release PR"]
-    RP --> Release["release published · tags"]
-    Release --> Build["build & publish jobs"]
-    Release --> Back["back-merge.yml · main to next"]
+    Promote["promote.yml"] --> Push["push on main"]
+    Push --> RP["release-please PR"]
+    RP --> Release["release + tags"]
+    Release --> Build["build & publish"]
+    Release --> Back["back-merge.yml"]
 ```
 
-Triggered automatically by a push to `main`; `promote.yml` is the only manual entry, to send `next` to `main` outside the weekly cadence.
+Automatic on a push to `main`. `promote.yml` is the only manual entry.
 
 ## Environments
 
-None. No server, no container, no infrastructure as code: what ships are release assets and published packages.
+None — no server, no container, no IaC. What ships are release assets and published packages.
 
-- Repository: <https://github.com/ai-driven-dev/framework>
-- npm: `@ai-driven-dev/cli`, published through OIDC trusted publishing, no token.
-- GitHub Packages and GitHub Releases for the archives.
+| Target | Where |
+| --- | --- |
+| Repository | <https://github.com/ai-driven-dev/framework> |
+| npm | `@ai-driven-dev/cli`, OIDC trusted publishing, no token |
+| Archives | GitHub Releases and GitHub Packages |
 
 ## Release
 
-The branch model is in `vcs.md`, the cadence and the two safety rules in [`RELEASE.md`](../../RELEASE.md). What happens on a release:
+Branch model in `vcs.md`, cadence and safety rules in [`RELEASE.md`](../../RELEASE.md).
 
-1. release-please opens the Release PR, bumping `marketplace.json` and each `plugin.json`. CI auto-merges it with the bot App token, so `main` never holds merged but unversioned code.
-2. Merging it creates the release and its tags. Versioning is per plugin, `include-component-in-tag: true`, tags shaped `<plugin>-v<semver>`.
-3. The release triggers the build jobs: `build-and-attach` (a clean marketplace bundle), `build-per-tool` (nine target-native distributions, each built by the CLI at a **pinned** version so a CLI release never silently changes the output), `build-plugin` (one archive per released plugin path), and `publish-cli`.
-4. Every archive is staged outside the repo tree and uploaded with `gh release upload --clobber`.
-5. `back-merge.yml` folds `main` back into `next` so the changelog, manifest and versions do not drift.
+1. release-please opens the Release PR, bumping `marketplace.json` and each `plugin.json`. CI auto-merges it, so `main` never holds merged but unversioned code.
+2. Merging creates the release and its tags — per plugin, `include-component-in-tag: true`, shaped `<plugin>-v<semver>`.
+3. Release jobs: `build-and-attach` (marketplace bundle), `build-per-tool` (nine distributions, CLI at a **pinned** version), `build-plugin` (one archive per released path), `publish-cli`.
+4. Archives are staged outside the repo tree, uploaded with `gh release upload --clobber`.
+5. `back-merge.yml` folds `main` into `next`.
 
-`kanban/`'s dependencies install before any `cli` job, since the CLI bundles that folder from source.
-
-Config: `release-please-config.json`, manifest: `.release-please-manifest.json`.
+Config: `release-please-config.json`. Manifest: `.release-please-manifest.json`.
 
 ## Monitoring
 
-None. Failures surface as a red workflow run; `back-merge.yml` opens a tracking issue when it cannot push, so a drift is never silent.
+None. Failures surface as a red run; `back-merge.yml` opens a tracking issue when it cannot push, so drift is never silent.

--- a/aidd_docs/memory/project-brief.md
+++ b/aidd_docs/memory/project-brief.md
@@ -5,34 +5,36 @@ What this project is, the problem it solves, and its domain language. The non-de
 ## What it is
 
 - A plugin marketplace that installs structured SDLC workflows into AI coding tools — Claude Code, Cursor, GitHub Copilot, Codex, opencode — plus the `aidd` binary that installs them.
-- For developers who already work with an AI assistant daily and want its output to be repeatable rather than improvised.
+- For developers already working with an AI assistant daily, who want its output repeatable rather than improvised.
 
 ## Why it exists
 
-- An AI assistant rediscovers a project on every session and improvises its process each time. The framework gives it durable project memory and a fixed set of workflows, so the same request produces comparable work twice.
-- The workflows are tool-agnostic markdown. Writing them once and translating them per tool avoids maintaining a separate prompt library for each assistant.
+- An assistant rediscovers the project every session and improvises its process. Durable memory plus fixed workflows make the same request produce comparable work twice.
+- Workflows are tool-agnostic markdown: written once, translated per tool, instead of one prompt library per assistant.
 
 ## Domain language
 
 | Term | Meaning |
 | ---- | ------- |
-| Plugin | An installable package grouping skills around one concern, listed in `marketplace.json` |
-| Skill | A router: a `SKILL.md` that dispatches a user request to its actions |
-| Action | One atomic step inside a skill, with its own inputs, outputs, process and test |
-| Agent | An isolated executor; runs in its own context and returns only a result |
-| Rule | A coding standard injected into the tool's context automatically |
-| Memory | The bank under `aidd_docs/memory/`, loaded at the start of every session |
-| Marketplace | `.claude-plugin/marketplace.json`, the registry listing every plugin and its version |
-| Concern | What a plugin owns; it decides where a capability lives |
-| Promote | Sending `next` to `main`, which opens the release |
+| Plugin | installable package grouping skills around one concern, listed in `marketplace.json` |
+| Skill | a router: `SKILL.md` dispatching a request to its actions |
+| Action | one atomic step, with its own inputs, outputs, process and test |
+| Agent | isolated executor; own context, returns only a result |
+| Rule | coding standard injected into the tool's context automatically |
+| Memory | the bank under `aidd_docs/memory/`, loaded every session |
+| Marketplace | `.claude-plugin/marketplace.json`, the plugin and version registry |
+| Concern | what a plugin owns; decides where a capability lives |
+| Promote | sending `next` to `main`, which opens the release |
 
 ## Key features
 
-- Install and update plugins per AI tool (`aidd plugin add`, `aidd ai`, `aidd ide`).
-- Build a target-native distribution of the repository for one tool (`aidd framework build`).
-- Bootstrap and refresh a project's memory bank, and wire it into every AI context file.
-- Generate context artifacts: skills, rules, agents, commands, hooks, Mermaid diagrams.
-- Run the development loop as workflows: plan, implement, assert, audit, review, test, refactor, debug.
-- Manage a typed product backlog — briefs, epics, stories, specs, spikes, defects.
-- Orchestrate a request end to end, from framing to a draft pull request.
-- Render task documents as a board (`aidd kanban`).
+| Capability | Entry |
+| --- | --- |
+| Install and update plugins per tool | `aidd plugin add`, `aidd ai`, `aidd ide` |
+| Build a target-native distribution | `aidd framework build` |
+| Bootstrap and refresh project memory | `aidd-context:02-project-memory` |
+| Generate context artifacts | `aidd-context:03-context-generate` and its per-kind generators |
+| Development loop | `aidd-dev` — plan, implement, assert, audit, review, test, refactor, debug |
+| Typed product backlog | `aidd-pm` — brief, epic, story, spec, spike, defect |
+| End-to-end orchestration | `aidd-orchestrator:01-sdlc` |
+| Task board | `aidd kanban` |

--- a/aidd_docs/memory/project-brief.md
+++ b/aidd_docs/memory/project-brief.md
@@ -1,61 +1,38 @@
 # Project Brief
 
-## Executive Summary
+What this project is, the problem it solves, and its domain language. The non-derivable "why", not the "how".
 
-- **Project Name**: AIDD Framework (AI-Driven Dev Framework)
-- **Vision**: Universal plugin marketplace for AI coding assistants
-- **Mission**: Provide structured, reusable skill sets that make AI assistants follow repeatable, high-quality development workflows
+## What it is
 
-### Full Description
+- A plugin marketplace that installs structured SDLC workflows into AI coding tools — Claude Code, Cursor, GitHub Copilot, Codex, opencode — plus the `aidd` binary that installs them.
+- For developers who already work with an AI assistant daily and want its output to be repeatable rather than improvised.
 
-AIDD Framework is a plugin system that installs focused skill sets into AI coding tools (Claude Code, Cursor, GitHub Copilot, Codex, OpenCode). Plugins deliver SDLC workflows — from brainstorming to PR creation — as slash-command-driven skills backed by structured markdown actions.
+## Why it exists
 
-## Context
+- An AI assistant rediscovers a project on every session and improvises its process each time. The framework gives it durable project memory and a fixed set of workflows, so the same request produces comparable work twice.
+- The workflows are tool-agnostic markdown. Writing them once and translating them per tool avoids maintaining a separate prompt library for each assistant.
 
-### Core Domain
+## Domain language
 
-AI-assisted software development tooling. The framework ships workflows, not code. Every artifact is a markdown file (skill, agent, rule, memory template) interpreted by an LLM at runtime.
+| Term | Meaning |
+| ---- | ------- |
+| Plugin | An installable package grouping skills around one concern, listed in `marketplace.json` |
+| Skill | A router: a `SKILL.md` that dispatches a user request to its actions |
+| Action | One atomic step inside a skill, with its own inputs, outputs, process and test |
+| Agent | An isolated executor; runs in its own context and returns only a result |
+| Rule | A coding standard injected into the tool's context automatically |
+| Memory | The bank under `aidd_docs/memory/`, loaded at the start of every session |
+| Marketplace | `.claude-plugin/marketplace.json`, the registry listing every plugin and its version |
+| Concern | What a plugin owns; it decides where a capability lives |
+| Promote | Sending `next` to `main`, which opens the release |
 
-### Ubiquitous Language
+## Key features
 
-| Term | Definition | Synonyms |
-| --- | --- | --- |
-| Plugin | Installable package grouping related skills | package |
-| Skill | Router-based workflow triggered by user phrase or slash command | command |
-| Action | Single step inside a skill, containing inputs/outputs/process/test | step |
-| Agent | Specialized AI persona for a focused sub-task | subagent |
-| Rule | Coding standard injected into LLM context automatically | guardrail |
-| Memory | Structured context file loaded at conversation start | context file |
-| SDLC | Software Development Life Cycle — the end-to-end pipeline from idea to deployed PR | |
-| Marketplace | Central registry listing available plugins with version metadata | |
-
-## Features & Use-cases
-
-- Install plugins per AI tool with `aidd plugin add <plugin> --tool <tool>`
-- Execute skills via slash commands (`/sdlc`, `/commit`, `/plan`, etc.)
-- Bootstrap project memory bank and context files with `aidd-context:02-project-memory`
-- Sync memory references across all AI context files automatically
-- Generate plans, assertions, reviews, and PRs through structured action chains
-- Run async development pipelines via `aidd-orchestrator`
-
-## User Journey maps
-
-```mermaid
-journey
-    title Developer using AIDD on a new feature
-    section Setup
-        Install plugin: 5: Developer
-        Run project init: 5: Developer
-    section Feature loop
-        Brainstorm request: 4: Developer
-        Generate plan: 5: AIDD
-        Implement code: 5: AIDD
-        Review code: 4: AIDD
-        Commit and PR: 5: AIDD
-```
-
-### Developer
-
-- Uses an AI coding assistant daily
-- Wants predictable, structured AI workflows
-- Needs memory of project context across sessions
+- Install and update plugins per AI tool (`aidd plugin add`, `aidd ai`, `aidd ide`).
+- Build a target-native distribution of the repository for one tool (`aidd framework build`).
+- Bootstrap and refresh a project's memory bank, and wire it into every AI context file.
+- Generate context artifacts: skills, rules, agents, commands, hooks, Mermaid diagrams.
+- Run the development loop as workflows: plan, implement, assert, audit, review, test, refactor, debug.
+- Manage a typed product backlog — briefs, epics, stories, specs, spikes, defects.
+- Orchestrate a request end to end, from framing to a draft pull request.
+- Render task documents as a board (`aidd kanban`).

--- a/aidd_docs/memory/testing.md
+++ b/aidd_docs/memory/testing.md
@@ -2,30 +2,46 @@
 
 How the project is tested: the layers, the tools, and the conventions. Where tests live and how to run them.
 
+> CLI internals (tiers, fixtures, naming, mocking) live in [`cli/aidd_docs/memory/testing.md`](../../cli/aidd_docs/memory/testing.md). This page is the repository-wide view.
+
 ## Strategy
 
-- `cli/vitest.workspace.ts` splits three projects: `unit`, `integration`, `e2e`. Each has its own script; `pnpm test` builds first, then runs all three.
-- Golden snapshots under `cli/tests/golden/` freeze the per-tool distribution output. The nine-cell `build-per-tool` matrix in `ci.yml` mirrors them, so a drift shows in both.
-- The markdown surface — skills, agents, rules — has no runner. An action is validated by its own `## Test` section, run end to end against a real project.
-- `scripts/` and the bundled hooks are covered by `node --test` in `scripts/__tests__/`, gated on every commit that touches them.
+| Surface | Validated by |
+| --- | --- |
+| Skills, agents, rules (markdown) | each action's own `## Test`, run end to end against a real project |
+| `scripts/` and bundled hooks | `node --test scripts/__tests__/*.test.js` |
+| `cli/` and `kanban/` | vitest, three tiers — see the CLI bank |
+| Per-tool distributions | golden snapshots in `cli/tests/golden/`, mirrored by the `build-per-tool` CI matrix |
+| Browser journeys | `aidd-dev:11-browser-qa`, see below |
 
 ## Tools
 
-- **vitest** in `cli/` and `kanban/`, with `@vitest/coverage-v8`.
-- **fast-check** for property-based cases, **ink-testing-library** for the terminal views.
-- **stryker** (`cli/stryker.conf.json`) for mutation testing, run on demand, never in CI.
-- **knip** for dead code, gated before push and in `cli-ci.yml`.
+| Tool | Use |
+| --- | --- |
+| vitest | `cli/`, `kanban/` |
+| fast-check | property-based cases |
+| ink-testing-library | terminal views |
+| stryker | mutation, on demand, never in CI |
+| knip | dead code, before push and in `cli-ci.yml` |
+| `@playwright/cli` | browser QA evidence, pinned, never an app dependency |
 
 ## Conventions
 
-- Tests live under `cli/tests/`, mirroring the source layers: `domain/`, `application/`, `infrastructure/`, plus `e2e/`, `golden/`, `fixtures/` and `helpers/`.
-- The filesystem and the network arrive through the adapters in `infrastructure/`, so a test substitutes an adapter rather than mocking a module. `vi.mock` is kept for the few adapters that wrap a process or a network call directly.
-- `cli/tests/fixtures/` is excluded from the repository's JSON and link checks, since it holds deliberately invalid inputs.
-- A plugin never holds its own tests: `hooks/` ships recursively into user projects.
+- A plugin never holds its own tests: `hooks/` ships recursively into user projects. Tests for a bundled script go in `scripts/__tests__/`.
+- `cli/tests/fixtures/` is excluded from the JSON and link checks; it holds deliberately invalid inputs.
+- Adapters are substituted, not mocked, wherever the seam exists.
 
 ## Run
 
-- `cd cli && pnpm test`: builds, then runs every project. `test:unit`, `test:integration`, `test:e2e` narrow it; `test:kanban` runs the kanban suite.
-- `cd cli && pnpm smoke`: builds and runs `scripts/smoke-tools.sh` against the binary.
-- `node --test 'scripts/__tests__/*.test.js'`: the repository's own scripts and hooks.
-- `pnpm exec lefthook run pre-push`: what CI will run, before you push.
+| Command | Scope |
+| --- | --- |
+| `node --test 'scripts/__tests__/*.test.js'` | repository scripts and hooks |
+| `cd cli && pnpm test` | build, then all three CLI tiers |
+| `cd cli && pnpm smoke` | built binary against `scripts/smoke-tools.sh` |
+| `pnpm exec lefthook run pre-push` | what CI runs |
+
+## Browser QA
+
+- Runner: `npx --yes @playwright/cli@0.1.17`, the framework pin. Never `latest` during QA.
+- Also required: `ffmpeg` and `ffprobe`. Output is WebM evidence per scenario.
+- Owned by `aidd-dev:11-browser-qa`; this repository ships the capability, it has no browser journey of its own.

--- a/aidd_docs/memory/testing.md
+++ b/aidd_docs/memory/testing.md
@@ -1,20 +1,31 @@
-# Testing Guidelines
+# Testing
 
-## Tools and Frameworks
+How the project is tested: the layers, the tools, and the conventions. Where tests live and how to run them.
 
-- **Playwright MCP**: browser automation available via `.playwright-mcp/` config, used for manual or AI-driven UI testing on downstream projects
+## Strategy
 
-## Testing Strategy
+- `cli/vitest.workspace.ts` splits three projects: `unit`, `integration`, `e2e`. Each has its own script; `pnpm test` builds first, then runs all three.
+- Golden snapshots under `cli/tests/golden/` freeze the per-tool distribution output. The nine-cell `build-per-tool` matrix in `ci.yml` mirrors them, so a drift shows in both.
+- The markdown surface — skills, agents, rules — has no runner. An action is validated by its own `## Test` section, run end to end against a real project.
+- `scripts/` and the bundled hooks are covered by `node --test` in `scripts/__tests__/`, gated on every commit that touches them.
 
-- No unit test runner configured at framework level
-- Skills are validated by running each action's `## Test` end-to-end against a real environment
-- Framework correctness validated by running actual skills against a real project (integration)
+## Tools
 
-## Test Execution Process
+- **vitest** in `cli/` and `kanban/`, with `@vitest/coverage-v8`.
+- **fast-check** for property-based cases, **ink-testing-library** for the terminal views.
+- **stryker** (`cli/stryker.conf.json`) for mutation testing, run on demand, never in CI.
+- **knip** for dead code, gated before push and in `cli-ci.yml`.
 
-- Each action declares a `## Test` (a command to run, an artifact check, or an observable side-effect) that must pass before the next action runs
-- `scripts/build-dist-verification.md` documents how to verify the build output
+## Conventions
 
-## Mocking and Stubbing
+- Tests live under `cli/tests/`, mirroring the source layers: `domain/`, `application/`, `infrastructure/`, plus `e2e/`, `golden/`, `fixtures/` and `helpers/`.
+- The filesystem and the network arrive through the adapters in `infrastructure/`, so a test substitutes an adapter rather than mocking a module. `vi.mock` is kept for the few adapters that wrap a process or a network call directly.
+- `cli/tests/fixtures/` is excluded from the repository's JSON and link checks, since it holds deliberately invalid inputs.
+- A plugin never holds its own tests: `hooks/` ships recursively into user projects.
 
-Not applicable: the framework has no runtime; all logic is markdown interpreted by an LLM.
+## Run
+
+- `cd cli && pnpm test`: builds, then runs every project. `test:unit`, `test:integration`, `test:e2e` narrow it; `test:kanban` runs the kanban suite.
+- `cd cli && pnpm smoke`: builds and runs `scripts/smoke-tools.sh` against the binary.
+- `node --test 'scripts/__tests__/*.test.js'`: the repository's own scripts and hooks.
+- `pnpm exec lefthook run pre-push`: what CI will run, before you push.

--- a/aidd_docs/memory/vcs.md
+++ b/aidd_docs/memory/vcs.md
@@ -2,6 +2,8 @@
 
 The version-control conventions this project follows: branches, commits, and the platform.
 
+> CLI-specific notes: [`cli/aidd_docs/memory/vcs.md`](../../cli/aidd_docs/memory/vcs.md).
+
 ## Setup
 
 - Production branch: `main`. Integration branch: `next`, the default target for day-to-day work.

--- a/aidd_docs/memory/vcs.md
+++ b/aidd_docs/memory/vcs.md
@@ -1,136 +1,41 @@
-# Versioning Control System (VCS) Guidelines
+# VCS
 
-- Production branch: `main`
-- Integration branch: `next` (default target for day-to-day work)
-- Platform: `github`
-- CLI: `gh`
-- Ticketing Tool: GitHub Issues
-- Pull request Template : `.github/PULL_REQUEST_TEMPLATE.md`
+The version-control conventions this project follows: branches, commits, and the platform.
 
-## Branch Naming Convention
+## Setup
 
-### Format
+- Production branch: `main`. Integration branch: `next`, the default target for day-to-day work.
+- Platform: GitHub, driven through `gh`. Tickets are GitHub Issues.
+- Pull request template: `.github/PULL_REQUEST_TEMPLATE.md`.
+- The release model — weekly promotion, hotfix path — is in [`RELEASE.md`](../../RELEASE.md); the tooling behind it is in `deployment.md`.
 
-```text
-type/ticket-short-description
-```
+## Branches
 
-### Types
-
-The single source of truth: find your row, read left to right — it tells you the
-branch to create, the issue type that applies, and where the PR goes. The branch
-**prefix** alone decides the target (not a type, not a board field); the
-`aidd-vcs:02-pull-request` skill reads this table to set the base automatically.
+- Format: `type/short-description`.
+- The **prefix alone decides the PR target**, not an issue type and not a board field. `aidd-vcs:02-pull-request` reads this table to set the base automatically.
 
 | I want to… | Issue template | Branch | Commit | Issue type | PR targets |
 | ---------- | -------------- | ------ | ------ | ---------- | ---------- |
-| ship a feature | ✨ Feature | `feat/…` | `feat:` | `Feature` | `next` |
-| fix a bug | 🐛 Bug | `fix/…` | `fix:` | `Bug` | `next` |
-| change docs only | 🗺️ Roadmap | `docs/…` | `docs:` | `Task` | `next` |
-| refactor (no behaviour change) | 🗺️ Roadmap | `refactor/…` | `refactor:` | `Task` | `next` |
-| build / config / deps | 🗺️ Roadmap | `chore/…` | `chore:` | `Task` | `next` |
-| add or update tests | 🗺️ Roadmap | `test/…` | `test:` | `Task` | `next` |
-| 🚨 urgent production fix | 🐛 Bug | `hotfix/…` | `fix:` | `Bug` | **`main`** |
+| ship a feature | 🌱 Quick Contribution | `feat/…` | `feat:` | `Feature` | `next` |
+| fix a bug | 🐛 Bug Report | `fix/…` | `fix:` | `Bug` | `next` |
+| change docs only | 📋 Detailed Contribution | `docs/…` | `docs:` | `Task` | `next` |
+| refactor (no behaviour change) | 📋 Detailed Contribution | `refactor/…` | `refactor:` | `Task` | `next` |
+| build / config / deps | 📋 Detailed Contribution | `chore/…` | `chore:` | `Task` | `next` |
+| add or update tests | 📋 Detailed Contribution | `test/…` | `test:` | `Task` | `next` |
+| 🚨 urgent production fix | 🐛 Bug Report | `hotfix/…` | `fix:` | `Bug` | **`main`** |
 
-#### Routing rule (strict)
+- Everything batches on `next` and ships in the weekly release. **Only `hotfix/*` targets `main`.**
+- The issue type categorizes, it never routes, and the form stamps it — never set it by hand. Labels exist only where a bot or a human reads one (`.github/labels.yml`).
+- The board does not advance on its own: `Todo → In review → Done` is moved by hand, by a human or an agent through `gh`. Board conventions are in `backlog.md`.
 
-- Everything batches on `next` and ships in the weekly release.
-- **Only `hotfix/*` targets `main`** — an urgent production fix, out of cycle.
+## Commits
 
-Once the PR is open, the board advances on its own:
-`Todo → In review` (PR opened) `→ Done` (merged).
+- Convention: [Conventional Commits](https://www.conventionalcommits.org/), enforced by `commitlint.config.cjs`. **Read that file before composing a message; if this page and the config disagree, the config wins.**
+- Format: `type(scope): description`, description in the imperative, lowercase, no trailing period, 72 characters max.
+- Scope is optional and must be kebab-case. The encouraged list lives in `scope-enum` at warning level, so an unknown scope warns without blocking. Introduce a new one only when none fits.
+- `framework` and `marketplace` are the scopes that bump `marketplace.json` through release-please.
+- A breaking change goes in the footer as `BREAKING CHANGE: …`.
 
-The **issue type** categorizes; it never routes. The form stamps it, so you
-never set it by hand. Labels categorize nothing here: one exists only when a bot
-or a human reads it (`.github/labels.yml`). The "Commit" column shows the
-conventional type; the authoritative type list is the
-[Commit Convention](#commit-convention) below (mirrors `commitlint.config.cjs`).
+## Commit Strategy
 
-### Examples
-
-```text
-feat/plugin-architecture
-fix/orchestrator-sdlc-push
-docs/update-api-examples
-chore/release-please-config
-```
-
-`next` is the day-to-day branch: branch from it, target it. `main` is production and only takes promotions from `next` plus `hotfix/*`. The release flow is in [`RELEASE.md`](../../RELEASE.md).
-
-## Commit Convention
-
-### Source of truth
-
-The repo's `commitlint.config.cjs` enforces the format and lists the encouraged scopes (read it before composing a commit message). The summary below mirrors that file; if the two disagree, the config wins.
-
-### Format
-
-```text
-type(scope): description
-
-[optional body]
-
-[optional footer]
-```
-
-### Types
-
-| Type | Usage |
-| --- | --- |
-| `feat` | New feature |
-| `fix` | Bug fix |
-| `docs` | Documentation only |
-| `refactor` | Code change (no feat/fix) |
-| `perf` | Performance improvement |
-| `test` | Add/update tests |
-| `chore` | Build, config, deps |
-| `style` | Formatting (no logic change) |
-| `ci` | CI/CD configuration |
-| `revert` | Revert previous commit |
-| `build` | Build system or external deps |
-
-### Scopes
-
-Scope is optional. When provided, it MUST be kebab-case (enforced by `scope-case`). A whitelist of encouraged scopes lives in `commitlint.config.cjs` (`scope-enum`) at the `warning` level: an unknown scope produces a warning but does NOT block the commit. Use a known scope whenever it fits; introduce a new one only when no existing scope describes the change.
-
-Encouraged scopes (kept in sync with `commitlint.config.cjs`):
-
-- **Plugin (long form)**: `aidd-context`, `aidd-dev`, `aidd-vcs`, `aidd-pm`, `aidd-refine`, `aidd-orchestrator`
-- **Plugin (short form)**: `context`, `dev`, `vcs`, `pm`, `refine`, `orchestrator`
-- **Root**: `framework`, `marketplace` (these bump `marketplace.json` via release-please)
-- **Tooling**: `release-please`, `ci`, `deps`, `lefthook`, `commitlint`, `contributing`, `docs`, `security`, `test`
-
-### Description rules
-
-- Imperative mood: "add" not "added"
-- Lowercase, no period
-- Max 72 chars
-
-### Examples
-
-```text
-feat(orchestrator): per-developer Anthropic account routing
-fix(orchestrator): SDLC owns push + PR
-refactor(aidd-pm): restructure spec into build and refine actions
-chore(release-please): register orchestrator and refine packages
-ci(framework): drop version.txt from tarball step
-```
-
-### Breaking Change
-
-```text
-feat(api): redesign plugin manifest format
-
-BREAKING CHANGE: plugin.json now requires a `strict` field.
-```
-
-## Release Management
-
-The release flow (main/next model, weekly cadence, hotfix) lives in [`RELEASE.md`](../../RELEASE.md). This section is the tooling only.
-
-- Automated via `release-please`, in `.github/workflows/ci.yml` on push to `main`.
-- The Release PR is auto-merged in that workflow (AIDD bot App token, a bypass actor on `main`).
-- Back-merge `main` -> `next` is automated in `.github/workflows/back-merge.yml`.
-- Config: `release-please-config.json`, manifest: `.release-please-manifest.json`.
-- Per-plugin versioning with `include-component-in-tag: true`.
-- Tags format: `<plugin>-v<semver>` (e.g. `aidd-dev-v1.2.0`).
+AI should auto commit: `never`. Committing and pushing happen only when the user asks.

--- a/plugins/aidd-context/hooks/update_memory.js
+++ b/plugins/aidd-context/hooks/update_memory.js
@@ -9,8 +9,13 @@
  *   - internal/ and external/ -> listed (plain paths, no @), read on demand.
  *
  * Reference syntax for the always-loaded tier:
- *   CLAUDE.md / AGENTS.md        -> @aidd_docs/memory/file.md
+ *   CLAUDE.md                    -> @aidd_docs/memory/file.md
+ *   AGENTS.md                    -> [aidd_docs/memory/file.md](aidd_docs/memory/file.md)
  *   .github/copilot-instructions -> [aidd_docs/memory/file.md](../aidd_docs/memory/file.md)
+ *
+ * Only Claude Code resolves the @ import form. The tools reading AGENTS.md
+ * (codex, cursor, opencode) do not, so an @ line there was inert text; a link
+ * is at least navigable.
  *
  * Usage:
  *   node update_memory.js                  every context file already present
@@ -52,7 +57,7 @@ const TOC_CLOSE = "<!-- files:end -->";
 
 const TARGET_FILES = [
   { path: "CLAUDE.md", syntax: "at" },
-  { path: "AGENTS.md", syntax: "at" },
+  { path: "AGENTS.md", syntax: "link" },
   { path: ".github/copilot-instructions.md", syntax: "link" },
 ];
 
@@ -116,14 +121,23 @@ function scanSubdir(fs, path, sub) {
   return out.sort();
 }
 
-function buildReference(syntax, filePath) {
-  const rel = filePath.replace(/\\/g, "/");
-  return syntax === "link" ? `[${rel}](../${rel})` : `@${rel}`;
+// A markdown link resolves against the file holding it, so it has to climb back
+// out of whatever directory that file sits in. Derived from the target's own
+// depth rather than hardcoded: a root-level AGENTS.md needs no prefix, while
+// .github/copilot-instructions.md needs one "../". Hardcoding one level made
+// every root-level link point outside the repository.
+function relativePrefix(targetPath) {
+  return "../".repeat(targetPath.split("/").length - 1);
 }
 
-function buildBlockContent(rootFiles, onDemandFiles, syntax) {
+function buildReference(syntax, filePath, prefix) {
+  const rel = filePath.replace(/\\/g, "/");
+  return syntax === "link" ? `[${rel}](${prefix}${rel})` : `@${rel}`;
+}
+
+function buildBlockContent(rootFiles, onDemandFiles, syntax, prefix = "") {
   const lines = [];
-  for (const f of rootFiles) lines.push(buildReference(syntax, f));
+  for (const f of rootFiles) lines.push(buildReference(syntax, f, prefix));
   if (onDemandFiles.length > 0) {
     lines.push("", ON_DEMAND_NOTE);
     for (const f of onDemandFiles) lines.push(`- ${f.replace(/\\/g, "/")}`);
@@ -284,7 +298,12 @@ function gitAdd(childProcess, files) {
     const original = readTextOrNull(fs, target.path);
     if (original === null) continue;
 
-    const innerContent = buildBlockContent(rootFiles, onDemandFiles, target.syntax);
+    const innerContent = buildBlockContent(
+      rootFiles,
+      onDemandFiles,
+      target.syntax,
+      relativePrefix(target.path),
+    );
     // Compare against what is on disk, not against the migrated text: a file
     // whose memory list is unchanged would otherwise look identical and skip
     // the write, leaving the legacy markers in place forever.

--- a/scripts/__tests__/update-memory.test.js
+++ b/scripts/__tests__/update-memory.test.js
@@ -14,7 +14,16 @@ const OPEN = "<!-- aidd_project_memory:start -->";
 const CLOSE = "<!-- aidd_project_memory:end -->";
 
 /** A throwaway project with a memory bank, a context file, and the hook run in it. */
-function run({ context, bank = ["architecture.md"], onDemand = [], packageJson, hookAt, args, runs = 1 }) {
+function run({
+  context,
+  contextAt = "CLAUDE.md",
+  bank = ["architecture.md"],
+  onDemand = [],
+  packageJson,
+  hookAt,
+  args,
+  runs = 1,
+}) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "update-memory-"));
   try {
     fs.mkdirSync(path.join(root, "aidd_docs/memory"), { recursive: true });
@@ -24,7 +33,11 @@ function run({ context, bank = ["architecture.md"], onDemand = [], packageJson, 
       fs.mkdirSync(path.dirname(full), { recursive: true });
       fs.writeFileSync(full, "# x\n");
     }
-    if (context !== undefined) fs.writeFileSync(path.join(root, "CLAUDE.md"), context);
+    if (context !== undefined) {
+      const target = path.join(root, contextAt);
+      fs.mkdirSync(path.dirname(target), { recursive: true });
+      fs.writeFileSync(target, context);
+    }
     if (packageJson) fs.writeFileSync(path.join(root, "package.json"), packageJson);
 
     // Copying the hook in mirrors how the CLI installs it, so the project's own
@@ -37,7 +50,7 @@ function run({ context, bank = ["architecture.md"], onDemand = [], packageJson, 
     }
 
     const invoke = () => spawnSync(process.execPath, [hook, ...(args ?? ["claude"])], { cwd: root });
-    const read = () => fs.readFileSync(path.join(root, "CLAUDE.md"), "utf8");
+    const read = () => fs.readFileSync(path.join(root, contextAt), "utf8");
 
     const first = invoke();
     const content = read();
@@ -189,4 +202,33 @@ test("an unpaired marker fails the run when the skill named the tools", () => {
 
   assert.equal(result.status, 1);
   assert.match(result.stderr, /unpaired project memory marker/u);
+});
+
+// The @ import form is Claude-only. AGENTS.md is read by codex, cursor and
+// opencode, none of which resolve it, so an @ line there was inert text.
+test("AGENTS.md gets markdown links, resolvable from the repository root", () => {
+  const content = run({
+    context: `${OPEN}\n${CLOSE}\n`,
+    contextAt: "AGENTS.md",
+    args: ["codex"],
+  }).content;
+
+  assert.match(content, /^\[aidd_docs\/memory\/architecture\.md\]\(aidd_docs\/memory\/architecture\.md\)$/mu);
+  assert.doesNotMatch(content, /\(\.\.\//u);
+});
+
+// A link resolves against the file holding it, so a nested context file has to
+// climb back out. Hardcoding one level made every root-level link escape the
+// repository, which the link check catches as a broken local path.
+test("a nested context file prefixes its links with the climb back out", () => {
+  const content = run({
+    context: `${OPEN}\n${CLOSE}\n`,
+    contextAt: ".github/copilot-instructions.md",
+    args: ["copilot"],
+  }).content;
+
+  assert.match(
+    content,
+    /^\[aidd_docs\/memory\/architecture\.md\]\(\.\.\/aidd_docs\/memory\/architecture\.md\)$/mu,
+  );
 });


### PR DESCRIPTION
Three commits: bank content, citation syntax in `AGENTS.md`, then the parent/child split.

## Redundancy with the CLI bank

`cli/` already carries its own `CLAUDE.md` and a full bank — architecture, testing, deployment, codebase-map, coding-assertions, project-brief, vcs, cli, auth. The root bank restated all of it, so the two drifted independently and a reader got the same subject twice, differently.

Root is now the repository-wide view and points to the child for CLI internals. Prose gave way to tables.

| File | Root holds | Delegates to child |
| --- | --- | --- |
| `architecture.md` | stack, plugin model, firewall, gotchas | layers, domain models, install flows, adapters |
| `codebase-map.md` | top-level areas, entry points, packages | where things live inside the CLI |
| `testing.md` | what validates each surface, browser QA | tiers, fixtures, naming, mocking |
| `deployment.md` | workflows, release flow | build, publish, self-update |
| `coding-assertions.md` | repo gates | CLI completion criteria |
| `cli.md` | what the binary is, command groups | interface and internals |

## Playwright

Dropped from `testing.md`, though `aidd-dev:11-browser-qa` runs the pinned `@playwright/cli@0.1.17` through `npx`, with `ffmpeg` and `ffprobe`, producing WebM evidence. Restored under the template's `Browser QA` section, with the pin and the "never `latest` during QA" rule.

## The bank content

The seven older files kept their original headings and described a repository that no longer exists:

- `testing.md` said no test runner was configured, next to a `cli/` running vitest, fast-check and stryker.
- `deployment.md` listed three CI steps where there are eight workflows, and said the promote **rebase** auto-merges — false since the branch model was fixed.
- `vcs.md` named renamed issue templates and omitted the `cli` and `aidd-ui` scopes.
- `codebase-map.md` had no sections, only a diagram redrawing the tree.
- `project-brief.md` carried an invented persona and a user-journey diagram for a CLI.

Every claim now traces to a file: `lefthook.yml` for the gates, `cli/package.json` and `cli/vitest.workspace.ts` for the layers, `docs/ARCHITECTURE.md` for the concern taxonomy, `kanban/src/presentation/kanban-deps.ts` for the seam between workspaces.

`README.md` joins the bank, its loading description corrected to the comment markers from #721.

## The citation syntax

`@aidd_docs/memory/x.md` is resolved by Claude Code only. `AGENTS.md` is read by codex, cursor and opencode, none of which resolve it — inert text pointing at files the tool never opened. That target now uses the link syntax the hook already supported.

Switching it exposed a second bug: `buildReference` hardcoded a `../` prefix, correct only because the one file using links (`.github/copilot-instructions.md`) sits one level down. On a root-level `AGENTS.md` that prefix sends every link outside the repository. The prefix now derives from the target's own depth.

Two tests cover it; the first fails against the hardcoded prefix, verified by reverting it:

```
✖ AGENTS.md gets markdown links, resolvable from the repository root
ℹ pass 31  ℹ fail 1
```

`CLAUDE.md` keeps its duplicated content and its `@` block, deliberately: it is the one tool that resolves imports.

## Checks run locally

```
✅ Links: 0 broken in 694 files
✅ context imports load: none sit inside an HTML block
ℹ pass 32  ℹ fail 0        (scripts/__tests__)
```

## Left alone

`backlog.md` is missing the template's `## Structure` section — nothing verified to put there. The CLI bank does not follow the templates either; separate concern.