### PR TITLE
feat(framework): reload OpenCode skills in development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,5 +17,5 @@ doctor: ## Check the local toolchain
 check: ## Run the pre-commit checks
 	pnpm exec lefthook run pre-commit
 
-reload: ## Dev: CLI-build this checkout into Claude+Codex native trees and reinstall (PLUGIN="aidd-refine aidd-pm", default all)
+reload: ## Dev: reload this checkout into Claude, Codex, and OpenCode (PLUGIN="aidd-refine aidd-pm", default all)
 	scripts/dev-sync.sh $(PLUGIN)

--- a/scripts/__tests__/dev-sync.test.js
+++ b/scripts/__tests__/dev-sync.test.js
@@ -1,0 +1,76 @@
+const assert = require("node:assert/strict");
+const { spawnSync } = require("node:child_process");
+const { chmodSync, existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } = require("node:fs");
+const { tmpdir } = require("node:os");
+const { join, resolve } = require("node:path");
+const test = require("node:test");
+
+const repo = resolve(__dirname, "../..");
+
+function executable(path, body) {
+  writeFileSync(path, `#!/bin/sh\nset -eu\n${body}\n`);
+  chmodSync(path, 0o755);
+}
+
+function runSync(fakeBin, home, args = ["all"]) {
+  return spawnSync("/bin/bash", [join(repo, "scripts/dev-sync.sh"), ...args], {
+    cwd: repo,
+    env: {
+      ...process.env,
+      PATH: `${fakeBin}:/usr/bin:/bin`,
+      HOME: home,
+      BUILD: join(home, "build"),
+    },
+    encoding: "utf8",
+  });
+}
+
+test("managed OpenCode reload uses the fixed-purpose helper without a local build", () => {
+  const root = mkdtempSync(join(tmpdir(), "aidd-dev-sync-managed-"));
+  try {
+    const fakeBin = join(root, "bin");
+    const home = join(root, "home");
+    mkdirSync(fakeBin);
+    mkdirSync(home);
+    executable(join(fakeBin, "aidd-opencode-reload"), 'echo "managed:ok"');
+
+    const result = runSync(fakeBin, home);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /reload opencode\s+managed:ok/);
+    assert.equal(existsSync(join(home, "build")), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("local OpenCode reload installs only the selected plugin skills globally", () => {
+  const root = mkdtempSync(join(tmpdir(), "aidd-dev-sync-local-"));
+  try {
+    const fakeBin = join(root, "bin");
+    const home = join(root, "home");
+    mkdirSync(fakeBin);
+    mkdirSync(home);
+    mkdirSync(join(home, ".config/opencode/skills/aidd-dev-stale"), { recursive: true });
+    writeFileSync(join(home, ".config/opencode/skills/aidd-dev-stale/SKILL.md"), "stale\n");
+    executable(join(fakeBin, "opencode"), "exit 0");
+    executable(
+      join(fakeBin, "npx"),
+      String.raw`out=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--out" ]; then shift; out=$1; fi
+  shift
+done
+mkdir -p "$out/.opencode/skills/aidd-dev-01-plan"
+printf '%s\n' '---' 'name: aidd-dev-01-plan' 'description: test' '---' > "$out/.opencode/skills/aidd-dev-01-plan/SKILL.md"`,
+    );
+
+    const result = runSync(fakeBin, home, ["aidd-dev"]);
+    assert.equal(result.status, 0, result.stderr);
+    const installed = join(home, ".config/opencode/skills/aidd-dev-01-plan/SKILL.md");
+    assert.match(readFileSync(installed, "utf8"), /name: aidd-dev-01-plan/);
+    assert.equal(existsSync(join(home, ".config/opencode/skills/aidd-dev-stale")), false);
+    assert.match(result.stdout, /install opencode\s+skills:ok/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/dev-sync.sh
+++ b/scripts/dev-sync.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# dev-sync.sh - (re)register the marketplace and install every plugin into Claude and Codex
+# dev-sync.sh - (re)install every plugin into Claude, Codex, and OpenCode
 # from THIS checkout. Claude installs from the raw repo (already native Claude format). Codex
 # installs from a native tree built by the aidd CLI (which maps Claude syntax -> Codex,
 # e.g. agents -> TOML), so what you run locally matches what ships at release.
@@ -8,9 +8,10 @@
 #   scripts/dev-sync.sh aidd-refine aidd-pm  # several
 #   scripts/dev-sync.sh all                  # every plugin (default)
 #
-# NOT live: the install copies built files into each tool's plugin cache, so re-run after
-# an edit. Idempotent; each tool is skipped if its CLI is absent. Needs network the first
-# time (npx fetches the CLI). Restart the Claude/Codex session afterwards to load the files.
+# NOT live: the local install copies built files into each tool's cache/config, so re-run
+# after an edit. Idempotent; each tool is skipped if its CLI is absent. Needs network the
+# first time (npx fetches the CLI). A managed OpenCode host may expose the fixed-purpose
+# `aidd-opencode-reload` helper instead; that helper decides which trusted checkout can load.
 #
 # Codex caveat: the CLI emits codex-agents/*.toml but the .codex-plugin manifest does not
 # declare them, and Codex only loads agents from ~/.codex/agents/ - so after install we copy
@@ -26,15 +27,33 @@ BUILD="${BUILD:-$HOME/.cache/aidd-framework-dev}"  # per-tool native trees the m
 CODEX_CACHE="${CODEX_CACHE:-$HOME/.codex/plugins/cache}"
 CLAUDE_CACHE="${CLAUDE_CACHE:-$HOME/.claude/plugins/cache}"
 CODEX_AGENTS="${CODEX_AGENTS:-$HOME/.codex/agents}"
+OPENCODE_SKILLS="${OPENCODE_SKILLS:-$HOME/.config/opencode/skills}"
 
 HAVE_CODEX=0;  command -v codex  >/dev/null 2>&1 && HAVE_CODEX=1
 HAVE_CLAUDE=0; command -v claude >/dev/null 2>&1 && HAVE_CLAUDE=1
+HAVE_OPENCODE=0; command -v opencode >/dev/null 2>&1 && HAVE_OPENCODE=1
+HAVE_MANAGED_OPENCODE=0; command -v aidd-opencode-reload >/dev/null 2>&1 && HAVE_MANAGED_OPENCODE=1
 
 build_tool() { # tool -> $BUILD/$tool ; returns non-zero on build failure
   local tool="$1"
   rm -rf "$BUILD/$tool"; mkdir -p "$BUILD/$tool"
+  local mode=()
+  [ "$tool" != opencode ] || mode=(--flat)
   npx --yes "@ai-driven-dev/cli@${AIDD_CLI_VERSION}" framework build \
-    --source "$FW" --target "$tool" --out "$BUILD/$tool" >/dev/null 2>&1
+    --source "$FW" --target "$tool" --out "$BUILD/$tool" "${mode[@]}" >/dev/null 2>&1
+}
+
+sync_opencode_skills() {
+  local name source skill destination
+  mkdir -p "$OPENCODE_SKILLS"
+  for name in "$@"; do
+    source="$BUILD/opencode/.opencode/skills"
+    find "$OPENCODE_SKILLS" -mindepth 1 -maxdepth 1 -type d -name "$name-*" -exec rm -rf -- {} +
+    for skill in "$source/$name-"*/; do
+      destination="$OPENCODE_SKILLS/$(basename "$skill")"
+      cp -R "$skill" "$destination"
+    done
+  done
 }
 
 register_marketplace() { # tool
@@ -104,8 +123,8 @@ sync_one() {
   echo
 }
 
-if [ "$HAVE_CODEX" = 0 ] && [ "$HAVE_CLAUDE" = 0 ]; then
-  echo "Neither Claude nor Codex CLI found - nothing to install."; exit 0
+if [ "$HAVE_CODEX" = 0 ] && [ "$HAVE_CLAUDE" = 0 ] && [ "$HAVE_OPENCODE" = 0 ] && [ "$HAVE_MANAGED_OPENCODE" = 0 ]; then
+  echo "No Claude, Codex, or OpenCode installation found - nothing to install."; exit 0
 fi
 
 targets=()
@@ -124,7 +143,21 @@ fi
 if [ "$HAVE_CLAUDE" = 1 ]; then
   register_marketplace claude
 fi
+if [ "$HAVE_OPENCODE" = 1 ] && [ "$HAVE_MANAGED_OPENCODE" = 0 ]; then
+  printf '%-22s' "build opencode"
+  build_tool opencode && echo "ok" || { echo "FAIL"; HAVE_OPENCODE=0; }
+fi
 
 for t in "${targets[@]}"; do sync_one "$t"; done
 
-echo "Done. Restart the Claude/Codex session to load the refreshed files."
+if [ "$HAVE_OPENCODE" = 1 ] && [ "$HAVE_MANAGED_OPENCODE" = 0 ]; then
+  printf '%-22s' "install opencode"
+  sync_opencode_skills "${targets[@]}"
+  echo "skills:ok"
+fi
+if [ "$HAVE_MANAGED_OPENCODE" = 1 ]; then
+  printf '%-22s' "reload opencode"
+  aidd-opencode-reload
+fi
+
+echo "Done. Restart Claude/Codex; OpenCode discovers the refreshed skills without a restart."


### PR DESCRIPTION
## 🎯 What & why

Extend `make reload` to install OpenCode skills locally and trigger the bounded managed reload on the OpenCode server.

## 🛠️ How it works

`dev-sync.sh` detects the fixed-purpose `aidd-opencode-reload` helper before local tool discovery. Managed OpenCode sends only the current framework commit; local OpenCode rebuilds and atomically replaces its global skill directory.

## 🧪 How to verify

- `node --test scripts/__tests__/dev-sync.test.js`
- On `aidd-agents`: `make reload` from `/workspace/framework`, then compare `/var/lib/aidd-opencode-skills/active-commit` with `git rev-parse HEAD`.

## ✅ I certify

- [ ] **I DO CERTIFY I READ EACH LINE OF THE PULL REQUEST BECAUSE I AM A SOFTWARE ENGINEER, NOT A AI PUPPY.**