### PR TITLE
fix(cli): check says whether the host will load what aidd installed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,16 +40,16 @@ Project docs, memory, specs, and plans live in `aidd_docs/`.
 
 <!-- aidd_project_memory:start -->
 
-@aidd_docs/memory/architecture.md
-@aidd_docs/memory/backlog.md
-@aidd_docs/memory/cli.md
-@aidd_docs/memory/codebase-map.md
-@aidd_docs/memory/coding-assertions.md
-@aidd_docs/memory/deployment.md
-@aidd_docs/memory/ecosystem.md
-@aidd_docs/memory/project-brief.md
-@aidd_docs/memory/testing.md
-@aidd_docs/memory/vcs.md
+[aidd_docs/memory/architecture.md](aidd_docs/memory/architecture.md)
+[aidd_docs/memory/backlog.md](aidd_docs/memory/backlog.md)
+[aidd_docs/memory/cli.md](aidd_docs/memory/cli.md)
+[aidd_docs/memory/codebase-map.md](aidd_docs/memory/codebase-map.md)
+[aidd_docs/memory/coding-assertions.md](aidd_docs/memory/coding-assertions.md)
+[aidd_docs/memory/deployment.md](aidd_docs/memory/deployment.md)
+[aidd_docs/memory/ecosystem.md](aidd_docs/memory/ecosystem.md)
+[aidd_docs/memory/project-brief.md](aidd_docs/memory/project-brief.md)
+[aidd_docs/memory/testing.md](aidd_docs/memory/testing.md)
+[aidd_docs/memory/vcs.md](aidd_docs/memory/vcs.md)
 
 <!-- read on demand, not auto-loaded -->
 - aidd_docs/memory/internal/decisions/a-price-table-is-the-destination-s.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,16 +40,16 @@ Project docs, memory, specs, and plans live in `aidd_docs/`.
 
 <!-- aidd_project_memory:start -->
 
-[aidd_docs/memory/architecture.md](aidd_docs/memory/architecture.md)
-[aidd_docs/memory/backlog.md](aidd_docs/memory/backlog.md)
-[aidd_docs/memory/cli.md](aidd_docs/memory/cli.md)
-[aidd_docs/memory/codebase-map.md](aidd_docs/memory/codebase-map.md)
-[aidd_docs/memory/coding-assertions.md](aidd_docs/memory/coding-assertions.md)
-[aidd_docs/memory/deployment.md](aidd_docs/memory/deployment.md)
-[aidd_docs/memory/ecosystem.md](aidd_docs/memory/ecosystem.md)
-[aidd_docs/memory/project-brief.md](aidd_docs/memory/project-brief.md)
-[aidd_docs/memory/testing.md](aidd_docs/memory/testing.md)
-[aidd_docs/memory/vcs.md](aidd_docs/memory/vcs.md)
+@aidd_docs/memory/architecture.md
+@aidd_docs/memory/backlog.md
+@aidd_docs/memory/cli.md
+@aidd_docs/memory/codebase-map.md
+@aidd_docs/memory/coding-assertions.md
+@aidd_docs/memory/deployment.md
+@aidd_docs/memory/ecosystem.md
+@aidd_docs/memory/project-brief.md
+@aidd_docs/memory/testing.md
+@aidd_docs/memory/vcs.md
 
 <!-- read on demand, not auto-loaded -->
 - aidd_docs/memory/internal/decisions/a-price-table-is-the-destination-s.md

--- a/aidd_docs/tasks/2026_09/2026_09_02_install-surfaces-agree/backlog-link.json
+++ b/aidd_docs/tasks/2026_09/2026_09_02_install-surfaces-agree/backlog-link.json
@@ -1,0 +1,5 @@
+{
+  "backlog": "ai-driven-dev/framework#703",
+  "writtenAt": "2026-09-02T20:15:00Z",
+  "writtenBy": "aidd-orchestrator:01-sdlc"
+}

--- a/aidd_docs/tasks/2026_09/2026_09_02_install-surfaces-agree/plan.md
+++ b/aidd_docs/tasks/2026_09/2026_09_02_install-surfaces-agree/plan.md
@@ -42,7 +42,7 @@ holds no tool name.
 | --- | --- | --- |
 | 1 | The model: `TelemetryHostRegistrationSetup`, four answers, on `TelemetrySetup` | `domain/models/telemetry-setup.ts` |
 | 2 | The port: `HostPluginRegistryReader`, sibling of `HookTrustReader` | `domain/ports/host-plugin-registry-reader.ts` |
-| 3 | The adapter: one reader per host whose registry was measured — Claude's JSON, Codex's line-scanned TOML. Copilot gets none, deliberately | `infrastructure/adapters/host-plugin-registry-reader-adapter.ts` |
+| 3 | The adapter: one reader per host whose registry was measured — Claude's JSON, Codex's line-scanned TOML, Copilot's JSON | `infrastructure/adapters/host-plugin-registry-reader-adapter.ts` |
 | 4 | The comparison: manifest -> `enabledPlugins` -> registry, in the use-case | `use-cases/telemetry/diagnose-telemetry-use-case.ts`, `deps.ts` |
 | 5 | The row: `plugins registered`, naming the missing side | `application/display/telemetry-check-display.ts` |
 | 6 | The tests, including the seam through `marketplace-sync-settings-use-case.ts` | `cli/tests/**` |
@@ -55,10 +55,8 @@ it would have drawn separates two flavours of one outcome. See `spec.md`.
 
 - **Unit** — the four answers, from evidence shapes. No filesystem.
 - **Integration** — each shipped reader against a written fixture: Claude's JSON and Codex's
-  TOML, plus absent, unreadable, `enabled = false`, and a registry that is JSONC where JSON
-  was expected — written from the recorded shape, never copied from the real file. The JSONC
-  case runs through the Claude reader, which is the only way to assert it once Copilot ships
-  no reader of its own.
+  TOML and Copilot's JSON, plus absent, unreadable, disabled, and a registry that is JSONC
+  where JSON was expected — written from the recorded shape, never copied from a real file.
 - **Integration, the seam** — drive `MarketplaceSyncSettingsUseCase` and assert the
   comparison sees what it wrote; this is the file with no test today.
 - **E2E** — `aidd telemetry check` in a sandboxed HOME prints the row and names the missing

--- a/aidd_docs/tasks/2026_09/2026_09_02_install-surfaces-agree/plan.md
+++ b/aidd_docs/tasks/2026_09/2026_09_02_install-surfaces-agree/plan.md
@@ -42,7 +42,7 @@ holds no tool name.
 | --- | --- | --- |
 | 1 | The model: `TelemetryHostRegistrationSetup`, four answers, on `TelemetrySetup` | `domain/models/telemetry-setup.ts` |
 | 2 | The port: `HostPluginRegistryReader`, sibling of `HookTrustReader` | `domain/ports/host-plugin-registry-reader.ts` |
-| 3 | The adapter: one reader per measured host, JSON / line-scanned TOML / JSONC | `infrastructure/adapters/host-plugin-registry-reader-adapter.ts` |
+| 3 | The adapter: one reader per host whose registry was measured — Claude's JSON, Codex's line-scanned TOML. Copilot gets none, deliberately | `infrastructure/adapters/host-plugin-registry-reader-adapter.ts` |
 | 4 | The comparison: manifest -> `enabledPlugins` -> registry, in the use-case | `use-cases/telemetry/diagnose-telemetry-use-case.ts`, `deps.ts` |
 | 5 | The row: `plugins registered`, naming the missing side | `application/display/telemetry-check-display.ts` |
 | 6 | The tests, including the seam through `marketplace-sync-settings-use-case.ts` | `cli/tests/**` |
@@ -54,9 +54,11 @@ it would have drawn separates two flavours of one outcome. See `spec.md`.
 ## Test strategy
 
 - **Unit** — the four answers, from evidence shapes. No filesystem.
-- **Integration** — each adapter against a written fixture: Claude's JSON, Codex's TOML,
-  Copilot's JSONC (written from the recorded shape, never copied from the real file), plus
-  absent, unreadable and `enabled = false`.
+- **Integration** — each shipped reader against a written fixture: Claude's JSON and Codex's
+  TOML, plus absent, unreadable, `enabled = false`, and a registry that is JSONC where JSON
+  was expected — written from the recorded shape, never copied from the real file. The JSONC
+  case runs through the Claude reader, which is the only way to assert it once Copilot ships
+  no reader of its own.
 - **Integration, the seam** — drive `MarketplaceSyncSettingsUseCase` and assert the
   comparison sees what it wrote; this is the file with no test today.
 - **E2E** — `aidd telemetry check` in a sandboxed HOME prints the row and names the missing

--- a/aidd_docs/tasks/2026_09/2026_09_02_install-surfaces-agree/plan.md
+++ b/aidd_docs/tasks/2026_09/2026_09_02_install-surfaces-agree/plan.md
@@ -8,7 +8,7 @@ spec: ./spec.md
 
 ## The shape, and why it is not a fifth claim
 
-`telemetry-check-display.ts:42` states the rule the report already follows: a setup row is
+`telemetry-check-display.ts` states the rule the report already follows: a setup row is
 *"a sentence, never the claims' `ok`/`FAIL`/`--` verdict column — that vocabulary is reserved
 for a grade, and nothing here is graded yet."*
 
@@ -40,7 +40,7 @@ holds no tool name.
 
 | # | Does | Touches |
 | --- | --- | --- |
-| 1 | The model: `TelemetryHostRegistrationSetup`, five answers, on `TelemetrySetup` | `domain/models/telemetry-setup.ts` |
+| 1 | The model: `TelemetryHostRegistrationSetup`, four answers, on `TelemetrySetup` | `domain/models/telemetry-setup.ts` |
 | 2 | The port: `HostPluginRegistryReader`, sibling of `HookTrustReader` | `domain/ports/host-plugin-registry-reader.ts` |
 | 3 | The adapter: one reader per measured host, JSON / line-scanned TOML / JSONC | `infrastructure/adapters/host-plugin-registry-reader-adapter.ts` |
 | 4 | The comparison: manifest -> `enabledPlugins` -> registry, in the use-case | `use-cases/telemetry/diagnose-telemetry-use-case.ts`, `deps.ts` |
@@ -53,7 +53,7 @@ it would have drawn separates two flavours of one outcome. See `spec.md`.
 
 ## Test strategy
 
-- **Unit** — the five answers, from evidence shapes. No filesystem.
+- **Unit** — the four answers, from evidence shapes. No filesystem.
 - **Integration** — each adapter against a written fixture: Claude's JSON, Codex's TOML,
   Copilot's JSONC (written from the recorded shape, never copied from the real file), plus
   absent, unreadable and `enabled = false`.

--- a/aidd_docs/tasks/2026_09/2026_09_02_install-surfaces-agree/plan.md
+++ b/aidd_docs/tasks/2026_09/2026_09_02_install-surfaces-agree/plan.md
@@ -1,0 +1,59 @@
+---
+status: planned
+backlog: ai-driven-dev/framework#703
+spec: ./spec.md
+---
+
+# Plan
+
+## The shape, and why it is not a fifth claim
+
+`telemetry-check-display.ts:42` states the rule the report already follows: a setup row is
+*"a sentence, never the claims' `ok`/`FAIL`/`--` verdict column — that vocabulary is reserved
+for a grade, and nothing here is graded yet."*
+
+The four claims all grade evidence **a run produced**: hook fired, session journalled, tool
+files readable, records join. This fact is available **before any session** — that is the
+point of it, and the acceptance says so ("no AI session, no network, no money"). So it is a
+setup row, and its natural pair is the one directly above it: `recorder declared` answers
+*was it declared*, this answers *will the host load it*.
+
+`TelemetryRecorderDeclarationSetup`'s own doc already names this hole:
+
+> A declaration is not proof the hook will fire — see `claude-cli-adapter.ts`'s own measured
+> case, where a declared entry is silently dropped as orphaned when a headless run never
+> registers the plugin — this fact states only that a declaration was found, never that it
+> works.
+
+That paragraph is where the next reader will look, so it is updated in the same commit to
+point at the new fact rather than describe an open hole.
+
+## Per tool without naming a tool
+
+The diagnose use-case already takes `readers: ReadonlyMap<AiToolId, SessionCostReader>`. The
+same shape carries this: `ReadonlyMap<AiToolId, HostPluginRegistryReader>`. A tool absent
+from the map is **unanswerable** — never assumed to agree. Per-tool knowledge lives in
+per-tool adapter functions, each carrying its own measurement in a doc comment; the domain
+holds no tool name.
+
+## Phases
+
+| # | Does | Touches |
+| --- | --- | --- |
+| 1 | The model: `TelemetryHostRegistrationSetup`, five answers, on `TelemetrySetup` | `domain/models/telemetry-setup.ts` |
+| 2 | The port: `HostPluginRegistryReader`, sibling of `HookTrustReader` | `domain/ports/host-plugin-registry-reader.ts` |
+| 3 | The adapter: one reader per measured host, JSON / line-scanned TOML / JSONC | `infrastructure/adapters/host-plugin-registry-reader-adapter.ts` |
+| 4 | The comparison: manifest -> `enabledPlugins` -> registry, in the use-case | `use-cases/telemetry/diagnose-telemetry-use-case.ts`, `deps.ts` |
+| 5 | The row: `plugins registered`, naming the missing side | `application/display/telemetry-check-display.ts` |
+| 6 | The tests, including the seam through `marketplace-sync-settings-use-case.ts` | `cli/tests/**` |
+
+## Test strategy
+
+- **Unit** — the five answers, from evidence shapes. No filesystem.
+- **Integration** — each adapter against a written fixture: Claude's JSON, Codex's TOML,
+  Copilot's JSONC (written from the recorded shape, never copied from the real file), plus
+  absent, unreadable and `enabled = false`.
+- **Integration, the seam** — drive `MarketplaceSyncSettingsUseCase` and assert the
+  comparison sees what it wrote; this is the file with no test today.
+- **E2E** — `aidd telemetry check` in a sandboxed HOME prints the row and names the missing
+  side, with no binary on PATH.

--- a/aidd_docs/tasks/2026_09/2026_09_02_install-surfaces-agree/plan.md
+++ b/aidd_docs/tasks/2026_09/2026_09_02_install-surfaces-agree/plan.md
@@ -47,6 +47,10 @@ holds no tool name.
 | 5 | The row: `plugins registered`, naming the missing side | `application/display/telemetry-check-display.ts` |
 | 6 | The tests, including the seam through `marketplace-sync-settings-use-case.ts` | `cli/tests/**` |
 
+**Four answers, not the five first sketched.** The fifth needed a declared-refs accessor the
+evidence port does not expose; the reason is written where the type is, and the distinction
+it would have drawn separates two flavours of one outcome. See `spec.md`.
+
 ## Test strategy
 
 - **Unit** — the five answers, from evidence shapes. No filesystem.

--- a/aidd_docs/tasks/2026_09/2026_09_02_install-surfaces-agree/spec.md
+++ b/aidd_docs/tasks/2026_09/2026_09_02_install-surfaces-agree/spec.md
@@ -57,13 +57,20 @@ config.json               // comments, then { firstLaunchAt, installedPlugins: [
    on it — verified, `SyntaxError: Unexpected token '/'`. A reader that let that throw fall
    through as "no plugins registered" would print a zero where the honest answer is *unknown*.
    This is the exact failure this layer exists to refuse, waiting in the first file it reads.
-2. **`installed_plugins.json` records a `scope`** — `user`, `project`, `local` observed —
-   but its `installPath` always points inside the plugins cache, never at a project. So the
-   registry says *this machine can load this ref*, never *this project wants it*.
-3. **Codex records `enabled`, and it is the only key it records.** 27 plugin tables on the
-   machine measured, every one `enabled = true`, and nothing else under any of them. So
-   `enabled = false` is possible and unobserved — a state where the host knows the plugin and
-   will still not load it, which is not the same fact as an absent entry.
+2. **`installed_plugins.json` binds a ref to a project.** Its `installPath` always points
+   inside the plugins cache — but that is not the whole entry. Read across all 115 entries
+   rather than the first one, they carry `projectPath` on 100 of them, exactly the 99 at
+   `scope: "project"` plus the one at `"local"`; the 15 user-scoped entries carry none,
+   because they apply everywhere. So the registry does say which project wants a ref, and
+   `aidd` writes every one at project scope (`claude-cli-adapter.ts`'s `PROJECT_SCOPE_ARGS`).
+   A reader that ignored it would report a plugin installed for another project as one this
+   host will load here.
+3. **Codex records `enabled`, and it is the only key it records.** Every plugin table on the
+   machine measured carries `enabled = true` and nothing else. So `enabled = false` is
+   possible and unobserved — a state where the host knows the plugin and will still not load
+   it, which is not the same fact as an absent entry. (Counted 27 tables on 2026-09-02 and 23
+   the next day: the count moves with what is installed, so the doc states the invariant and
+   not the number.)
 4. **The architecture already exists.** `HookTrustReader` +
    `hook-trust-reader-adapter.ts` reads `~/.codex/config.toml` to answer one `check` claim,
    with the error handling this needs. What is built here is its sibling, not a new layer —

--- a/aidd_docs/tasks/2026_09/2026_09_02_install-surfaces-agree/spec.md
+++ b/aidd_docs/tasks/2026_09/2026_09_02_install-surfaces-agree/spec.md
@@ -103,20 +103,31 @@ AIDD manifest  ──►  the project's enabledPlugins  ──►  the host's ow
    installed            declares                       actually load
 ```
 
-**Five answers per installed plugin, never fewer:**
+**Four answers per installed plugin, never fewer:**
 
 | Answer | Means |
 | --- | --- |
 | registered | the registry was read and carries the ref |
-| registered, disabled | the registry carries it and records it off — Codex's `enabled = false` |
-| declared, not registered | the registry was read and lacks it, naming which file — the #703 failure |
-| not declared | the manifest has it and `enabledPlugins` does not, so the sync skipped it |
-| unanswerable | the ref cannot be built (no marketplace recorded), or the registry could not be read or parsed |
+| registered-disabled | the registry carries it and records it off — Codex's `enabled = false` |
+| not-registered | the registry was read and lacks it, naming which file — the #703 failure |
+| unanswerable | the ref cannot be built (no marketplace recorded), or no registry could be read |
 
-The last is not a soft version of the third. A file that cannot be parsed and a file that
-says "no" are different facts, and printing them alike is the defect this ticket is about.
-`registered, disabled` earns its own row for the same reason: folding it into `registered`
-would report a plugin that will not load as one that will.
+`unanswerable` is not a soft version of `not-registered`. A file that cannot be parsed and a
+file that says "no" are different facts, and printing them alike is the defect this ticket is
+about. `registered-disabled` earns its own row for the same reason: folding it into
+`registered` would report a plugin that will not load as one that will. And `unanswerable`
+itself carries two distinct sentences, because they send a person to different places: a tool
+that declares no native activation has no registry to look for, while a tool that declares
+one and has no reader here has a registry nobody has measured.
+
+**A fifth answer was designed and is not built.** Telling "the host does not carry it" from
+"it never reached the project's `enabledPlugins` at all" needs the set of declared refs per
+tool, and `TelemetryEvidenceReader` exposes no accessor for it — `readRecorderDeclaration`
+looks for the recorder specifically, not every declared key. That is a port method, an
+adapter method and their tests, for a distinction between two flavours of one outcome: the
+plugin will not load. The comparison starts from the manifest, which is the half that made
+the distinction visible and the half that matters; the second hop is named in #703's thread
+rather than half-built.
 
 ## Acceptance
 
@@ -125,6 +136,8 @@ would report a plugin that will not load as one that will.
 - [ ] A registry that cannot be read reports as unanswerable, distinctly from one read and
       lacking the entry. Asserted with a JSONC fixture — written from the shape recorded above,
       never copied from the real file, which carries hashed experiment keys and machine paths.
+- [ ] A manifest that cannot be parsed is reported, never fatal: `check` is the command a
+      person runs when something is already wrong.
 - [ ] The comparison starts from AIDD's own manifest, so a plugin the sync skipped is visible
       rather than reading as agreement between two absences.
 - [ ] Codex's `config.toml` is line-scanned, not parsed, and the doc comment says why against

--- a/aidd_docs/tasks/2026_09/2026_09_02_install-surfaces-agree/spec.md
+++ b/aidd_docs/tasks/2026_09/2026_09_02_install-surfaces-agree/spec.md
@@ -1,0 +1,111 @@
+---
+status: framed
+backlog: ai-driven-dev/framework#703
+branch: fix/install-surfaces-agree
+base: next@627408fb
+---
+
+# The two install surfaces agree, or `check` says which one is missing
+
+## The gap, in one sentence
+
+`aidd telemetry check` can say **the plugin is declared**. It cannot say **the host CLI
+registered it, so it will actually load** — and those are different facts, which is the
+whole of #703.
+
+## Boundary check — inside, and here is why
+
+This reads a host tool's own configuration files under the person's home directory. Against
+`aidd_docs/memory/internal/decisions/measurement-may-reach-a-hosted-destination.md`:
+
+- **Clause 1** — *"The shipped route reads the files each AI tool already wrote."* A plugin
+  registry is one such file. The transcripts already read under `~/.claude/projects/` are the
+  same act with a heavier payload.
+- **Clause 5** — what is read is on the person's own machine, from their own profile, by
+  them. Nothing leaves it, and no account is involved.
+- **The "it stops growing" consequence applies to report axes**, not to diagnosis. This adds
+  no eighth axis: `check` answers whether the chain will record, and this is one more claim
+  inside that question, not an aggregation.
+
+Inside the boundary. Nothing here needs a destination, a network or an account.
+
+## What was measured, 2026-09-02, on the machine that built this
+
+Read to learn shape only. No value from any of these files enters a fixture.
+
+**All three hosts key their registry on the same string** the CLI already writes into
+`enabledPlugins` — `<plugin>@<marketplace>`. That is the join, and it is uniform:
+
+| Host | File | Format | Marketplaces | Plugins |
+| --- | --- | --- | --- | --- |
+| Claude Code | `~/.claude/plugins/known_marketplaces.json`, `installed_plugins.json` | JSON | object keyed by name | `plugins`, keyed by `<plugin>@<marketplace>` |
+| Codex | `~/.codex/config.toml` | TOML | `[marketplaces.<name>]` | `[plugins."<plugin>@<marketplace>"]`, with `enabled` |
+| Copilot | `~/.copilot/config.json` | **JSONC** | — | `installedPlugins`, an array |
+
+Shapes, keys only:
+
+```
+known_marketplaces.json   { "<name>": { source: {source, repo|path}, installLocation, lastUpdated, autoUpdate? } }
+installed_plugins.json    { version, plugins: { "<plugin>@<marketplace>": [ {scope, installPath, version, installedAt, lastUpdated, gitCommitSha} ] } }
+config.toml               [marketplaces.<name>] · [plugins."<plugin>@<marketplace>"] enabled = true
+config.json               // comments, then { firstLaunchAt, installedPlugins: [], … }
+```
+
+**Three findings that shape the design, not decoration:**
+
+1. **Copilot's file is JSONC.** It opens with two `//` comment lines, so `JSON.parse` throws
+   on it — verified, `SyntaxError: Unexpected token '/'`. A reader that let that throw fall
+   through as "no plugins registered" would print a zero where the honest answer is *unknown*.
+   This is the exact failure this layer exists to refuse, waiting in the first file it reads.
+2. **`installed_plugins.json` records a `scope`** — `user`, `project`, `local` observed —
+   but its `installPath` always points inside the plugins cache, never at a project. So the
+   registry says *this machine can load this ref*; only the project's own `enabledPlugins`
+   says *this project wants it*. The comparison needs both sides and cannot be done from
+   either alone.
+3. **The architecture already exists.** `HookTrustReader` +
+   `hook-trust-reader-adapter.ts` reads `~/.codex/config.toml` to answer one `check` claim,
+   with the three-state error handling this needs. What is built here is its sibling, not a
+   new layer.
+
+## Design
+
+**No new command.** `aidd telemetry check` already asks whether the chain will record. This
+is one more claim inside it. The surface stays seven.
+
+**A registry is declared per tool, never hardcoded.** The three hosts that declare
+`nativeActivation` (`claude.ts:123`, `codex.ts:260`, `copilot.ts:335`) gain an optional
+declaration of where their registry lives and how it is read — the same way
+`marketplaceSettings` already declares where the settings file lives. A tool that declares
+none is reported as *not answerable*, never as agreeing.
+
+**Three answers per declared plugin, never two:**
+
+| Answer | Means |
+| --- | --- |
+| registered | the registry was read and carries the ref |
+| declared, not registered | the registry was read and does not carry it — the #703 failure, naming which of the two files lacks it |
+| unknown | the registry could not be read or parsed — absent file, permissions, JSONC |
+
+The third is not a soft version of the second. A file that cannot be parsed and a file that
+says "no" are different facts, and printing them alike is the defect this ticket is about.
+
+## Acceptance
+
+- [ ] The host's own registry is read, not only the declaration the CLI wrote.
+- [ ] `check` states whether the two agree and names the missing side — never a bare pass.
+- [ ] A registry that cannot be read reports as unknown, distinctly from one read and lacking
+      the entry. Asserted with a JSONC fixture, because that is a real file, not a hypothetical.
+- [ ] A test fails when the two surfaces disagree, driven **through**
+      `marketplace-sync-settings-use-case.ts` — which has no test file today.
+- [ ] The whole comparison runs with no AI session, no network, no money, no binary on PATH.
+- [ ] No tool is hardcoded: Codex and Copilot are answered by their own declaration or
+      reported unanswerable, never assumed.
+- [ ] If the check output shape changes, every consumer is updated in the same commit,
+      `plugins/aidd-telemetry/skills/02-check/` included.
+
+## Out of scope
+
+- Fixing an installation the comparison finds broken. Naming it is this ticket; the
+  activation itself already works and shipped in #706.
+- #703's third box, which moved to #694 — with no run file there is no session to tell from
+  another, so only the diagnostic can answer it.

--- a/aidd_docs/tasks/2026_09/2026_09_02_install-surfaces-agree/spec.md
+++ b/aidd_docs/tasks/2026_09/2026_09_02_install-surfaces-agree/spec.md
@@ -59,13 +59,20 @@ config.json               // comments, then { firstLaunchAt, installedPlugins: [
    This is the exact failure this layer exists to refuse, waiting in the first file it reads.
 2. **`installed_plugins.json` records a `scope`** — `user`, `project`, `local` observed —
    but its `installPath` always points inside the plugins cache, never at a project. So the
-   registry says *this machine can load this ref*; only the project's own `enabledPlugins`
-   says *this project wants it*. The comparison needs both sides and cannot be done from
-   either alone.
-3. **The architecture already exists.** `HookTrustReader` +
+   registry says *this machine can load this ref*, never *this project wants it*.
+3. **Codex records `enabled`, and it is the only key it records.** 27 plugin tables on the
+   machine measured, every one `enabled = true`, and nothing else under any of them. So
+   `enabled = false` is possible and unobserved — a state where the host knows the plugin and
+   will still not load it, which is not the same fact as an absent entry.
+4. **The architecture already exists.** `HookTrustReader` +
    `hook-trust-reader-adapter.ts` reads `~/.codex/config.toml` to answer one `check` claim,
-   with the three-state error handling this needs. What is built here is its sibling, not a
-   new layer.
+   with the error handling this needs. What is built here is its sibling, not a new layer —
+   and it inherits that adapter's stated choice to **line-scan** `config.toml` rather than
+   parse it: *"carries arbitrary nested tables and multi-line values this adapter has no
+   business understanding"*. Concretely, the file measured is 26 KB and most of it is
+   `[projects."<absolute path>"]` tables; parsing the whole document to read `[plugins.…]`
+   would pull every project path on the machine into a process that then writes diagnostic
+   output. Line-scanning reads the one shape Codex always emits verbatim and nothing else.
 
 ## Design
 
@@ -78,23 +85,50 @@ declaration of where their registry lives and how it is read — the same way
 `marketplaceSettings` already declares where the settings file lives. A tool that declares
 none is reported as *not answerable*, never as agreeing.
 
-**Three answers per declared plugin, never two:**
+**The declaration side is AIDD's own manifest, not `enabledPlugins`.** This is the
+correction that changes what the code compares. `mergeEnabledPlugins`
+(`marketplace-sync-settings-use-case.ts:413-417`) iterates `manifest.getPlugins(toolId)` and
+**skips silently, twice**: once when a plugin records no marketplace, once when its
+marketplace does not resolve. A plugin AIDD installed under either condition never reaches
+`enabledPlugins` at all — so comparing `enabledPlugins` against the registry would find both
+sides absent and call it agreement, while the plugin is installed and will never load. The
+manifest is what that loop reads *from*, and it carries `name` and an optional `marketplace`
+(`domain/models/plugin.ts:36`), which is exactly the `<plugin>@<marketplace>` ref.
+
+So there are **three surfaces, two hops**:
+
+```
+AIDD manifest  ──►  the project's enabledPlugins  ──►  the host's own registry
+   what AIDD           what the project                what the host will
+   installed            declares                       actually load
+```
+
+**Five answers per installed plugin, never fewer:**
 
 | Answer | Means |
 | --- | --- |
 | registered | the registry was read and carries the ref |
-| declared, not registered | the registry was read and does not carry it — the #703 failure, naming which of the two files lacks it |
-| unknown | the registry could not be read or parsed — absent file, permissions, JSONC |
+| registered, disabled | the registry carries it and records it off — Codex's `enabled = false` |
+| declared, not registered | the registry was read and lacks it, naming which file — the #703 failure |
+| not declared | the manifest has it and `enabledPlugins` does not, so the sync skipped it |
+| unanswerable | the ref cannot be built (no marketplace recorded), or the registry could not be read or parsed |
 
-The third is not a soft version of the second. A file that cannot be parsed and a file that
+The last is not a soft version of the third. A file that cannot be parsed and a file that
 says "no" are different facts, and printing them alike is the defect this ticket is about.
+`registered, disabled` earns its own row for the same reason: folding it into `registered`
+would report a plugin that will not load as one that will.
 
 ## Acceptance
 
 - [ ] The host's own registry is read, not only the declaration the CLI wrote.
 - [ ] `check` states whether the two agree and names the missing side — never a bare pass.
-- [ ] A registry that cannot be read reports as unknown, distinctly from one read and lacking
-      the entry. Asserted with a JSONC fixture, because that is a real file, not a hypothetical.
+- [ ] A registry that cannot be read reports as unanswerable, distinctly from one read and
+      lacking the entry. Asserted with a JSONC fixture — written from the shape recorded above,
+      never copied from the real file, which carries hashed experiment keys and machine paths.
+- [ ] The comparison starts from AIDD's own manifest, so a plugin the sync skipped is visible
+      rather than reading as agreement between two absences.
+- [ ] Codex's `config.toml` is line-scanned, not parsed, and the doc comment says why against
+      `hook-trust-reader-adapter.ts`'s own stated reason.
 - [ ] A test fails when the two surfaces disagree, driven **through**
       `marketplace-sync-settings-use-case.ts` — which has no test file today.
 - [ ] The whole comparison runs with no AI session, no network, no money, no binary on PATH.

--- a/aidd_docs/tasks/2026_09/2026_09_02_install-surfaces-agree/spec.md
+++ b/aidd_docs/tasks/2026_09/2026_09_02_install-surfaces-agree/spec.md
@@ -68,9 +68,8 @@ config.json               // comments, then { firstLaunchAt, installedPlugins: [
 3. **Codex records `enabled`, and it is the only key it records.** Every plugin table on the
    machine measured carries `enabled = true` and nothing else. So `enabled = false` is
    possible and unobserved — a state where the host knows the plugin and will still not load
-   it, which is not the same fact as an absent entry. (Counted 27 tables on 2026-09-02 and 23
-   the next day: the count moves with what is installed, so the doc states the invariant and
-   not the number.)
+   it, which is not the same fact as an absent entry. The count is deliberately not stated: it
+   moves with what happens to be installed, so it can carry no argument.
 4. **The architecture already exists.** `HookTrustReader` +
    `hook-trust-reader-adapter.ts` reads `~/.codex/config.toml` to answer one `check` claim,
    with the error handling this needs. What is built here is its sibling, not a new layer —

--- a/aidd_docs/tasks/2026_09/2026_09_02_install-surfaces-agree/spec.md
+++ b/aidd_docs/tasks/2026_09/2026_09_02_install-surfaces-agree/spec.md
@@ -40,7 +40,7 @@ Read to learn shape only. No value from any of these files enters a fixture.
 | --- | --- | --- | --- | --- |
 | Claude Code | `~/.claude/plugins/known_marketplaces.json`, `installed_plugins.json` | JSON | object keyed by name | `plugins`, keyed by `<plugin>@<marketplace>` |
 | Codex | `~/.codex/config.toml` | TOML | `[marketplaces.<name>]` | `[plugins."<plugin>@<marketplace>"]`, with `enabled` |
-| Copilot | `~/.copilot/config.json` | **JSONC** | — | `installedPlugins`, an array |
+| Copilot | `~/.copilot/settings.json` | JSON | `extraKnownMarketplaces` | `enabledPlugins`, `<plugin>@<marketplace>` to a boolean |
 
 Shapes, keys only:
 
@@ -53,10 +53,14 @@ config.json               // comments, then { firstLaunchAt, installedPlugins: [
 
 **Three findings that shape the design, not decoration:**
 
-1. **Copilot's file is JSONC.** It opens with two `//` comment lines, so `JSON.parse` throws
-   on it — verified, `SyntaxError: Unexpected token '/'`. A reader that let that throw fall
-   through as "no plugins registered" would print a zero where the honest answer is *unknown*.
-   This is the exact failure this layer exists to refuse, waiting in the first file it reads.
+1. **The file that looks like Copilot's registry is not it.** `~/.copilot/config.json` is
+   JSONC — it opens with two `//` comment lines, so `JSON.parse` throws, verified — and its
+   `installedPlugins` reads empty on a machine that has run installs. Both facts are true and
+   neither matters: driven live on 2026-09-03 against Copilot CLI 1.0.82 under a sandboxed
+   home, `plugin marketplace add` and `plugin install` write `~/.copilot/settings.json`.
+   `uninstall` sets the ref to `false` rather than deleting it, so registered-but-off is an
+   ordinary state there. The JSONC hazard stands on its own: a registry that parses as
+   nothing must read as *unknown*, never as "carries none".
 2. **`installed_plugins.json` binds a ref to a project.** Its `installPath` always points
    inside the plugins cache — but that is not the whole entry. Read across all 115 entries
    rather than the first one, they carry `projectPath` on 100 of them, exactly the 99 at

--- a/cli/src/application/display/telemetry-check-display.ts
+++ b/cli/src/application/display/telemetry-check-display.ts
@@ -6,6 +6,7 @@ import type {
 import type { TelemetryExportLeftover } from "../../domain/models/telemetry-export-leftover.js";
 import type {
   TelemetryAllowedSetup,
+  TelemetryHostRegistrationSetup,
   TelemetryIdentitySetup,
   TelemetryPluginVersionSetup,
   TelemetryRecorderDeclarationSetup,
@@ -97,6 +98,31 @@ function describePluginVersion(plugin: TelemetryPluginVersionSetup): string {
   );
 }
 
+/** The other half of `recorder declared`: whether the host will act on the declaration.
+ *
+ * One line per plugin rather than a single verdict, because the answer is genuinely per
+ * plugin and a rolled-up "some are not registered" is the kind of sentence a person cannot
+ * act on. Ordered so what a person must fix comes first: anything that will not load, then
+ * what nobody could ask about, then what is fine — a reader who stops after one line has
+ * still read the problem.
+ *
+ * `nothing installed` is a real, healthy answer and says so, rather than printing an empty
+ * block that reads like a failure to look. */
+function describeHostRegistration(registration: TelemetryHostRegistrationSetup): string {
+  const entries = registration.entries;
+  if (entries.length === 0) return "no plugin recorded for any tool";
+  const rank: Record<string, number> = {
+    "not-registered": 0,
+    "registered-disabled": 1,
+    unanswerable: 2,
+    registered: 3,
+  };
+  const ordered = [...entries].sort((a, b) => (rank[a.answer] ?? 9) - (rank[b.answer] ?? 9));
+  return ordered
+    .map((entry) => `\n    ${entry.tool}/${entry.plugin}: ${entry.answer} — ${entry.detail}`)
+    .join("");
+}
+
 function printSetup(output: CLIOutput, setup: TelemetrySetup): void {
   printSetupRow(output, "measurement allowed", describeAllowed(setup.allowed));
   printSetupRow(output, "identity attached", describeIdentity(setup.identity));
@@ -110,6 +136,7 @@ function printSetup(output: CLIOutput, setup: TelemetrySetup): void {
     "recorder declared",
     describeRecorderDeclaration(setup.recorderDeclaration)
   );
+  printSetupRow(output, "plugins registered", describeHostRegistration(setup.hostRegistration));
   printSetupRow(output, "cli version", setup.versions.cli);
   printSetupRow(output, "plugin version", describePluginVersion(setup.versions.plugin));
   output.print("");

--- a/cli/src/application/display/telemetry-check-display.ts
+++ b/cli/src/application/display/telemetry-check-display.ts
@@ -109,6 +109,9 @@ function describePluginVersion(plugin: TelemetryPluginVersionSetup): string {
  * `nothing installed` is a real, healthy answer and says so, rather than printing an empty
  * block that reads like a failure to look. */
 function describeHostRegistration(registration: TelemetryHostRegistrationSetup): string {
+  if (registration.manifestUnreadable !== undefined) {
+    return `AIDD's own manifest could not be read — ${registration.manifestUnreadable}`;
+  }
   const entries = registration.entries;
   if (entries.length === 0) return "no plugin recorded for any tool";
   const rank: Record<string, number> = {

--- a/cli/src/application/display/telemetry-check-display.ts
+++ b/cli/src/application/display/telemetry-check-display.ts
@@ -6,6 +6,7 @@ import type {
 import type { TelemetryExportLeftover } from "../../domain/models/telemetry-export-leftover.js";
 import type {
   TelemetryAllowedSetup,
+  TelemetryHostRegistrationAnswer,
   TelemetryHostRegistrationSetup,
   TelemetryIdentitySetup,
   TelemetryPluginVersionSetup,
@@ -114,13 +115,16 @@ function describeHostRegistration(registration: TelemetryHostRegistrationSetup):
   }
   const entries = registration.entries;
   if (entries.length === 0) return "no plugin recorded for any tool";
-  const rank: Record<string, number> = {
+  // Keyed on the answer type, not on `string`: a fifth answer then fails to compile here
+  // rather than sorting silently last, which is how a new "will not load" state would end up
+  // printed below the ones that are fine.
+  const rank: Record<TelemetryHostRegistrationAnswer, number> = {
     "not-registered": 0,
     "registered-disabled": 1,
     unanswerable: 2,
     registered: 3,
   };
-  const ordered = [...entries].sort((a, b) => (rank[a.answer] ?? 9) - (rank[b.answer] ?? 9));
+  const ordered = [...entries].sort((a, b) => rank[a.answer] - rank[b.answer]);
   return ordered
     .map((entry) => `\n    ${entry.tool}/${entry.plugin}: ${entry.answer} — ${entry.detail}`)
     .join("");

--- a/cli/src/application/display/telemetry-check-display.ts
+++ b/cli/src/application/display/telemetry-check-display.ts
@@ -125,9 +125,18 @@ function describeHostRegistration(registration: TelemetryHostRegistrationSetup):
     registered: 3,
   };
   const ordered = [...entries].sort((a, b) => rank[a.answer] - rank[b.answer]);
-  return ordered
-    .map((entry) => `\n    ${entry.tool}/${entry.plugin}: ${entry.answer} — ${entry.detail}`)
-    .join("");
+  // A sentence first, then the lines. Every other setup row leads with one, and a label
+  // followed by padding and a newline reads as a value the command failed to produce.
+  const trouble = ordered.filter((entry) => entry.answer !== "registered").length;
+  const headline =
+    trouble === 0
+      ? `all ${ordered.length} will load`
+      : `${trouble} of ${ordered.length} will not load, or could not be answered`;
+  return ordered.reduce(
+    (text, entry) =>
+      `${text}\n    ${entry.tool}/${entry.plugin}: ${entry.answer} — ${entry.detail}`,
+    headline
+  );
 }
 
 function printSetup(output: CLIOutput, setup: TelemetrySetup): void {

--- a/cli/src/application/use-cases/plugin/plugin-remove-use-case.ts
+++ b/cli/src/application/use-cases/plugin/plugin-remove-use-case.ts
@@ -15,14 +15,17 @@ import type { FileWriter } from "../../../domain/ports/file-writer.js";
 import type { Logger } from "../../../domain/ports/logger.js";
 import type { ManifestRepository } from "../../../domain/ports/manifest-repository.js";
 import type { NativePluginActivator } from "../../../domain/ports/native-plugin-activator.js";
-import { getToolConfig, isAiTool } from "../../../domain/tools/registry.js";
+import {
+  getToolConfig,
+  isAiTool,
+  resolvePluginsCapability,
+} from "../../../domain/tools/registry.js";
 import { loadPluginManifest } from "./plugin-file-sync.js";
 import {
   isFrameworkPrimeFlatMcp,
   resolvePluginBaseDir,
   resolvePluginToolIds,
 } from "./plugin-target-resolution.js";
-import { resolvePluginsCapability } from "./translator/project-hooks-materializer.js";
 
 export interface PluginRemoveOptions {
   pluginName: string;

--- a/cli/src/application/use-cases/plugin/translator/built-tree-materialization-translator.ts
+++ b/cli/src/application/use-cases/plugin/translator/built-tree-materialization-translator.ts
@@ -11,15 +11,13 @@ import type { FileReader } from "../../../../domain/ports/file-reader.js";
 import type { FileWriter } from "../../../../domain/ports/file-writer.js";
 import type { Hasher } from "../../../../domain/ports/hasher.js";
 import type { MarketplaceRegistry } from "../../../../domain/ports/marketplace-registry.js";
+import { resolvePluginsCapability } from "../../../../domain/tools/registry.js";
 import type { EnsureBuiltMarketplace } from "../../shared/ensure-built-marketplace-use-case.js";
 import { isPluginFileAtDesiredState } from "../plugin-file-sync.js";
 import { resolvePluginBaseDir } from "../plugin-target-resolution.js";
 import { ModeBFlatMaterializationTranslator } from "./mode-b-flat-materialization-translator.js";
 import type { PluginTranslator } from "./plugin-translator.js";
-import {
-  ProjectHooksMaterializer,
-  resolvePluginsCapability,
-} from "./project-hooks-materializer.js";
+import { ProjectHooksMaterializer } from "./project-hooks-materializer.js";
 
 /**
  * Materializes plugin content by copying the per-target BUILT tree verbatim into the

--- a/cli/src/application/use-cases/plugin/translator/project-hooks-materializer.ts
+++ b/cli/src/application/use-cases/plugin/translator/project-hooks-materializer.ts
@@ -1,5 +1,4 @@
 import { join } from "node:path";
-import type { PluginsCapability } from "../../../../domain/capabilities/plugins-capability.js";
 import {
   cursorProjectHooksScriptPath,
   mergeCursorProjectHooksJson,
@@ -15,11 +14,7 @@ import type {
 import type { AiToolId } from "../../../../domain/models/tool-ids.js";
 import type { FileReader } from "../../../../domain/ports/file-reader.js";
 import type { FileWriter } from "../../../../domain/ports/file-writer.js";
-import {
-  getToolConfig,
-  isAiTool,
-  resolvePluginsCapability,
-} from "../../../../domain/tools/registry.js";
+import { resolvePluginsCapability } from "../../../../domain/tools/registry.js";
 
 const HOOKS_MANIFEST_PATH = "hooks/hooks.json";
 

--- a/cli/src/application/use-cases/plugin/translator/project-hooks-materializer.ts
+++ b/cli/src/application/use-cases/plugin/translator/project-hooks-materializer.ts
@@ -15,7 +15,11 @@ import type {
 import type { AiToolId } from "../../../../domain/models/tool-ids.js";
 import type { FileReader } from "../../../../domain/ports/file-reader.js";
 import type { FileWriter } from "../../../../domain/ports/file-writer.js";
-import { getToolConfig, isAiTool } from "../../../../domain/tools/registry.js";
+import {
+  getToolConfig,
+  isAiTool,
+  resolvePluginsCapability,
+} from "../../../../domain/tools/registry.js";
 
 const HOOKS_MANIFEST_PATH = "hooks/hooks.json";
 
@@ -99,12 +103,4 @@ export function withoutHooks(dist: PluginDistribution): PluginDistribution {
     files: dist.files.filter((f) => f.relativePath.split("/")[0] !== "hooks"),
     components: { ...dist.components, hooks: [] },
   });
-}
-
-export function resolvePluginsCapability(toolId: AiToolId): PluginsCapability | null {
-  const toolConfig = getToolConfig(toolId);
-  if (!isAiTool(toolConfig)) return null;
-  const caps = toolConfig.capabilities as Record<string, unknown>;
-  if (!("plugins" in caps)) return null;
-  return caps.plugins as PluginsCapability;
 }

--- a/cli/src/application/use-cases/telemetry/diagnose-telemetry-use-case.ts
+++ b/cli/src/application/use-cases/telemetry/diagnose-telemetry-use-case.ts
@@ -30,6 +30,7 @@ import type { TelemetrySink } from "../../../domain/ports/telemetry-sink.js";
 import type { VersionControl } from "../../../domain/ports/version-control.js";
 import type { VersionReader } from "../../../domain/ports/version-reader.js";
 import { getAiToolConfig } from "../../../domain/tools/registry.js";
+import { resolvePluginsCapability } from "../plugin/translator/project-hooks-materializer.js";
 
 const DEFAULT_RUNS_DIR_LABEL = "aidd_docs/runs";
 
@@ -202,6 +203,7 @@ export class DiagnoseTelemetryUseCase {
           marketplace: plugin.marketplace,
         })),
         reading: await this.hostRegistries.get(tool)?.read(),
+        declaresNativeActivation: resolvePluginsCapability(tool)?.nativeActivation != null,
       }))
     );
     return buildHostRegistration(evidence.filter((entry) => entry.plugins.length > 0));

--- a/cli/src/application/use-cases/telemetry/diagnose-telemetry-use-case.ts
+++ b/cli/src/application/use-cases/telemetry/diagnose-telemetry-use-case.ts
@@ -1,3 +1,4 @@
+import { describeError } from "../../../domain/describe-error.js";
 import { resolveSessionAnchor } from "../../../domain/models/session-anchor.js";
 import { attributeMoment, buildStepIntervals } from "../../../domain/models/step-attribution.js";
 import {
@@ -161,7 +162,7 @@ export class DiagnoseTelemetryUseCase {
       identity: await this.readIdentitySetup(),
       recordsLocation: { path: this.telemetrySink.rootDir },
       recorderDeclaration,
-      hostRegistration: await this.readHostRegistration(),
+      hostRegistration: await this.readHostRegistration(options.projectRoot),
       versions: {
         cli: this.currentVersion.get(),
         plugin: pluginVersionFrom(await this.runJournalReader.list()),
@@ -180,7 +181,7 @@ export class DiagnoseTelemetryUseCase {
    * `buildHostRegistration` turns into `unanswerable` — never into agreement. A manifest
    * that cannot be loaded contributes nothing, the same normal state as a project with no
    * plugins installed. */
-  private async readHostRegistration(): Promise<TelemetryHostRegistrationSetup> {
+  private async readHostRegistration(projectRoot: string): Promise<TelemetryHostRegistrationSetup> {
     let manifest: Awaited<ReturnType<ManifestRepository["load"]>>;
     try {
       manifest = await this.manifestRepo.load();
@@ -188,25 +189,24 @@ export class DiagnoseTelemetryUseCase {
       // `Manifest`'s parser maps over fields it does not guard, so a damaged manifest throws
       // rather than returning null. Reported, never swallowed and never fatal: this is the
       // command a person runs precisely when something is wrong.
-      const shaped = error as { code?: string; message?: string };
-      return {
-        ...buildHostRegistration([]),
-        manifestUnreadable: shaped.code ?? shaped.message ?? String(error),
-      };
+      return { ...buildHostRegistration([]), manifestUnreadable: describeError(error) };
     }
     if (manifest === null) return buildHostRegistration([]);
     const evidence = await Promise.all(
-      AI_TOOL_IDS.map(async (tool) => ({
+      // Filtered before the read, never after: a tool with no plugin recorded contributes no
+      // entry, so opening its registry would be a home-directory read whose result is thrown
+      // away on every `check`.
+      AI_TOOL_IDS.filter((tool) => manifest.getPlugins(tool).length > 0).map(async (tool) => ({
         tool,
         plugins: manifest.getPlugins(tool).map((plugin) => ({
           name: plugin.name,
           marketplace: plugin.marketplace,
         })),
-        reading: await this.hostRegistries.get(tool)?.read(),
+        reading: await this.hostRegistries.get(tool)?.read(projectRoot),
         declaresNativeActivation: resolvePluginsCapability(tool)?.nativeActivation != null,
       }))
     );
-    return buildHostRegistration(evidence.filter((entry) => entry.plugins.length > 0));
+    return buildHostRegistration(evidence);
   }
 
   // `PersonIdentityStore.readStrict()` promises to throw on a damaged file, unlike the

--- a/cli/src/application/use-cases/telemetry/diagnose-telemetry-use-case.ts
+++ b/cli/src/application/use-cases/telemetry/diagnose-telemetry-use-case.ts
@@ -180,7 +180,19 @@ export class DiagnoseTelemetryUseCase {
    * that cannot be loaded contributes nothing, the same normal state as a project with no
    * plugins installed. */
   private async readHostRegistration(): Promise<TelemetryHostRegistrationSetup> {
-    const manifest = await this.manifestRepo.load();
+    let manifest: Awaited<ReturnType<ManifestRepository["load"]>>;
+    try {
+      manifest = await this.manifestRepo.load();
+    } catch (error) {
+      // `Manifest`'s parser maps over fields it does not guard, so a damaged manifest throws
+      // rather than returning null. Reported, never swallowed and never fatal: this is the
+      // command a person runs precisely when something is wrong.
+      const shaped = error as { code?: string; message?: string };
+      return {
+        ...buildHostRegistration([]),
+        manifestUnreadable: shaped.code ?? shaped.message ?? String(error),
+      };
+    }
     if (manifest === null) return buildHostRegistration([]);
     const evidence = await Promise.all(
       AI_TOOL_IDS.map(async (tool) => ({

--- a/cli/src/application/use-cases/telemetry/diagnose-telemetry-use-case.ts
+++ b/cli/src/application/use-cases/telemetry/diagnose-telemetry-use-case.ts
@@ -30,8 +30,7 @@ import type { TelemetryEvidenceReader } from "../../../domain/ports/telemetry-ev
 import type { TelemetrySink } from "../../../domain/ports/telemetry-sink.js";
 import type { VersionControl } from "../../../domain/ports/version-control.js";
 import type { VersionReader } from "../../../domain/ports/version-reader.js";
-import { getAiToolConfig } from "../../../domain/tools/registry.js";
-import { resolvePluginsCapability } from "../plugin/translator/project-hooks-materializer.js";
+import { getAiToolConfig, resolvePluginsCapability } from "../../../domain/tools/registry.js";
 
 const DEFAULT_RUNS_DIR_LABEL = "aidd_docs/runs";
 
@@ -189,7 +188,14 @@ export class DiagnoseTelemetryUseCase {
       // `Manifest`'s parser maps over fields it does not guard, so a damaged manifest throws
       // rather than returning null. Reported, never swallowed and never fatal: this is the
       // command a person runs precisely when something is wrong.
-      return { ...buildHostRegistration([]), manifestUnreadable: describeError(error) };
+      // Names the file, because the row directly above says `recorder declared: yes` about
+      // the same one: that row scans the raw JSON for a declaration while this goes through
+      // the manifest's own validation, so a file that parses but fails validation makes the
+      // two rows disagree. Naming it is what tells a person they are one file, read twice.
+      return {
+        ...buildHostRegistration([]),
+        manifestUnreadable: `${this.manifestRepo.path} — ${describeError(error)}`,
+      };
     }
     if (manifest === null) return buildHostRegistration([]);
     const evidence = await Promise.all(

--- a/cli/src/application/use-cases/telemetry/diagnose-telemetry-use-case.ts
+++ b/cli/src/application/use-cases/telemetry/diagnose-telemetry-use-case.ts
@@ -10,7 +10,9 @@ import {
 } from "../../../domain/models/telemetry-claim.js";
 import type { TelemetryExportLeftover } from "../../../domain/models/telemetry-export-leftover.js";
 import {
+  buildHostRegistration,
   buildTelemetryAllowedSetup,
+  type TelemetryHostRegistrationSetup,
   type TelemetryIdentitySetup,
   type TelemetryPluginVersionSetup,
   type TelemetryRecorderDeclarationSetup,
@@ -18,6 +20,8 @@ import {
 } from "../../../domain/models/telemetry-setup.js";
 import { AI_TOOL_IDS, type AiToolId } from "../../../domain/models/tool-ids.js";
 import type { HookTrustReader } from "../../../domain/ports/hook-trust-reader.js";
+import type { HostPluginRegistryReader } from "../../../domain/ports/host-plugin-registry-reader.js";
+import type { ManifestRepository } from "../../../domain/ports/manifest-repository.js";
 import type { PersonIdentityStore } from "../../../domain/ports/person-identity-store.js";
 import type { RunJournal, RunJournalReader } from "../../../domain/ports/run-journal-reader.js";
 import type { SessionCostReader } from "../../../domain/ports/session-cost-reader.js";
@@ -127,7 +131,9 @@ export class DiagnoseTelemetryUseCase {
     private readonly hookTrustReader: HookTrustReader,
     private readonly personIdentityStore: PersonIdentityStore,
     private readonly telemetrySink: TelemetrySink,
-    private readonly currentVersion: VersionReader
+    private readonly currentVersion: VersionReader,
+    private readonly manifestRepo: ManifestRepository,
+    private readonly hostRegistries: ReadonlyMap<AiToolId, HostPluginRegistryReader>
   ) {}
 
   async execute(options: DiagnoseTelemetryOptions): Promise<DiagnoseTelemetryResult> {
@@ -154,11 +160,39 @@ export class DiagnoseTelemetryUseCase {
       identity: await this.readIdentitySetup(),
       recordsLocation: { path: this.telemetrySink.rootDir },
       recorderDeclaration,
+      hostRegistration: await this.readHostRegistration(),
       versions: {
         cli: this.currentVersion.get(),
         plugin: pluginVersionFrom(await this.runJournalReader.list()),
       },
     };
+  }
+
+  /** Every plugin AIDD's own manifest records, against what each host's registry says.
+   *
+   * Driven from the manifest and never from a settings file: `mergeEnabledPlugins` skips a
+   * plugin silently when it records no marketplace or when that marketplace does not
+   * resolve, so a settings-first comparison would find both sides absent and read it as
+   * agreement while the plugin never loads.
+   *
+   * A tool with no reader in the map contributes its plugins with no reading at all, which
+   * `buildHostRegistration` turns into `unanswerable` — never into agreement. A manifest
+   * that cannot be loaded contributes nothing, the same normal state as a project with no
+   * plugins installed. */
+  private async readHostRegistration(): Promise<TelemetryHostRegistrationSetup> {
+    const manifest = await this.manifestRepo.load();
+    if (manifest === null) return buildHostRegistration([]);
+    const evidence = await Promise.all(
+      AI_TOOL_IDS.map(async (tool) => ({
+        tool,
+        plugins: manifest.getPlugins(tool).map((plugin) => ({
+          name: plugin.name,
+          marketplace: plugin.marketplace,
+        })),
+        reading: await this.hostRegistries.get(tool)?.read(),
+      }))
+    );
+    return buildHostRegistration(evidence.filter((entry) => entry.plugins.length > 0));
   }
 
   // `PersonIdentityStore.readStrict()` promises to throw on a damaged file, unlike the

--- a/cli/src/application/use-cases/telemetry/forget-telemetry-use-case.ts
+++ b/cli/src/application/use-cases/telemetry/forget-telemetry-use-case.ts
@@ -1,3 +1,4 @@
+import { errorMessage } from "../../../domain/describe-error.js";
 import { RUNS_ENTRY } from "../../../domain/models/paths.js";
 import type {
   TelemetryHistoryReading,
@@ -33,12 +34,6 @@ export interface TelemetryRemovalResult {
    * become reachable by having removed the rest, so this is the exact same reading, not a
    * fresh one. */
   readonly history: TelemetryHistoryReading;
-}
-
-// Local rather than `infrastructure/json-file.ts`'s `describeError`: this layer does not
-// import infrastructure, and `scripts/check-cli-layering.mjs` enforces it.
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
 }
 
 /**

--- a/cli/src/application/use-cases/telemetry/read-local-cost-use-case.ts
+++ b/cli/src/application/use-cases/telemetry/read-local-cost-use-case.ts
@@ -2,6 +2,7 @@ import type {
   TelemetryLocalRead,
   TelemetryLocalReadDeclared,
 } from "../../../domain/capabilities/telemetry-capability.js";
+import { errorMessage } from "../../../domain/describe-error.js";
 import {
   resolveSessionProject,
   type SessionProject,
@@ -280,12 +281,6 @@ function mergeToolReports(
   sessions: readonly LocalCostSessionReport[]
 ): readonly LocalCostToolReport[] {
   return AI_TOOL_IDS.map((tool) => mergeOneTool(tool, sessions));
-}
-
-// Local rather than `infrastructure/json-file.ts`'s `describeError`: this layer does not
-// import infrastructure, and the check at `scripts/check-cli-layering.mjs` enforces it.
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
 }
 
 const REFUSED_REASON =

--- a/cli/src/domain/describe-error.ts
+++ b/cli/src/domain/describe-error.ts
@@ -1,0 +1,24 @@
+/**
+ * The concise half of a failure, for a diagnostic line a person reads.
+ *
+ * A filesystem failure's `code` — `ENOENT`, `EACCES` — is the half that says what happened;
+ * `.message` on the same error restates the path the sentence around it already names. A
+ * parse failure carries no `code`, so it falls through to the message, which is where the
+ * useful half of a `SyntaxError` lives.
+ *
+ * In the domain rather than beside the adapters that raise these errors: a use case has to
+ * describe one too, and a use case may not import infrastructure. Pure, no I/O.
+ *
+ * Shared rather than copied. Three call sites had grown their own version of this rule and a
+ * fourth was inlined; this repository's norm is that a duplicate is either justified against
+ * its neighbour or removed, and none of the four had a reason the others did not. The one
+ * genuine exception stays where it is: `person-identity-adapter.ts` describes a JSON parse
+ * error alone and reads `.message` unconditionally, which is a different rule rather than a
+ * worse copy of this one.
+ */
+export function describeError(error: unknown): string {
+  if (error instanceof Error && "code" in error && typeof error.code === "string") {
+    return error.code;
+  }
+  return error instanceof Error ? error.message : String(error);
+}

--- a/cli/src/domain/describe-error.ts
+++ b/cli/src/domain/describe-error.ts
@@ -9,16 +9,33 @@
  * In the domain rather than beside the adapters that raise these errors: a use case has to
  * describe one too, and a use case may not import infrastructure. Pure, no I/O.
  *
- * Shared rather than copied. Three call sites had grown their own version of this rule and a
- * fourth was inlined; this repository's norm is that a duplicate is either justified against
- * its neighbour or removed, and none of the four had a reason the others did not. The one
- * genuine exception stays where it is: `person-identity-adapter.ts` describes a JSON parse
- * error alone and reads `.message` unconditionally, which is a different rule rather than a
- * worse copy of this one.
+ * Shared rather than copied. `hook-trust-reader-adapter.ts` carried this rule, the host
+ * registry reader grew a second copy of it, and the telemetry diagnostic inlined a third;
+ * this repository's norm is that a duplicate is either justified against its neighbour or
+ * removed, and none of the three had a reason the others did not.
+ *
+ * A different rule lives in `infrastructure/json-file.ts` and returns `.message` alone. That
+ * is not a worse copy of this one — it describes a JSON parse error, which carries no `code`
+ * worth preferring — and it stays where it is.
  */
 export function describeError(error: unknown): string {
   if (error instanceof Error && "code" in error && typeof error.code === "string") {
     return error.code;
   }
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * The message alone, for a failure whose `code` says nothing worth reading — a JSON parse
+ * error being the case that matters here, where the `SyntaxError`'s message is the whole
+ * answer and there is no `code` at all.
+ *
+ * Beside `describeError` rather than in a second module, because the two are one decision
+ * with two answers and a reader choosing between them should see both at once. Two call
+ * sites had each grown a byte-identical private copy, both justified by "this layer does not
+ * import infrastructure" — true when the only shared version lived there, and no longer a
+ * reason now that one lives here.
+ */
+export function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }

--- a/cli/src/domain/describe-error.ts
+++ b/cli/src/domain/describe-error.ts
@@ -14,9 +14,11 @@
  * this repository's norm is that a duplicate is either justified against its neighbour or
  * removed, and none of the three had a reason the others did not.
  *
- * A different rule lives in `infrastructure/json-file.ts` and returns `.message` alone. That
- * is not a worse copy of this one — it describes a JSON parse error, which carries no `code`
- * worth preferring — and it stays where it is.
+ * `infrastructure/json-file.ts` exported a `describeError` that was in fact this file's
+ * `errorMessage`, byte for byte. Two exported functions of one name with different
+ * behaviour is worse than either duplicate: an import chosen by autocomplete would have
+ * turned a JSON parse message into `ENOENT` with nothing to notice it. That copy is gone and
+ * its one caller imports `errorMessage` from here.
  */
 export function describeError(error: unknown): string {
   if (error instanceof Error && "code" in error && typeof error.code === "string") {

--- a/cli/src/domain/models/paths.ts
+++ b/cli/src/domain/models/paths.ts
@@ -42,3 +42,12 @@ export function pathContainsOrEquals(outer: string, inner: string): boolean {
 export function pathsOverlap(a: string, b: string): boolean {
   return pathContainsOrEquals(a, b) || pathContainsOrEquals(b, a);
 }
+
+/** The manifest's filename, in the domain because two adapters name that file and a
+ * diagnostic prints both. `telemetry-evidence-adapter.ts` scans it for a declaration while
+ * `manifest-repository-adapter.ts` loads and validates it, and `aidd telemetry check` prints
+ * a row from each — so a person reads two sentences about one file. They agreed by two
+ * matching literals until this existed, which is agreement by coincidence: renaming the file
+ * at one site would have made the rows contradict each other again, which is the defect that
+ * pairing was introduced to close. */
+export const MANIFEST_FILENAME = "manifest.json";

--- a/cli/src/domain/models/telemetry-setup.ts
+++ b/cli/src/domain/models/telemetry-setup.ts
@@ -239,6 +239,13 @@ export interface TelemetryHostRegistrationEvidence {
   readonly tool: AiToolId;
   readonly plugins: readonly { readonly name: string; readonly marketplace?: string }[];
   readonly reading?: HostPluginRegistryReading;
+  /** Whether the tool declares a native activation at all — it drives its own CLI to
+   * register a plugin, so a registry exists to be found. Carried because the two silences
+   * are different problems: a tool that declares none has no registry to read, while one
+   * that declares an activation and has no reader here has a registry nobody has measured.
+   * Telling a person the first when the second is true would send them looking for a file
+   * that does not exist. */
+  readonly declaresNativeActivation?: boolean;
 }
 
 /**
@@ -254,12 +261,13 @@ export function buildHostRegistration(
 ): TelemetryHostRegistrationSetup {
   const entries: TelemetryHostRegistrationEntry[] = [];
   const locationsChecked: string[] = [];
-  for (const { tool, plugins, reading } of evidence) {
+  for (const item of evidence) {
+    const { tool, plugins, reading } = item;
     if (reading !== undefined && !locationsChecked.includes(reading.location)) {
       locationsChecked.push(reading.location);
     }
     for (const plugin of plugins) {
-      entries.push(hostRegistrationEntry(tool, plugin, reading));
+      entries.push(hostRegistrationEntry(tool, plugin, reading, item.declaresNativeActivation));
     }
   }
   return { entries, locationsChecked };
@@ -268,7 +276,8 @@ export function buildHostRegistration(
 function hostRegistrationEntry(
   tool: AiToolId,
   plugin: { readonly name: string; readonly marketplace?: string },
-  reading: HostPluginRegistryReading | undefined
+  reading: HostPluginRegistryReading | undefined,
+  declaresNativeActivation: boolean | undefined
 ): TelemetryHostRegistrationEntry {
   // No marketplace recorded means no ref exists to look up — every measured host keys its
   // registry on `<plugin>@<marketplace>`, so this is unanswerable at the source rather than
@@ -282,21 +291,66 @@ function hostRegistrationEntry(
     };
   }
   const ref = `${plugin.name}@${plugin.marketplace}`;
-  return { tool, plugin: plugin.name, ref, ...askRegistry(tool, ref, reading) };
+  return {
+    tool,
+    plugin: plugin.name,
+    ref,
+    ...askRegistry(tool, ref, reading, declaresNativeActivation),
+  };
 }
 
 /** What one registry says about one ref, given the reading it produced. Split from the
  * entry it becomes so the two absences above — no ref to ask about, and no registry to ask
  * — stay visibly separate from the four answers a registry can give. */
+/** What one registry says about one ref. Split from the entry it becomes so the absences —
+ * no ref to ask about, and no registry that answered — stay visibly separate from the three
+ * answers a registry that did answer can give. */
 function askRegistry(
   tool: AiToolId,
   ref: string,
-  reading: HostPluginRegistryReading | undefined
+  reading: HostPluginRegistryReading | undefined,
+  declaresNativeActivation: boolean | undefined
 ): { answer: TelemetryHostRegistrationAnswer; detail: string } {
+  const answered = whatAnswered(tool, reading, declaresNativeActivation);
+  if ("detail" in answered) return answered;
+  const enabled = answered.refs.get(ref);
+  if (enabled === undefined) {
+    return {
+      answer: "not-registered",
+      detail: `${answered.location} does not carry ${ref} — ${tool} will drop the declaration as orphaned`,
+    };
+  }
+  if (!enabled) {
+    return {
+      answer: "registered-disabled",
+      detail: `${answered.location} carries ${ref} and records it disabled`,
+    };
+  }
+  return { answer: "registered", detail: answered.location };
+}
+
+/** Either the refs a registry actually produced, or the reason nothing did — returned as
+ * one value so the caller never has to re-narrow, and so no branch can reach a lookup
+ * against a registry that never opened.
+ *
+ * Three reasons, not one, because they send a person somewhere different: a tool that drives
+ * its own CLI keeps a registry somebody could go and measure, a tool that declares no native
+ * activation has none to look for at all, and a registry that was found and could not be
+ * read names the file and the failure. */
+function whatAnswered(
+  tool: AiToolId,
+  reading: HostPluginRegistryReading | undefined,
+  declaresNativeActivation: boolean | undefined
+):
+  | { readonly refs: ReadonlyMap<string, boolean>; readonly location: string }
+  | { readonly answer: TelemetryHostRegistrationAnswer; readonly detail: string } {
   if (reading === undefined) {
     return {
       answer: "unanswerable",
-      detail: `nothing here knows where ${tool} keeps its plugin registry`,
+      detail:
+        declaresNativeActivation === true
+          ? `${tool} keeps a plugin registry, and nothing here has established its shape`
+          : `${tool} declares no plugin registry to read`,
     };
   }
   if (reading.refs === undefined) {
@@ -305,18 +359,5 @@ function askRegistry(
       detail: `${reading.location} could not be read — ${reading.unreadable ?? "no reason given"}`,
     };
   }
-  const enabled = reading.refs.get(ref);
-  if (enabled === undefined) {
-    return {
-      answer: "not-registered",
-      detail: `${reading.location} does not carry ${ref} — ${tool} will drop the declaration as orphaned`,
-    };
-  }
-  if (!enabled) {
-    return {
-      answer: "registered-disabled",
-      detail: `${reading.location} carries ${ref} and records it disabled`,
-    };
-  }
-  return { answer: "registered", detail: reading.location };
+  return { refs: reading.refs, location: reading.location };
 }

--- a/cli/src/domain/models/telemetry-setup.ts
+++ b/cli/src/domain/models/telemetry-setup.ts
@@ -1,4 +1,6 @@
+import type { HostPluginRegistryReading } from "../ports/host-plugin-registry-reader.js";
 import { personRefusesTelemetry, TELEMETRY_REFUSAL_VARIABLE } from "./telemetry-switch.js";
+import type { AiToolId } from "./tool-ids.js";
 
 /**
  * What is already in place before `aidd telemetry check` grades whether anything
@@ -17,6 +19,7 @@ export interface TelemetrySetup {
   readonly identity: TelemetryIdentitySetup;
   readonly recordsLocation: TelemetryRecordsLocationSetup;
   readonly recorderDeclaration: TelemetryRecorderDeclarationSetup;
+  readonly hostRegistration: TelemetryHostRegistrationSetup;
   readonly versions: TelemetryVersionsSetup;
 }
 
@@ -122,9 +125,10 @@ export interface TelemetryRecordsLocationSetup {
  * enabled plugins, or a hooks block that invokes the recorder's own entry point directly
  * (Claude's nested `hooks` key, or Cursor's project-scope flat file — the marketplace
  * route is not the only one this build can see). A declaration is not proof the hook will
- * fire — see `claude-cli-adapter.ts`'s own measured case, where a declared entry is
- * silently dropped as orphaned when a headless run never registers the plugin — this fact
- * states only that a declaration was found, never that it works. */
+ * fire: a declared entry is silently dropped as orphaned when a host never registers the
+ * plugin in its own registry (`claude-cli-adapter.ts`'s measured case). This fact states
+ * only that a declaration was found; whether the host will act on it is
+ * `TelemetryHostRegistrationSetup`, directly below. */
 export interface TelemetryRecorderDeclarationSetup {
   readonly declared: boolean;
   /** Where it was found declared — non-empty exactly when `declared` is `true`. */
@@ -140,4 +144,169 @@ export interface TelemetryRecorderDeclarationSetup {
    * at one readable location is real regardless of what else could not be read, so a
    * consumer should only look at this when `declared` is `false`. */
   readonly unreadable: readonly string[];
+}
+
+/**
+ * Whether the host will actually load what AIDD installed — the other half of
+ * `TelemetryRecorderDeclarationSetup`, which answers only whether a declaration exists.
+ *
+ * Two facts, two different files, and #703 is the gap between them: a project's own
+ * settings can carry a perfectly good `enabledPlugins` entry while the host's registry
+ * knows nothing about it, at which point the host drops the entry as orphaned and every
+ * visible signal still says healthy. `claude --debug-file` says it in one line nobody
+ * passes the flag to see: `Skipping orphaned enabledPlugins entry …: marketplace not
+ * registered`.
+ *
+ * **Read from AIDD's own manifest, never from `enabledPlugins`.** That is not a
+ * preference: `mergeEnabledPlugins` iterates the manifest and skips silently twice — once
+ * for a plugin recording no marketplace, once for a marketplace that does not resolve
+ * (`marketplace-sync-settings-use-case.ts`). A plugin installed under either condition
+ * reaches no settings file at all, so comparing settings against a registry would find
+ * both sides absent and read it as agreement while the plugin never loads. The manifest is
+ * what that loop reads from, so it is what this reads from too.
+ *
+ * Costs no session, no network and no money: every fact here comes from files already on
+ * disk, which is what makes it answerable before a person has spent anything.
+ */
+export interface TelemetryHostRegistrationSetup {
+  /** One per plugin AIDD installed for a tool whose registration can be asked about at
+   * all. Empty when the manifest records no plugin, which is a normal state, not a fault. */
+  readonly entries: readonly TelemetryHostRegistrationEntry[];
+  /** Every registry location consulted, whatever each one answered, so a person can go and
+   * look at the same file this did. The same set regardless of the outcome, mirroring
+   * `TelemetryRecorderDeclarationSetup.locationsChecked`. */
+  readonly locationsChecked: readonly string[];
+}
+
+/**
+ * Four answers, and none of them collapses into another.
+ *
+ * `registered-disabled` is its own answer rather than a shade of `registered` because
+ * folding it in would report a plugin that will not load as one that will — Codex records
+ * `enabled` per plugin table and nothing else, so `enabled = false` is a host that knows
+ * the plugin and still declines it.
+ *
+ * `unanswerable` is its own answer rather than a shade of `not-registered` for the rule
+ * this whole layer is built on: an unknown is never a zero. A registry that cannot be read
+ * — absent, unreadable, or JSONC where JSON was expected — has said nothing, and printing
+ * that as "not registered" would invent a fact. Copilot's own `~/.copilot/config.json`
+ * opens with two `//` comment lines, so this is not hypothetical: a naive parse throws on
+ * the first registry a reader meets.
+ *
+ * **A fifth answer was designed and is not built here.** The plan distinguished a plugin
+ * the host does not carry from one that never reached the project's own `enabledPlugins`
+ * at all, which happens because `mergeEnabledPlugins` skips silently twice. Telling those
+ * apart needs the set of declared refs per tool, and `TelemetryEvidenceReader` exposes no
+ * accessor for it — `readRecorderDeclaration` looks for the recorder specifically, not for
+ * every declared key. Adding one is a port method, an adapter method and their tests, for a
+ * distinction between two flavours of the same outcome: the plugin will not load. The
+ * comparison here starts from the manifest, which is what made that distinction visible in
+ * the first place and is the half that matters; the second hop is named in #703's own
+ * thread rather than half-built. */
+export type TelemetryHostRegistrationAnswer =
+  | "registered"
+  | "registered-disabled"
+  | "not-registered"
+  | "unanswerable";
+
+export interface TelemetryHostRegistrationEntry {
+  readonly tool: AiToolId;
+  readonly plugin: string;
+  /** `<plugin>@<marketplace>`, the one string all three measured hosts key their registry
+   * on and the same string `enabledPlugins` uses. Absent exactly when the manifest records
+   * no marketplace for the plugin, which is the case no registry can be asked about. */
+  readonly ref?: string;
+  readonly answer: TelemetryHostRegistrationAnswer;
+  /** One sentence naming what was read and what it said, so the answer can be acted on
+   * rather than merely believed. */
+  readonly detail: string;
+}
+
+/** What one tool contributes to the comparison: the plugins AIDD's own manifest records for
+ * it, and what its registry answered — `undefined` when nothing here knows how to ask that
+ * host, which is a different fact from asking and getting nothing back. */
+export interface TelemetryHostRegistrationEvidence {
+  readonly tool: AiToolId;
+  readonly plugins: readonly { readonly name: string; readonly marketplace?: string }[];
+  readonly reading?: HostPluginRegistryReading;
+}
+
+/**
+ * The comparison itself: for every plugin AIDD installed, what the host's own registry says
+ * about it.
+ *
+ * Pure, and driven from the manifest rather than from any settings file, for the reason
+ * `TelemetryHostRegistrationSetup` states — a plugin the settings sync skipped would
+ * otherwise be absent from both sides and read as agreement.
+ */
+export function buildHostRegistration(
+  evidence: readonly TelemetryHostRegistrationEvidence[]
+): TelemetryHostRegistrationSetup {
+  const entries: TelemetryHostRegistrationEntry[] = [];
+  const locationsChecked: string[] = [];
+  for (const { tool, plugins, reading } of evidence) {
+    if (reading !== undefined && !locationsChecked.includes(reading.location)) {
+      locationsChecked.push(reading.location);
+    }
+    for (const plugin of plugins) {
+      entries.push(hostRegistrationEntry(tool, plugin, reading));
+    }
+  }
+  return { entries, locationsChecked };
+}
+
+function hostRegistrationEntry(
+  tool: AiToolId,
+  plugin: { readonly name: string; readonly marketplace?: string },
+  reading: HostPluginRegistryReading | undefined
+): TelemetryHostRegistrationEntry {
+  // No marketplace recorded means no ref exists to look up — every measured host keys its
+  // registry on `<plugin>@<marketplace>`, so this is unanswerable at the source rather than
+  // a lookup that failed.
+  if (plugin.marketplace === undefined || plugin.marketplace === "") {
+    return {
+      tool,
+      plugin: plugin.name,
+      answer: "unanswerable",
+      detail: "AIDD records no marketplace for it, so no host registry can be asked",
+    };
+  }
+  const ref = `${plugin.name}@${plugin.marketplace}`;
+  return { tool, plugin: plugin.name, ref, ...askRegistry(tool, ref, reading) };
+}
+
+/** What one registry says about one ref, given the reading it produced. Split from the
+ * entry it becomes so the two absences above — no ref to ask about, and no registry to ask
+ * — stay visibly separate from the four answers a registry can give. */
+function askRegistry(
+  tool: AiToolId,
+  ref: string,
+  reading: HostPluginRegistryReading | undefined
+): { answer: TelemetryHostRegistrationAnswer; detail: string } {
+  if (reading === undefined) {
+    return {
+      answer: "unanswerable",
+      detail: `nothing here knows where ${tool} keeps its plugin registry`,
+    };
+  }
+  if (reading.refs === undefined) {
+    return {
+      answer: "unanswerable",
+      detail: `${reading.location} could not be read — ${reading.unreadable ?? "no reason given"}`,
+    };
+  }
+  const enabled = reading.refs.get(ref);
+  if (enabled === undefined) {
+    return {
+      answer: "not-registered",
+      detail: `${reading.location} does not carry ${ref} — ${tool} will drop the declaration as orphaned`,
+    };
+  }
+  if (!enabled) {
+    return {
+      answer: "registered-disabled",
+      detail: `${reading.location} carries ${ref} and records it disabled`,
+    };
+  }
+  return { answer: "registered", detail: reading.location };
 }

--- a/cli/src/domain/models/telemetry-setup.ts
+++ b/cli/src/domain/models/telemetry-setup.ts
@@ -176,6 +176,16 @@ export interface TelemetryHostRegistrationSetup {
    * look at the same file this did. The same set regardless of the outcome, mirroring
    * `TelemetryRecorderDeclarationSetup.locationsChecked`. */
   readonly locationsChecked: readonly string[];
+  /** Why AIDD's own manifest could not be read, when it could not.
+   *
+   * Its own field rather than an absent-entries silence, and this is not defensive
+   * programming: `Manifest`'s parser reads `files.map(...)` on each tool without guarding
+   * the field, so a hand-edited or truncated `.aidd/manifest.json` throws a `TypeError`
+   * rather than returning null. Before this fact existed, `aidd telemetry check` never
+   * loaded the manifest at all — measuring it is what put that crash on the diagnostic's
+   * path, so the diagnostic is what has to survive it. A damaged manifest is exactly when a
+   * person runs `check`, and the one thing it must not do then is die. */
+  readonly manifestUnreadable?: string;
 }
 
 /**

--- a/cli/src/domain/models/telemetry-setup.ts
+++ b/cli/src/domain/models/telemetry-setup.ts
@@ -172,10 +172,6 @@ export interface TelemetryHostRegistrationSetup {
   /** One per plugin AIDD installed for a tool whose registration can be asked about at
    * all. Empty when the manifest records no plugin, which is a normal state, not a fault. */
   readonly entries: readonly TelemetryHostRegistrationEntry[];
-  /** Every registry location consulted, whatever each one answered, so a person can go and
-   * look at the same file this did. The same set regardless of the outcome, mirroring
-   * `TelemetryRecorderDeclarationSetup.locationsChecked`. */
-  readonly locationsChecked: readonly string[];
   /** Why AIDD's own manifest could not be read, when it could not.
    *
    * Its own field rather than an absent-entries silence, and this is not defensive
@@ -260,17 +256,13 @@ export function buildHostRegistration(
   evidence: readonly TelemetryHostRegistrationEvidence[]
 ): TelemetryHostRegistrationSetup {
   const entries: TelemetryHostRegistrationEntry[] = [];
-  const locationsChecked: string[] = [];
   for (const item of evidence) {
     const { tool, plugins, reading } = item;
-    if (reading !== undefined && !locationsChecked.includes(reading.location)) {
-      locationsChecked.push(reading.location);
-    }
     for (const plugin of plugins) {
       entries.push(hostRegistrationEntry(tool, plugin, reading, item.declaresNativeActivation));
     }
   }
-  return { entries, locationsChecked };
+  return { entries };
 }
 
 function hostRegistrationEntry(
@@ -302,9 +294,6 @@ function hostRegistrationEntry(
 /** What one registry says about one ref, given the reading it produced. Split from the
  * entry it becomes so the two absences above — no ref to ask about, and no registry to ask
  * — stay visibly separate from the four answers a registry can give. */
-/** What one registry says about one ref. Split from the entry it becomes so the absences —
- * no ref to ask about, and no registry that answered — stay visibly separate from the three
- * answers a registry that did answer can give. */
 function askRegistry(
   tool: AiToolId,
   ref: string,

--- a/cli/src/domain/ports/host-plugin-registry-reader.ts
+++ b/cli/src/domain/ports/host-plugin-registry-reader.ts
@@ -1,0 +1,35 @@
+/**
+ * What a host's own plugin registry says, read from the file that host maintains itself.
+ *
+ * A host loads a plugin only once it appears in its own user-global registry, whatever the
+ * project's settings declare. That is the asymmetry #703 is about: `aidd` writes a
+ * declaration, the host keeps a registry, and only the second one decides. Measured
+ * 2026-09-02 across the three hosts that declare a native activation — Claude Code, Codex
+ * and Copilot — all three key that registry on the same `<plugin>@<marketplace>` string
+ * `enabledPlugins` uses, so a reading is a set of refs whatever file it came out of.
+ *
+ * One implementation per host, because only the file and its parse differ; the shape below
+ * is the same for all of them, and a host with no implementation is simply not in the map
+ * the diagnostic consults — never assumed to agree.
+ */
+export interface HostPluginRegistryReading {
+  /** The file consulted, named whatever it answered, so a person can open the same one. */
+  readonly location: string;
+  /**
+   * Every ref the registry carries, mapped to whether the host records it as enabled.
+   *
+   * **Absent, never empty, when the registry could not be read.** An empty map is a real
+   * answer — the file opened and carries no plugin — and it must not be reachable from a
+   * file that never opened at all. Keeping the two apart in the type is what stops a
+   * caller inventing "not registered" out of a permissions error.
+   */
+  readonly refs?: ReadonlyMap<string, boolean>;
+  /** Why the registry could not be read, when it could not: absent, unreadable, or holding
+   * something this reader will not pretend to understand. Present exactly when `refs` is
+   * absent. */
+  readonly unreadable?: string;
+}
+
+export interface HostPluginRegistryReader {
+  read(): Promise<HostPluginRegistryReading>;
+}

--- a/cli/src/domain/ports/host-plugin-registry-reader.ts
+++ b/cli/src/domain/ports/host-plugin-registry-reader.ts
@@ -31,5 +31,9 @@ export interface HostPluginRegistryReading {
 }
 
 export interface HostPluginRegistryReader {
-  read(): Promise<HostPluginRegistryReading>;
+  /** `projectRoot` because a registry may bind a ref to one project rather than to the
+   * machine — Claude's does, on 100 of the 115 entries measured. A reader whose host records
+   * no such binding ignores it and says so in its own doc, rather than silently answering a
+   * narrower question than it was asked. */
+  read(projectRoot: string): Promise<HostPluginRegistryReading>;
 }

--- a/cli/src/domain/ports/manifest-repository.ts
+++ b/cli/src/domain/ports/manifest-repository.ts
@@ -1,6 +1,10 @@
 import type { Manifest } from "../models/manifest.js";
 
 export interface ManifestRepository {
+  /** Where the manifest lives, so a diagnostic can name the file it failed to read rather
+   * than report a failure a person cannot locate. Mirrors `PersonIdentityStore.filePath`
+   * and `TelemetrySink.rootDir`, which exist for the same reason. */
+  readonly path: string;
   load(): Promise<Manifest | null>;
   save(manifest: Manifest): Promise<void>;
   delete(): Promise<void>;

--- a/cli/src/domain/tools/registry.ts
+++ b/cli/src/domain/tools/registry.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+import type { PluginsCapability } from "../capabilities/plugins-capability.js";
 import {
   CategoryMismatchError,
   UnknownToolCategoryError,
@@ -99,4 +100,20 @@ export async function hasToolSignals(
     if (/^name:\s*['"]?aidd[_:]/m.test(content)) matches.push(join(config.signalDir, filePath));
   }
   return matches;
+}
+
+/**
+ * A tool's plugin capability, or `null` when it declares none.
+ *
+ * Here rather than beside one of its callers: it reads nothing but this registry, and its
+ * callers now span three of them — the plugin translators, plugin removal, and the telemetry
+ * diagnostic. A use case reaching into a hooks materializer to ask what a tool declares is a
+ * placement the layering gate happens to permit and the project's own rule does not.
+ */
+export function resolvePluginsCapability(toolId: AiToolId): PluginsCapability | null {
+  const toolConfig = getToolConfig(toolId);
+  if (!isAiTool(toolConfig)) return null;
+  const caps = toolConfig.capabilities as Record<string, unknown>;
+  if (!("plugins" in caps)) return null;
+  return caps.plugins as PluginsCapability;
 }

--- a/cli/src/infrastructure/adapters/hook-trust-reader-adapter.ts
+++ b/cli/src/infrastructure/adapters/hook-trust-reader-adapter.ts
@@ -1,5 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
+import { describeError } from "../../domain/describe-error.js";
 import type { TelemetryCodexHookTrust } from "../../domain/models/telemetry-claim.js";
 import type { HookTrustReader } from "../../domain/ports/hook-trust-reader.js";
 import { resolveHomeDir } from "../home-dir.js";
@@ -42,21 +43,6 @@ function parseHookTrust(content: string): { trusted: boolean } {
   const at = lines.findIndex((line) => line.startsWith(prefix) && line.endsWith(suffix));
   if (at === -1) return { trusted: false };
   return { trusted: /^trusted_hash\s*=/.test((lines[at + 1] ?? "").trim()) };
-}
-
-// `error.code || error.message`, the rule the deleted `hook-trust.cjs` read by: a
-// filesystem failure's `code`
-// (`ENOENT`, `EACCES`) is the concise, meaningful half - `.message` on the same error
-// restates the path this sentence already names, which is the mismatch phase 5's
-// confrontation caught once already for a sibling adapter's punctuation (measurements.md).
-// Not `person-identity-adapter.ts`'s own `describeError`: that one describes a JSON parse
-// error, which carries no `code` worth preferring, so it reads `.message` alone - a
-// different error kind, not a duplicate of this one.
-function describeError(error: unknown): string {
-  if (error instanceof Error && "code" in error && typeof error.code === "string") {
-    return error.code;
-  }
-  return error instanceof Error ? error.message : String(error);
 }
 
 export class HookTrustReaderAdapter implements HookTrustReader {

--- a/cli/src/infrastructure/adapters/host-plugin-registry-reader-adapter.ts
+++ b/cli/src/infrastructure/adapters/host-plugin-registry-reader-adapter.ts
@@ -97,7 +97,8 @@ class ClaudeInstalledPluginsReader implements HostPluginRegistryReader {
  * output to a terminal.
  *
  * The one shape it needs is the header Codex writes verbatim, `[plugins."<ref>"]`, and the
- * `enabled` line that follows it. `enabled = false` is carried through as `false` rather
+ * `enabled` key in the table under it. Line-scanning reads that shape wherever it appears,
+ * a string value included, which is why the first occurrence of a ref is the one kept. `enabled = false` is carried through as `false` rather
  * than dropped: a host that knows a plugin and declines it is not a host that never heard
  * of it, and the two must not print alike.
  */
@@ -194,7 +195,11 @@ function scanCodexPluginTables(content: string): ReadonlyMap<string, boolean> {
   for (const [index, line] of lines.entries()) {
     const header = CODEX_PLUGIN_HEADER.exec(line.trim());
     const ref = header?.[1];
-    if (ref === undefined) continue;
+    // First occurrence wins. TOML forbids defining a table twice, so a second line that
+    // looks like this header is necessarily not one — the likeliest source being a header
+    // spelled inside a multi-line string value. Last-write-wins would let that text
+    // override the real table's own `enabled`.
+    if (ref === undefined || refs.has(ref)) continue;
     refs.set(ref, enabledInTableBody(lines, index + 1));
   }
   return refs;

--- a/cli/src/infrastructure/adapters/host-plugin-registry-reader-adapter.ts
+++ b/cli/src/infrastructure/adapters/host-plugin-registry-reader-adapter.ts
@@ -20,14 +20,17 @@ import { resolveHomeDir } from "../home-dir.js";
  *   Codex        ~/.codex/config.toml                       [plugins."ref"] enabled = true
  *   Copilot      ~/.copilot/config.json                     JSONC, { …, installedPlugins: [] }
  *
- * **Copilot has no reader here, deliberately.** Its file is JSONC — it opens with two `//`
- * comment lines, so `JSON.parse` throws on it outright — and its `installedPlugins` read
- * empty on a machine that had run installs. One of those two facts alone would be a reason
- * to be careful; together they mean nobody has established that this array is the registry
- * a Copilot install writes to. Writing a reader against it would produce a confident
- * "not registered" from a file nobody has shown answers the question, which is the exact
- * defect this whole feature exists to remove. Copilot reads unanswerable until somebody
- * measures what its install actually writes.
+ * **Copilot's registry was measured on 2026-09-03, and it is not the file this once
+ * declined to read.** An earlier version refused Copilot because `~/.copilot/config.json` is
+ * JSONC and its `installedPlugins` read empty on a machine that had run installs. The
+ * instinct was right and the conclusion was wrong: that array is not the registry, and the
+ * registry is `~/.copilot/settings.json`. Driven live under a sandboxed home,
+ * `copilot plugin marketplace add <dir>` writes `extraKnownMarketplaces` and
+ * `copilot plugin install <plugin>@<marketplace>` writes
+ * `enabledPlugins: { "<plugin>@<marketplace>": true }` — plain JSON, no comments, and the
+ * same key every other host uses. `copilot plugin uninstall` sets that value to `false`
+ * rather than deleting the key, so a registered-but-off plugin is an ordinary state here,
+ * not a shape only Codex can produce.
  */
 export function hostPluginRegistryReaders(
   home: string = resolveHomeDir()
@@ -38,6 +41,7 @@ export function hostPluginRegistryReaders(
       new ClaudeInstalledPluginsReader(join(home, ".claude", "plugins", "installed_plugins.json")),
     ],
     ["codex", new CodexConfigPluginsReader(join(home, ".codex", "config.toml"))],
+    ["copilot", new CopilotSettingsPluginsReader(join(home, ".copilot", "settings.json"))],
   ]);
 }
 
@@ -116,6 +120,44 @@ class CodexConfigPluginsReader implements HostPluginRegistryReader {
       return { location: this.path, unreadable: describeError(error) };
     }
     return { location: this.path, refs: scanCodexPluginTables(content) };
+  }
+}
+
+/**
+ * Copilot's own registry: `enabledPlugins` in `~/.copilot/settings.json`, keyed on the same
+ * `<plugin>@<marketplace>` ref as every other host and carrying a boolean.
+ *
+ * The boolean is the whole of the difference from Claude's file. `copilot plugin uninstall`
+ * writes `false` and keeps the key, so a plugin the host knows and declines is a state a
+ * person reaches with one ordinary command — measured, not inferred.
+ *
+ * No project binding: the file records nothing but marketplaces and refs, so like Codex it
+ * answers for the machine and cannot answer for one project.
+ */
+class CopilotSettingsPluginsReader implements HostPluginRegistryReader {
+  constructor(private readonly path: string) {}
+
+  async read(_projectRoot: string): Promise<HostPluginRegistryReading> {
+    let content: string;
+    try {
+      content = await readFile(this.path, "utf8");
+    } catch (error) {
+      return { location: this.path, unreadable: describeError(error) };
+    }
+    try {
+      const parsed = JSON.parse(content) as { enabledPlugins?: Record<string, unknown> };
+      const enabled = parsed.enabledPlugins;
+      // Absent is a real answer here, unlike a file that would not open: Copilot writes the
+      // key on its first install, so a settings file without one belongs to somebody who has
+      // installed no plugin — which is "carries none", not "could not be read".
+      if (enabled === undefined) return { location: this.path, refs: new Map() };
+      return {
+        location: this.path,
+        refs: new Map(Object.entries(enabled).map(([ref, on]) => [ref, on !== false])),
+      };
+    } catch (error) {
+      return { location: this.path, unreadable: describeError(error) };
+    }
   }
 }
 

--- a/cli/src/infrastructure/adapters/host-plugin-registry-reader-adapter.ts
+++ b/cli/src/infrastructure/adapters/host-plugin-registry-reader-adapter.ts
@@ -1,0 +1,130 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { AiToolId } from "../../domain/models/tool-ids.js";
+import type {
+  HostPluginRegistryReader,
+  HostPluginRegistryReading,
+} from "../../domain/ports/host-plugin-registry-reader.js";
+import { resolveHomeDir } from "../home-dir.js";
+
+/**
+ * One reader per host whose own plugin registry was measured, keyed the way
+ * `DiagnoseTelemetryUseCase` already keys its cost readers: a tool absent from the map is
+ * a tool nothing here claims to know, and the diagnostic reports it unanswerable rather
+ * than assuming it agrees.
+ *
+ * Measured 2026-09-02 on the machine that built this, reading shape only:
+ *
+ *   Claude Code  ~/.claude/plugins/installed_plugins.json   { version, plugins: { ref: [ … ] } }
+ *   Codex        ~/.codex/config.toml                       [plugins."ref"] enabled = true
+ *   Copilot      ~/.copilot/config.json                     JSONC, { …, installedPlugins: [] }
+ *
+ * **Copilot has no reader here, deliberately.** Its file is JSONC — it opens with two `//`
+ * comment lines, so `JSON.parse` throws on it outright — and its `installedPlugins` read
+ * empty on a machine that had run installs. One of those two facts alone would be a reason
+ * to be careful; together they mean nobody has established that this array is the registry
+ * a Copilot install writes to. Writing a reader against it would produce a confident
+ * "not registered" from a file nobody has shown answers the question, which is the exact
+ * defect this whole feature exists to remove. Copilot reads unanswerable until somebody
+ * measures what its install actually writes.
+ */
+export function hostPluginRegistryReaders(
+  home: string = resolveHomeDir()
+): ReadonlyMap<AiToolId, HostPluginRegistryReader> {
+  return new Map<AiToolId, HostPluginRegistryReader>([
+    [
+      "claude",
+      new ClaudeInstalledPluginsReader(join(home, ".claude", "plugins", "installed_plugins.json")),
+    ],
+    ["codex", new CodexConfigPluginsReader(join(home, ".codex", "config.toml"))],
+  ]);
+}
+
+/** `error.code || error.message`, the rule `hook-trust-reader-adapter.ts` reads by and for
+ * its reason: a filesystem failure's `code` (`ENOENT`, `EACCES`) is the concise half, while
+ * `.message` restates the path the sentence around it already names. A parse failure has no
+ * `code` worth preferring, so it falls through to the message, which is where the useful
+ * half of a `SyntaxError` lives. */
+function describeError(error: unknown): string {
+  const shaped = error as { code?: string; message?: string };
+  return shaped.code ?? shaped.message ?? String(error);
+}
+
+/**
+ * Claude Code's own registry: a JSON document whose `plugins` object is keyed by the same
+ * `<plugin>@<marketplace>` ref `enabledPlugins` uses. Presence is the whole answer — the
+ * entries beneath a key record scope, install path and version, none of which decides
+ * whether the plugin loads, and Claude records no enabled flag at all. So every ref it
+ * carries maps to `true`.
+ */
+class ClaudeInstalledPluginsReader implements HostPluginRegistryReader {
+  constructor(private readonly path: string) {}
+
+  async read(): Promise<HostPluginRegistryReading> {
+    let content: string;
+    try {
+      content = await readFile(this.path, "utf8");
+    } catch (error) {
+      return { location: this.path, unreadable: describeError(error) };
+    }
+    try {
+      const parsed = JSON.parse(content) as { plugins?: Record<string, unknown> };
+      const plugins = parsed.plugins;
+      if (plugins === undefined || typeof plugins !== "object") {
+        return { location: this.path, unreadable: "no `plugins` object" };
+      }
+      return { location: this.path, refs: new Map(Object.keys(plugins).map((ref) => [ref, true])) };
+    } catch (error) {
+      return { location: this.path, unreadable: describeError(error) };
+    }
+  }
+}
+
+/**
+ * Codex's own registry, line-scanned rather than parsed — the choice
+ * `hook-trust-reader-adapter.ts` already made against this same file, for the reason it
+ * states: it *"carries arbitrary nested tables and multi-line values this adapter has no
+ * business understanding."* Concretely, the file measured is 26 KB and most of it is
+ * `[projects."<absolute path>"]` tables; parsing the whole document to read `[plugins.…]`
+ * would pull every project path on the machine into a process that then writes diagnostic
+ * output to a terminal.
+ *
+ * The one shape it needs is the header Codex writes verbatim, `[plugins."<ref>"]`, and the
+ * `enabled` line that follows it. `enabled = false` is carried through as `false` rather
+ * than dropped: a host that knows a plugin and declines it is not a host that never heard
+ * of it, and the two must not print alike.
+ */
+class CodexConfigPluginsReader implements HostPluginRegistryReader {
+  constructor(private readonly path: string) {}
+
+  async read(): Promise<HostPluginRegistryReading> {
+    let content: string;
+    try {
+      content = await readFile(this.path, "utf8");
+    } catch (error) {
+      return { location: this.path, unreadable: describeError(error) };
+    }
+    return { location: this.path, refs: scanCodexPluginTables(content) };
+  }
+}
+
+const CODEX_PLUGIN_HEADER = /^\[plugins\."(.+)"\]$/u;
+const CODEX_ENABLED_LINE = /^enabled\s*=\s*(true|false)$/u;
+
+/** Absent `enabled` reads as enabled: Codex writes the key on every table it creates (27 of
+ * 27 on the machine measured), so a table without one is a shape nobody has produced —
+ * and between "the host listed this plugin" and "the host listed it and said nothing", the
+ * listing is the fact. Only a literal `false` withholds it. */
+function scanCodexPluginTables(content: string): ReadonlyMap<string, boolean> {
+  const refs = new Map<string, boolean>();
+  const lines = content.split("\n");
+  for (const [index, line] of lines.entries()) {
+    const header = CODEX_PLUGIN_HEADER.exec(line.trim());
+    if (header === null) continue;
+    const ref = header[1];
+    if (ref === undefined) continue;
+    const enabled = CODEX_ENABLED_LINE.exec((lines[index + 1] ?? "").trim());
+    refs.set(ref, enabled === null ? true : enabled[1] === "true");
+  }
+  return refs;
+}

--- a/cli/src/infrastructure/adapters/host-plugin-registry-reader-adapter.ts
+++ b/cli/src/infrastructure/adapters/host-plugin-registry-reader-adapter.ts
@@ -161,6 +161,83 @@ class CopilotSettingsPluginsReader implements HostPluginRegistryReader {
   }
 }
 
+const CODEX_PLUGIN_HEADER = /^\[plugins\."(.+?)"\]\s*(?:#.*)?$/u;
+const CODEX_TABLE_HEADER = /^\[/u;
+const CODEX_ENABLED_LINE = /^enabled\s*=\s*(true|false)\s*(?:#.*)?$/u;
+const CODEX_MULTILINE_DELIMITER = /"""|'''/gu;
+
+/**
+ * Reads each plugin table's body, and only outside multi-line strings.
+ *
+ * Two defects were found here by running it rather than reading it, and both produced the
+ * inversion this whole feature exists to remove: a host that will not load a plugin,
+ * reported as one that will.
+ *
+ * The first took `lines[index + 1]` and called that "absent `enabled` reads as enabled". It
+ * meant "not on the immediately following line", so a blank line, a comment, a reordered key
+ * or a trailing comment each turned `enabled = false` into an enabled plugin.
+ *
+ * The second was the fix for the first. Keeping the first occurrence of a ref was justified
+ * by "TOML forbids defining a table twice, so a second line that looks like this header is
+ * necessarily not one" — which proves one of the two is fake and never which one. A header
+ * spelled inside a multi-line string BEFORE the real table therefore won, and a disabled
+ * plugin read as registered again, in the mirror image of what last-wins got wrong.
+ *
+ * Skipping multi-line strings is what makes the ordering rule true rather than asserted: a
+ * fake header is not seen at all, so the only header that can be taken is a real one, and
+ * TOML's own prohibition then guarantees there is exactly one of those.
+ *
+ * Absent `enabled` reads as enabled: Codex writes the key on every table it creates, so a
+ * table without one is a shape it does not produce, and between "the host listed this
+ * plugin" and "the host listed it and said nothing", the listing is the fact.
+ */
+function scanCodexPluginTables(content: string): ReadonlyMap<string, boolean> {
+  const refs = new Map<string, boolean>();
+  const lines = outsideMultilineStrings(content.split("\n"));
+  for (const [index, line] of lines.entries()) {
+    if (line === null) continue;
+    const ref = CODEX_PLUGIN_HEADER.exec(line.trim())?.[1];
+    if (ref === undefined || refs.has(ref)) continue;
+    refs.set(ref, enabledInTableBody(lines, index + 1));
+  }
+  return refs;
+}
+
+/**
+ * The same lines, with every one inside a multi-line string replaced by `null`.
+ *
+ * Positions are preserved rather than filtered out, so a table's body still begins at the
+ * line after its header. A delimiter can open and close on one line, so the number of
+ * delimiters on a line decides the state after it and an odd count is what flips it; the
+ * line carrying the opening delimiter is itself outside, which is right — that line is the
+ * assignment, not the content.
+ */
+function outsideMultilineStrings(lines: readonly string[]): readonly (string | null)[] {
+  let inside = false;
+  return lines.map((line) => {
+    const wasInside = inside;
+    const delimiters = line.match(CODEX_MULTILINE_DELIMITER)?.length ?? 0;
+    if (delimiters % 2 === 1) inside = !inside;
+    return wasInside ? null : line;
+  });
+}
+
+/** The first `enabled` assignment between a table header and the next table, defaulting to
+ * enabled when the table declares none. A line inside a multi-line string is `null` here and
+ * neither ends the table nor answers for it. */
+function enabledInTableBody(lines: readonly (string | null)[], from: number): boolean {
+  for (let at = from; at < lines.length; at += 1) {
+    const line = lines[at];
+    if (line === null || line === undefined) continue;
+    const trimmed = line.trim();
+    if (CODEX_TABLE_HEADER.test(trimmed)) return true;
+    if (trimmed === "" || trimmed.startsWith("#")) continue;
+    const enabled = CODEX_ENABLED_LINE.exec(trimmed);
+    if (enabled !== null) return enabled[1] === "true";
+  }
+  return true;
+}
+
 /** One installed-plugin entry, narrowed to the two fields that decide whether a ref counts
  * for the project being diagnosed. Everything else Claude records there — install path,
  * version, timestamps, commit sha — describes what was installed, never where it applies. */
@@ -204,58 +281,4 @@ async function resolvedPath(path: string): Promise<string> {
   } catch {
     return path;
   }
-}
-
-const CODEX_PLUGIN_HEADER = /^\[plugins\."(.+?)"\]\s*(?:#.*)?$/u;
-const CODEX_TABLE_HEADER = /^\[/u;
-const CODEX_ENABLED_LINE = /^enabled\s*=\s*(true|false)\s*(?:#.*)?$/u;
-
-/**
- * Reads each plugin table's **body**, not the single line after its header.
- *
- * The first version of this took `lines[index + 1]`, and its doc claimed that meant
- * "absent `enabled` reads as enabled". It did not: it meant "not on the immediately
- * following line". Run against six shapes TOML permits, four of them turned
- * `enabled = false` into an enabled plugin — a blank line, a comment line, a reordered key
- * ahead of `enabled`, and a trailing `# comment` on the `enabled` line itself — and a header
- * carrying its own trailing comment dropped the plugin entirely. Every one of those is the
- * exact inversion this feature exists to remove, reached by a file Codex is free to write
- * and a person is free to edit.
- *
- * So: on a header, walk to the next table (`[`), skipping blanks and comments, and take the
- * first `enabled` assignment found. Absent then genuinely means absent, which is what the
- * paragraph below is allowed to claim.
- *
- * Absent reads as enabled: Codex writes the key on every table it creates, so a table
- * without one is a shape it does not produce, and between "the host listed this plugin" and
- * "the host listed it and said nothing", the listing is the fact. Only a literal `false`
- * withholds it.
- */
-function scanCodexPluginTables(content: string): ReadonlyMap<string, boolean> {
-  const refs = new Map<string, boolean>();
-  const lines = content.split("\n");
-  for (const [index, line] of lines.entries()) {
-    const header = CODEX_PLUGIN_HEADER.exec(line.trim());
-    const ref = header?.[1];
-    // First occurrence wins. TOML forbids defining a table twice, so a second line that
-    // looks like this header is necessarily not one — the likeliest source being a header
-    // spelled inside a multi-line string value. Last-write-wins would let that text
-    // override the real table's own `enabled`.
-    if (ref === undefined || refs.has(ref)) continue;
-    refs.set(ref, enabledInTableBody(lines, index + 1));
-  }
-  return refs;
-}
-
-/** The first `enabled` assignment between a table header and the next table, defaulting to
- * enabled when the table declares none. */
-function enabledInTableBody(lines: readonly string[], from: number): boolean {
-  for (let at = from; at < lines.length; at += 1) {
-    const line = (lines[at] ?? "").trim();
-    if (CODEX_TABLE_HEADER.test(line)) return true;
-    if (line === "" || line.startsWith("#")) continue;
-    const enabled = CODEX_ENABLED_LINE.exec(line);
-    if (enabled !== null) return enabled[1] === "true";
-  }
-  return true;
 }

--- a/cli/src/infrastructure/adapters/host-plugin-registry-reader-adapter.ts
+++ b/cli/src/infrastructure/adapters/host-plugin-registry-reader-adapter.ts
@@ -1,5 +1,6 @@
-import { readFile } from "node:fs/promises";
+import { readFile, realpath } from "node:fs/promises";
 import { join } from "node:path";
+import { describeError } from "../../domain/describe-error.js";
 import type { AiToolId } from "../../domain/models/tool-ids.js";
 import type {
   HostPluginRegistryReader,
@@ -40,27 +41,28 @@ export function hostPluginRegistryReaders(
   ]);
 }
 
-/** `error.code || error.message`, the rule `hook-trust-reader-adapter.ts` reads by and for
- * its reason: a filesystem failure's `code` (`ENOENT`, `EACCES`) is the concise half, while
- * `.message` restates the path the sentence around it already names. A parse failure has no
- * `code` worth preferring, so it falls through to the message, which is where the useful
- * half of a `SyntaxError` lives. */
-function describeError(error: unknown): string {
-  const shaped = error as { code?: string; message?: string };
-  return shaped.code ?? shaped.message ?? String(error);
-}
-
 /**
  * Claude Code's own registry: a JSON document whose `plugins` object is keyed by the same
- * `<plugin>@<marketplace>` ref `enabledPlugins` uses. Presence is the whole answer — the
- * entries beneath a key record scope, install path and version, none of which decides
- * whether the plugin loads, and Claude records no enabled flag at all. So every ref it
- * carries maps to `true`.
+ * `<plugin>@<marketplace>` ref `enabledPlugins` uses, each key holding one entry per scope
+ * the ref was installed at.
+ *
+ * **Presence is not the whole answer, and an earlier version of this file said it was.**
+ * That claim came from reading the first entry of the first key and generalising; read
+ * across all 115 entries on the machine measured, they carry a seventh field the first one
+ * did not — `projectPath` — on 100 of them, exactly the 99 at `scope: "project"` plus the
+ * one at `"local"`. So the registry does say which project wants a ref, and `aidd` writes
+ * every one of them at project scope: `claude-cli-adapter.ts`'s own `PROJECT_SCOPE_ARGS`.
+ *
+ * Ignoring that would report a ref installed for another project as `registered` here, which
+ * is the same unmeasured confidence this file refuses to extend to Copilot a few lines up. A
+ * ref counts for this project when some entry is user-scoped — machine-wide by construction,
+ * and those carry no `projectPath` — or names this project. Claude records no enabled flag
+ * anywhere, so a ref that counts maps to `true`.
  */
 class ClaudeInstalledPluginsReader implements HostPluginRegistryReader {
   constructor(private readonly path: string) {}
 
-  async read(): Promise<HostPluginRegistryReading> {
+  async read(projectRoot: string): Promise<HostPluginRegistryReading> {
     let content: string;
     try {
       content = await readFile(this.path, "utf8");
@@ -68,12 +70,17 @@ class ClaudeInstalledPluginsReader implements HostPluginRegistryReader {
       return { location: this.path, unreadable: describeError(error) };
     }
     try {
-      const parsed = JSON.parse(content) as { plugins?: Record<string, unknown> };
+      const parsed = JSON.parse(content) as { plugins?: Record<string, ClaudeEntry[]> };
       const plugins = parsed.plugins;
       if (plugins === undefined || typeof plugins !== "object") {
         return { location: this.path, unreadable: "no `plugins` object" };
       }
-      return { location: this.path, refs: new Map(Object.keys(plugins).map((ref) => [ref, true])) };
+      const refs = new Map<string, boolean>();
+      const here = await resolvedPath(projectRoot);
+      for (const [ref, entries] of Object.entries(plugins)) {
+        if (await countsForProject(entries, here)) refs.set(ref, true);
+      }
+      return { location: this.path, refs };
     } catch (error) {
       return { location: this.path, unreadable: describeError(error) };
     }
@@ -97,7 +104,10 @@ class ClaudeInstalledPluginsReader implements HostPluginRegistryReader {
 class CodexConfigPluginsReader implements HostPluginRegistryReader {
   constructor(private readonly path: string) {}
 
-  async read(): Promise<HostPluginRegistryReading> {
+  // `projectRoot` is deliberately unused: Codex's plugin tables carry `enabled` and nothing
+  // else — no path, no scope — so its registry answers for the machine and cannot answer for
+  // one project. Said here rather than left to look like an oversight.
+  async read(_projectRoot: string): Promise<HostPluginRegistryReading> {
     let content: string;
     try {
       content = await readFile(this.path, "utf8");
@@ -108,23 +118,97 @@ class CodexConfigPluginsReader implements HostPluginRegistryReader {
   }
 }
 
-const CODEX_PLUGIN_HEADER = /^\[plugins\."(.+)"\]$/u;
-const CODEX_ENABLED_LINE = /^enabled\s*=\s*(true|false)$/u;
+/** One installed-plugin entry, narrowed to the two fields that decide whether a ref counts
+ * for the project being diagnosed. Everything else Claude records there — install path,
+ * version, timestamps, commit sha — describes what was installed, never where it applies. */
+interface ClaudeEntry {
+  readonly scope?: string;
+  readonly projectPath?: string;
+}
 
-/** Absent `enabled` reads as enabled: Codex writes the key on every table it creates (27 of
- * 27 on the machine measured), so a table without one is a shape nobody has produced —
- * and between "the host listed this plugin" and "the host listed it and said nothing", the
- * listing is the fact. Only a literal `false` withholds it. */
+/** A user-scoped entry applies everywhere and carries no `projectPath`; any other scope
+ * applies to the project it names. An entry with neither is not evidence of anything and is
+ * ignored rather than counted, which is the same refusal to guess the rest of this file
+ * makes. */
+async function countsForProject(
+  entries: readonly ClaudeEntry[],
+  projectRoot: string
+): Promise<boolean> {
+  if (!Array.isArray(entries)) return false;
+  for (const entry of entries) {
+    if (entry.scope === "user") return true;
+    if (entry.projectPath === undefined) continue;
+    if ((await resolvedPath(entry.projectPath)) === projectRoot) return true;
+  }
+  return false;
+}
+
+/**
+ * Both sides of the project comparison go through here, and this is not defensive tidying:
+ * an end-to-end run caught the string comparison failing on an ordinary macOS temp
+ * directory, where `/var` is a symlink to `/private/var`. Claude writes the path it resolved
+ * and the CLI holds the path it was invoked from; on any machine where one of them crosses a
+ * link, comparing the raw strings reports a registered plugin as missing.
+ *
+ * A path that cannot be resolved — most often because it no longer exists, which a stale
+ * registry entry naturally produces — falls back to itself rather than throwing: an entry
+ * for a deleted project should simply not match this one, not cost every other entry its
+ * answer.
+ */
+async function resolvedPath(path: string): Promise<string> {
+  try {
+    return await realpath(path);
+  } catch {
+    return path;
+  }
+}
+
+const CODEX_PLUGIN_HEADER = /^\[plugins\."(.+?)"\]\s*(?:#.*)?$/u;
+const CODEX_TABLE_HEADER = /^\[/u;
+const CODEX_ENABLED_LINE = /^enabled\s*=\s*(true|false)\s*(?:#.*)?$/u;
+
+/**
+ * Reads each plugin table's **body**, not the single line after its header.
+ *
+ * The first version of this took `lines[index + 1]`, and its doc claimed that meant
+ * "absent `enabled` reads as enabled". It did not: it meant "not on the immediately
+ * following line". Run against six shapes TOML permits, four of them turned
+ * `enabled = false` into an enabled plugin — a blank line, a comment line, a reordered key
+ * ahead of `enabled`, and a trailing `# comment` on the `enabled` line itself — and a header
+ * carrying its own trailing comment dropped the plugin entirely. Every one of those is the
+ * exact inversion this feature exists to remove, reached by a file Codex is free to write
+ * and a person is free to edit.
+ *
+ * So: on a header, walk to the next table (`[`), skipping blanks and comments, and take the
+ * first `enabled` assignment found. Absent then genuinely means absent, which is what the
+ * paragraph below is allowed to claim.
+ *
+ * Absent reads as enabled: Codex writes the key on every table it creates, so a table
+ * without one is a shape it does not produce, and between "the host listed this plugin" and
+ * "the host listed it and said nothing", the listing is the fact. Only a literal `false`
+ * withholds it.
+ */
 function scanCodexPluginTables(content: string): ReadonlyMap<string, boolean> {
   const refs = new Map<string, boolean>();
   const lines = content.split("\n");
   for (const [index, line] of lines.entries()) {
     const header = CODEX_PLUGIN_HEADER.exec(line.trim());
-    if (header === null) continue;
-    const ref = header[1];
+    const ref = header?.[1];
     if (ref === undefined) continue;
-    const enabled = CODEX_ENABLED_LINE.exec((lines[index + 1] ?? "").trim());
-    refs.set(ref, enabled === null ? true : enabled[1] === "true");
+    refs.set(ref, enabledInTableBody(lines, index + 1));
   }
   return refs;
+}
+
+/** The first `enabled` assignment between a table header and the next table, defaulting to
+ * enabled when the table declares none. */
+function enabledInTableBody(lines: readonly string[], from: number): boolean {
+  for (let at = from; at < lines.length; at += 1) {
+    const line = (lines[at] ?? "").trim();
+    if (CODEX_TABLE_HEADER.test(line)) return true;
+    if (line === "" || line.startsWith("#")) continue;
+    const enabled = CODEX_ENABLED_LINE.exec(line);
+    if (enabled !== null) return enabled[1] === "true";
+  }
+  return true;
 }

--- a/cli/src/infrastructure/adapters/manifest-repository-adapter.ts
+++ b/cli/src/infrastructure/adapters/manifest-repository-adapter.ts
@@ -9,8 +9,12 @@ const MANIFEST_FILENAME = "manifest.json";
 export class ManifestRepositoryAdapter implements ManifestRepository {
   constructor(private readonly projectRoot: string) {}
 
-  private get manifestPath(): string {
+  get path(): string {
     return join(this.projectRoot, AIDD_DIR, MANIFEST_FILENAME);
+  }
+
+  private get manifestPath(): string {
+    return this.path;
   }
 
   private get aiddDir(): string {

--- a/cli/src/infrastructure/adapters/manifest-repository-adapter.ts
+++ b/cli/src/infrastructure/adapters/manifest-repository-adapter.ts
@@ -1,20 +1,14 @@
 import { mkdir, readdir, readFile, rm, rmdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { Manifest } from "../../domain/models/manifest.js";
-import { AIDD_DIR } from "../../domain/models/paths.js";
+import { AIDD_DIR, MANIFEST_FILENAME } from "../../domain/models/paths.js";
 import type { ManifestRepository } from "../../domain/ports/manifest-repository.js";
-
-const MANIFEST_FILENAME = "manifest.json";
 
 export class ManifestRepositoryAdapter implements ManifestRepository {
   constructor(private readonly projectRoot: string) {}
 
   get path(): string {
     return join(this.projectRoot, AIDD_DIR, MANIFEST_FILENAME);
-  }
-
-  private get manifestPath(): string {
-    return this.path;
   }
 
   private get aiddDir(): string {
@@ -24,7 +18,7 @@ export class ManifestRepositoryAdapter implements ManifestRepository {
   async load(): Promise<Manifest | null> {
     let raw: string;
     try {
-      raw = await readFile(this.manifestPath, "utf-8");
+      raw = await readFile(this.path, "utf-8");
     } catch {
       return null;
     }
@@ -35,12 +29,12 @@ export class ManifestRepositoryAdapter implements ManifestRepository {
   async save(manifest: Manifest): Promise<void> {
     await mkdir(this.aiddDir, { recursive: true });
     const json = JSON.stringify(manifest.toJSON(), null, 2);
-    await writeFile(this.manifestPath, json, "utf-8");
+    await writeFile(this.path, json, "utf-8");
   }
 
   async delete(): Promise<void> {
     try {
-      await rm(this.manifestPath, { force: true });
+      await rm(this.path, { force: true });
     } catch {
       // No error if missing
     }

--- a/cli/src/infrastructure/adapters/person-identity-adapter.ts
+++ b/cli/src/infrastructure/adapters/person-identity-adapter.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
+import { errorMessage } from "../../domain/describe-error.js";
 import { UnreadableIdentityFileError } from "../../domain/errors.js";
 import {
   withAlsoMeAdded,
@@ -11,7 +12,7 @@ import type { PersonIdentity } from "../../domain/ports/person-identity-reader.j
 import type { PersonIdentityStore } from "../../domain/ports/person-identity-store.js";
 import { IdentityWriteError } from "../errors.js";
 import { resolveAiddConfigDir } from "../home-dir.js";
-import { asPlainObject, describeError, isErrnoException } from "../json-file.js";
+import { asPlainObject, isErrnoException } from "../json-file.js";
 
 const PRIVATE_FILE_MODE = 0o600;
 const PRIVATE_DIR_MODE = 0o700;
@@ -80,7 +81,7 @@ export class PersonIdentityAdapter implements PersonIdentityStore {
     try {
       return parseIdentity(raw);
     } catch (error) {
-      throw new UnreadableIdentityFileError(this.filePath, describeError(error));
+      throw new UnreadableIdentityFileError(this.filePath, errorMessage(error));
     }
   }
 
@@ -150,7 +151,7 @@ export class PersonIdentityAdapter implements PersonIdentityStore {
       return await readFile(this.filePath, "utf8");
     } catch (error) {
       if (isErrnoException(error) && error.code === "ENOENT") return null;
-      throw new UnreadableIdentityFileError(this.filePath, describeError(error));
+      throw new UnreadableIdentityFileError(this.filePath, errorMessage(error));
     }
   }
 

--- a/cli/src/infrastructure/adapters/telemetry-evidence-adapter.ts
+++ b/cli/src/infrastructure/adapters/telemetry-evidence-adapter.ts
@@ -6,7 +6,7 @@ import { hookCommandsForEvent } from "../../domain/formats/flat-hooks-merge.js";
 import { genericFlatHooksScriptPath } from "../../domain/formats/flat-paths.js";
 import { asPlainObject } from "../../domain/formats/plain-object.js";
 import { CLAUDE_PLUGIN_ROOT_TOKEN } from "../../domain/formats/plugin-root-token-rewrite.js";
-import { AIDD_DIR } from "../../domain/models/paths.js";
+import { AIDD_DIR, MANIFEST_FILENAME } from "../../domain/models/paths.js";
 import {
   findLeftoverExportKeys,
   type TelemetryExportLeftover,
@@ -31,7 +31,6 @@ import {
 } from "./hook-trust-reader-adapter.js";
 
 const UNRECOGNISED_FILE_NAME = "_unrecognised.jsonl";
-const MANIFEST_FILENAME = "manifest.json";
 
 function runsDir(projectRoot: string): string {
   return process.env.AIDD_RUNS_DIR || join(projectRoot, "aidd_docs", "runs");

--- a/cli/src/infrastructure/deps.ts
+++ b/cli/src/infrastructure/deps.ts
@@ -132,6 +132,7 @@ import { GitHubRawFetcherAdapter } from "./adapters/github-raw-fetcher-adapter.j
 import { GitHubReleaseResolverAdapter } from "./adapters/github-release-resolver-adapter.js";
 import { HasherAdapter } from "./adapters/hasher-adapter.js";
 import { HookTrustReaderAdapter } from "./adapters/hook-trust-reader-adapter.js";
+import { hostPluginRegistryReaders } from "./adapters/host-plugin-registry-reader-adapter.js";
 import { ManifestRepositoryAdapter } from "./adapters/manifest-repository-adapter.js";
 import { MarketplaceCacheAdapter } from "./adapters/marketplace-cache-adapter.js";
 import { MarketplaceRegistryAdapter } from "./adapters/marketplace-registry-adapter.js";
@@ -758,7 +759,9 @@ export async function createDeps(
     hookTrustReaderAdapter,
     personIdentityAdapter,
     telemetrySink,
-    currentVersionProvider
+    currentVersionProvider,
+    manifestRepo,
+    hostPluginRegistryReaders()
   );
   const reportCostUseCase = new ReportCostUseCase(
     telemetrySink,

--- a/cli/src/infrastructure/json-file.ts
+++ b/cli/src/infrastructure/json-file.ts
@@ -18,7 +18,3 @@ export function asPlainObject(value: unknown): Record<string, unknown> {
 export function isErrnoException(error: unknown): error is NodeJS.ErrnoException {
   return error instanceof Error && "code" in error;
 }
-
-export function describeError(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}

--- a/cli/tests/application/display/telemetry-check-display.unit.test.ts
+++ b/cli/tests/application/display/telemetry-check-display.unit.test.ts
@@ -35,6 +35,7 @@ function setup(overrides: Partial<TelemetrySetup> = {}): TelemetrySetup {
     },
     identity: { attached: false, path: "/home/.config/aidd/identity.json", readable: true },
     recordsLocation: { path: "/home/.config/aidd/telemetry" },
+    hostRegistration: { entries: [], locationsChecked: [] },
     recorderDeclaration: {
       declared: true,
       declaredAt: ["/repo/.aidd/manifest.json"],

--- a/cli/tests/application/display/telemetry-check-display.unit.test.ts
+++ b/cli/tests/application/display/telemetry-check-display.unit.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { printTelemetryCheckReport } from "../../../src/application/display/telemetry-check-display.js";
 import { CLIOutput } from "../../../src/application/output.js";
-import type { TelemetrySetup } from "../../../src/domain/models/telemetry-setup.js";
+import type {
+  TelemetryHostRegistrationEntry,
+  TelemetrySetup,
+} from "../../../src/domain/models/telemetry-setup.js";
 
 /**
  * `aidd telemetry check` exists to send a person to the right place when nothing is being
@@ -35,7 +38,7 @@ function setup(overrides: Partial<TelemetrySetup> = {}): TelemetrySetup {
     },
     identity: { attached: false, path: "/home/.config/aidd/identity.json", readable: true },
     recordsLocation: { path: "/home/.config/aidd/telemetry" },
-    hostRegistration: { entries: [], locationsChecked: [] },
+    hostRegistration: { entries: [] },
     recorderDeclaration: {
       declared: true,
       declaredAt: ["/repo/.aidd/manifest.json"],
@@ -118,7 +121,7 @@ describe("the setup a person reads before any claim", () => {
         recorderDeclaration: {
           declared: false,
           declaredAt: [],
-          locationsChecked: ["/repo/.aidd/manifest.json"],
+          locationsChecked: [],
           unreadable: ["/repo/.aidd/manifest.json"],
         },
       }),
@@ -219,5 +222,78 @@ describe("the claims, and what is deliberately not one", () => {
       expect(output.warnings.join("\n")).toContain("OTEL_EXPORTER_OTLP_ENDPOINT");
       expect(output.text).not.toContain("OTEL_EXPORTER_OTLP_ENDPOINT");
     }
+  });
+});
+
+describe("the row saying whether the host will load what aidd installed", () => {
+  function report(hostRegistration: TelemetrySetup["hostRegistration"]): string {
+    const output = new CapturingOutput();
+    printTelemetryCheckReport(output, {
+      gate: "measurement is off",
+      setup: setup({ hostRegistration }),
+      leftoverExportConfig: [],
+    });
+    return output.text;
+  }
+
+  const REGISTRY = "/home/dev/.claude/plugins/installed_plugins.json";
+
+  function entry(
+    answer: TelemetryHostRegistrationEntry["answer"],
+    plugin: string
+  ): TelemetryHostRegistrationEntry {
+    return { tool: "claude", plugin, answer, detail: REGISTRY };
+  }
+
+  // The one thing a person must not miss is what will not load. A reader who stops after the
+  // first line has still read the problem.
+  it("puts what will not load above what is fine", () => {
+    const text = report({
+      entries: [entry("registered", "fine"), entry("not-registered", "broken")],
+    });
+
+    expect(text.indexOf("broken")).toBeLessThan(text.indexOf("fine"));
+  });
+
+  it("orders a disabled registration and an unanswerable one between the two", () => {
+    const text = report({
+      entries: [
+        entry("registered", "fine"),
+        entry("unanswerable", "unknown"),
+        entry("registered-disabled", "off"),
+        entry("not-registered", "broken"),
+      ],
+    });
+    const at = (plugin: string) => text.indexOf(plugin);
+
+    expect(at("broken")).toBeLessThan(at("off"));
+    expect(at("off")).toBeLessThan(at("unknown"));
+    expect(at("unknown")).toBeLessThan(at("fine"));
+  });
+
+  it("names the answer and the detail on each line, never a bare pass", () => {
+    const text = report({
+      entries: [{ ...entry("not-registered", "aidd-telemetry"), detail: "does not carry it" }],
+    });
+
+    expect(text).toContain("claude/aidd-telemetry: not-registered — does not carry it");
+  });
+
+  // A project with nothing installed is healthy, and an empty block would read as a failure
+  // to look rather than as an answer.
+  it("says a project has no plugin recorded rather than printing nothing", () => {
+    expect(report({ entries: [] })).toContain("no plugin recorded for any tool");
+  });
+
+  // The crash guard, made visible: a manifest that cannot be parsed is its own sentence, and
+  // must never print as the empty case above — one is damage, the other is a normal state.
+  it("says the manifest could not be read, distinctly from having nothing installed", () => {
+    const text = report({
+      entries: [],
+      manifestUnreadable: "Cannot read properties of undefined (reading 'map')",
+    });
+
+    expect(text).toContain("AIDD's own manifest could not be read");
+    expect(text).not.toContain("no plugin recorded");
   });
 });

--- a/cli/tests/application/use-cases/doctor-plugin.unit.test.ts
+++ b/cli/tests/application/use-cases/doctor-plugin.unit.test.ts
@@ -49,7 +49,7 @@ function makeFs(fileExists: boolean, diskHash: string): FileReader {
 
 function makeManifestRepo(manifest: Manifest): ManifestRepository {
   return {
-    path: "/test-project/.aidd/manifest.json",
+    path: "/proj/.aidd/manifest.json",
     load: async () => manifest,
     save: async () => {},
     delete: async () => {},

--- a/cli/tests/application/use-cases/doctor-plugin.unit.test.ts
+++ b/cli/tests/application/use-cases/doctor-plugin.unit.test.ts
@@ -48,7 +48,12 @@ function makeFs(fileExists: boolean, diskHash: string): FileReader {
 }
 
 function makeManifestRepo(manifest: Manifest): ManifestRepository {
-  return { load: async () => manifest, save: async () => {}, delete: async () => {} };
+  return {
+    path: "/test-project/.aidd/manifest.json",
+    load: async () => manifest,
+    save: async () => {},
+    delete: async () => {},
+  };
 }
 
 const noopHasher: Hasher = {

--- a/cli/tests/application/use-cases/marketplace/marketplace-sync-native-activation.integration.test.ts
+++ b/cli/tests/application/use-cases/marketplace/marketplace-sync-native-activation.integration.test.ts
@@ -47,7 +47,7 @@ function marketplace(): Marketplace {
   });
 }
 
-function manifestWithPlugin(): InMemoryManifestRepository {
+function manifestWithPlugin(marketplace: string = MARKETPLACE): InMemoryManifestRepository {
   const manifest = Manifest.create();
   manifest.addTool("claude", "test", []);
   manifest.addPlugin(
@@ -57,19 +57,19 @@ function manifestWithPlugin(): InMemoryManifestRepository {
       "1.0.0",
       { kind: "github", repo: "ai-driven-dev/framework" },
       true,
-      MARKETPLACE
+      marketplace
     )
   );
   return new InMemoryManifestRepository(manifest);
 }
 
-function buildSync(activator: FakeNativePluginActivator) {
+function buildSync(activator: FakeNativePluginActivator, pluginMarketplace?: string) {
   const registry = new InMemoryMarketplaceRegistry();
   return {
     registry,
     useCase: new MarketplaceSyncSettingsUseCase(
       new InMemoryFileAdapter(),
-      manifestWithPlugin(),
+      manifestWithPlugin(pluginMarketplace),
       registry,
       NO_CATALOG,
       new DeterministicHasher(),
@@ -111,5 +111,35 @@ describe("syncing settings registers the plugin with the host's own CLI", () => 
     await useCase.execute({ projectRoot: PROJECT_ROOT });
 
     expect(activator.enabledPlugins).toEqual([]);
+  });
+
+  /**
+   * The half of the disagreement the contract argues hardest for, and the reason the
+   * comparison starts from the manifest rather than from a settings file.
+   *
+   * `mergeEnabledPlugins` skips a plugin whose marketplace does not resolve — silently,
+   * with a bare `continue`. So this plugin reaches no settings file and no host CLI, while
+   * AIDD's own manifest says it is installed. A diagnostic reading settings against a
+   * registry would find both sides absent and call that agreement; reading the manifest
+   * against the registry is what makes it visible.
+   */
+  it("registers nothing for a plugin whose marketplace does not resolve, and says nothing about it", async () => {
+    const activator = new FakeNativePluginActivator({ available: true });
+    const { useCase, registry } = buildSync(activator, "a-marketplace-nobody-added");
+    await registry.save(PROJECT_ROOT, marketplace());
+
+    await useCase.execute({ projectRoot: PROJECT_ROOT });
+
+    expect(activator.enabledPlugins).toEqual([]);
+    // And the manifest still carries it, which is the only place it can now be seen from.
+    const entry = buildHostRegistration([
+      {
+        tool: "claude",
+        plugins: [{ name: PLUGIN, marketplace: "a-marketplace-nobody-added" }],
+        reading: { location: "/registry", refs: new Map() },
+      },
+    ]).entries[0];
+
+    expect(entry?.answer).toBe("not-registered");
   });
 });

--- a/cli/tests/application/use-cases/marketplace/marketplace-sync-native-activation.integration.test.ts
+++ b/cli/tests/application/use-cases/marketplace/marketplace-sync-native-activation.integration.test.ts
@@ -1,0 +1,115 @@
+import "../../../../src/domain/tools/ai/claude.js";
+import { describe, expect, it } from "vitest";
+import { MarketplaceSyncSettingsUseCase } from "../../../../src/application/use-cases/marketplace/marketplace-sync-settings-use-case.js";
+import { Manifest } from "../../../../src/domain/models/manifest.js";
+import { Marketplace } from "../../../../src/domain/models/marketplace.js";
+import { Plugin } from "../../../../src/domain/models/plugin.js";
+import { buildHostRegistration } from "../../../../src/domain/models/telemetry-setup.js";
+import type { PluginCatalogRepository } from "../../../../src/domain/ports/plugin-catalog-repository.js";
+import { CapturingLogger } from "../../../helpers/ports/capturing-logger.js";
+import { DeterministicHasher } from "../../../helpers/ports/deterministic-hasher.js";
+import { fakeEnsureBuiltMarketplace } from "../../../helpers/ports/fake-ensure-built-marketplace.js";
+import { FakeNativePluginActivator } from "../../../helpers/ports/fake-native-plugin-activator.js";
+import { InMemoryFileAdapter } from "../../../helpers/ports/in-memory-file-adapter.js";
+import { InMemoryManifestRepository } from "../../../helpers/ports/in-memory-manifest-repository.js";
+import { InMemoryMarketplaceRegistry } from "../../../helpers/ports/in-memory-marketplace-registry.js";
+
+/**
+ * The seam #703 is about, from the writing side.
+ *
+ * `aidd` declares a plugin in a project's own settings, and the host loads it only once
+ * that host's own CLI has registered it — `activateNativeTools` is what performs that
+ * second half. Nothing asserted it: `marketplace-sync-settings-use-case.ts` had no test
+ * file at all, so the one act that makes a declared plugin actually load was covered
+ * nowhere, on the branch that shipped it.
+ *
+ * The pairing that matters is the ref. This file proves the activation is driven with the
+ * same `<plugin>@<marketplace>` string `TelemetryHostRegistrationSetup` looks up, so the
+ * two halves cannot drift into disagreeing about what to call one plugin — the failure the
+ * diagnostic exists to report would otherwise become a failure it invents.
+ */
+const PROJECT_ROOT = "/test-project";
+const MARKETPLACE = "aidd-framework";
+const PLUGIN = "aidd-telemetry";
+const REF = `${PLUGIN}@${MARKETPLACE}`;
+
+const NO_CATALOG: PluginCatalogRepository = {
+  load: async () => null,
+  loadForeign: async () => [],
+};
+
+function marketplace(): Marketplace {
+  return Marketplace.create({
+    name: MARKETPLACE,
+    source: { kind: "github", repo: "ai-driven-dev/framework" },
+    scope: "project",
+    addedAt: "2026-09-02T00:00:00Z",
+  });
+}
+
+function manifestWithPlugin(): InMemoryManifestRepository {
+  const manifest = Manifest.create();
+  manifest.addTool("claude", "test", []);
+  manifest.addPlugin(
+    "claude",
+    Plugin.fromMetadata(
+      PLUGIN,
+      "1.0.0",
+      { kind: "github", repo: "ai-driven-dev/framework" },
+      true,
+      MARKETPLACE
+    )
+  );
+  return new InMemoryManifestRepository(manifest);
+}
+
+function buildSync(activator: FakeNativePluginActivator) {
+  const registry = new InMemoryMarketplaceRegistry();
+  return {
+    registry,
+    useCase: new MarketplaceSyncSettingsUseCase(
+      new InMemoryFileAdapter(),
+      manifestWithPlugin(),
+      registry,
+      NO_CATALOG,
+      new DeterministicHasher(),
+      new CapturingLogger(),
+      new Map([["claude", activator]]),
+      fakeEnsureBuiltMarketplace()
+    ),
+  };
+}
+
+describe("syncing settings registers the plugin with the host's own CLI", () => {
+  it("drives the host CLI with the same ref the diagnostic looks up", async () => {
+    const activator = new FakeNativePluginActivator({ available: true });
+    const { useCase, registry } = buildSync(activator);
+    await registry.save(PROJECT_ROOT, marketplace());
+
+    await useCase.execute({ projectRoot: PROJECT_ROOT });
+
+    expect(activator.enabledPlugins).toContain(REF);
+    // The other half of the pairing: the ref the comparison asks a registry about. If either
+    // side ever spells it differently, this line and the one above stop agreeing.
+    const asked = buildHostRegistration([
+      {
+        tool: "claude",
+        plugins: [{ name: PLUGIN, marketplace: MARKETPLACE }],
+        reading: { location: "/registry", refs: new Map([[REF, true]]) },
+      },
+    ]);
+    expect(asked.entries[0]?.ref).toBe(activator.enabledPlugins[0]);
+  });
+
+  // The #703 state itself, from this side: the settings are written, the host CLI is absent,
+  // and nothing registers. The diagnostic is the only thing that can then tell a person.
+  it("registers nothing when the host CLI is not available, and does not fail the sync", async () => {
+    const activator = new FakeNativePluginActivator({ available: false });
+    const { useCase, registry } = buildSync(activator);
+    await registry.save(PROJECT_ROOT, marketplace());
+
+    await useCase.execute({ projectRoot: PROJECT_ROOT });
+
+    expect(activator.enabledPlugins).toEqual([]);
+  });
+});

--- a/cli/tests/application/use-cases/plugin/plugin-list-use-case.unit.test.ts
+++ b/cli/tests/application/use-cases/plugin/plugin-list-use-case.unit.test.ts
@@ -21,6 +21,7 @@ function makeManifestWithPlugin(): Manifest {
 
 function makeManifestRepository(manifest: Manifest): ManifestRepository {
   return {
+    path: "/test-project/.aidd/manifest.json",
     load: async () => manifest,
     save: async () => {},
     delete: async () => {},

--- a/cli/tests/application/use-cases/status-plugin-user-scope.unit.test.ts
+++ b/cli/tests/application/use-cases/status-plugin-user-scope.unit.test.ts
@@ -44,7 +44,7 @@ function makeFs(fileExists: boolean, diskHash: string): FileReader {
 
 function makeManifestRepo(manifest: Manifest): ManifestRepository {
   return {
-    path: "/test-project/.aidd/manifest.json",
+    path: "/proj/.aidd/manifest.json",
     load: async () => manifest,
     save: async () => {},
     delete: async () => {},

--- a/cli/tests/application/use-cases/status-plugin-user-scope.unit.test.ts
+++ b/cli/tests/application/use-cases/status-plugin-user-scope.unit.test.ts
@@ -43,7 +43,12 @@ function makeFs(fileExists: boolean, diskHash: string): FileReader {
 }
 
 function makeManifestRepo(manifest: Manifest): ManifestRepository {
-  return { load: async () => manifest, save: async () => {}, delete: async () => {} };
+  return {
+    path: "/test-project/.aidd/manifest.json",
+    load: async () => manifest,
+    save: async () => {},
+    delete: async () => {},
+  };
 }
 
 const noopHasher: Hasher = {

--- a/cli/tests/application/use-cases/status-plugin.unit.test.ts
+++ b/cli/tests/application/use-cases/status-plugin.unit.test.ts
@@ -41,7 +41,12 @@ function makeFs(fileExists: boolean, diskHash: string): FileReader {
 }
 
 function makeManifestRepo(manifest: Manifest): ManifestRepository {
-  return { load: async () => manifest, save: async () => {}, delete: async () => {} };
+  return {
+    path: "/test-project/.aidd/manifest.json",
+    load: async () => manifest,
+    save: async () => {},
+    delete: async () => {},
+  };
 }
 
 const noopHasher: Hasher = {

--- a/cli/tests/application/use-cases/status-plugin.unit.test.ts
+++ b/cli/tests/application/use-cases/status-plugin.unit.test.ts
@@ -42,7 +42,7 @@ function makeFs(fileExists: boolean, diskHash: string): FileReader {
 
 function makeManifestRepo(manifest: Manifest): ManifestRepository {
   return {
-    path: "/test-project/.aidd/manifest.json",
+    path: "/proj/.aidd/manifest.json",
     load: async () => manifest,
     save: async () => {},
     delete: async () => {},

--- a/cli/tests/application/use-cases/telemetry/diagnose-telemetry-use-case.unit.test.ts
+++ b/cli/tests/application/use-cases/telemetry/diagnose-telemetry-use-case.unit.test.ts
@@ -5,6 +5,8 @@ import "../../../../src/domain/tools/ai/copilot.js";
 import "../../../../src/domain/tools/ai/cursor.js";
 import "../../../../src/domain/tools/ai/opencode.js";
 import { DiagnoseTelemetryUseCase } from "../../../../src/application/use-cases/telemetry/diagnose-telemetry-use-case.js";
+import { Manifest } from "../../../../src/domain/models/manifest.js";
+import { Plugin } from "../../../../src/domain/models/plugin.js";
 import type { TelemetryCodexHookTrust } from "../../../../src/domain/models/telemetry-claim.js";
 import type { AiToolId } from "../../../../src/domain/models/tool-ids.js";
 import type { HookTrustReader } from "../../../../src/domain/ports/hook-trust-reader.js";
@@ -18,6 +20,7 @@ import type {
 } from "../../../../src/domain/ports/session-cost-reader.js";
 import type { VersionControl } from "../../../../src/domain/ports/version-control.js";
 import { FakeCurrentVersion } from "../../../helpers/ports/fake-current-version.js";
+import { InMemoryManifestRepository } from "../../../helpers/ports/in-memory-manifest-repository.js";
 import { InMemoryPersonIdentityStore } from "../../../helpers/ports/in-memory-person-identity-store.js";
 import { InMemoryRunJournalReader } from "../../../helpers/ports/in-memory-run-journal-reader.js";
 import { InMemoryTelemetrySink } from "../../../helpers/ports/in-memory-telemetry-sink.js";
@@ -406,5 +409,101 @@ describe("the versions check reports", () => {
 
     expect(nothing.setup.versions.plugin).toEqual({ kind: "nothing-journalled" });
     expect(journalledWithout.setup.versions.plugin).toEqual({ kind: "unrecorded" });
+  });
+});
+
+/** A repository whose load throws, which is what a hand-edited `.aidd/manifest.json`
+ * actually produces: `Manifest`'s parser maps over fields it does not guard. Written as a
+ * real implementation of the port rather than a cast, so it cannot drift from it. */
+class ThrowingManifestRepository implements ManifestRepository {
+  constructor(private readonly failure: Error) {}
+  async load(): Promise<Manifest | null> {
+    throw this.failure;
+  }
+  async save(): Promise<void> {}
+  async delete(): Promise<void> {}
+}
+
+function manifestWithClaudePlugin(marketplace?: string): InMemoryManifestRepository {
+  const manifest = Manifest.create();
+  manifest.addTool("claude", "test", []);
+  manifest.addPlugin(
+    "claude",
+    Plugin.fromMetadata(
+      "aidd-telemetry",
+      "1.0.0",
+      { kind: "github", repo: "ai-driven-dev/framework" },
+      true,
+      marketplace
+    )
+  );
+  return new InMemoryManifestRepository(manifest);
+}
+
+function registryCarrying(
+  refs: readonly string[]
+): ReadonlyMap<AiToolId, HostPluginRegistryReader> {
+  const reader: HostPluginRegistryReader = {
+    read: async () => ({ location: REGISTRY, refs: new Map(refs.map((ref) => [ref, true])) }),
+  };
+  return new Map<AiToolId, HostPluginRegistryReader>([["claude", reader]]);
+}
+
+const REGISTRY = "/home/dev/.claude/plugins/installed_plugins.json";
+const REF = "aidd-telemetry@aidd-framework";
+
+describe("DiagnoseTelemetryUseCase — what the host will actually load", () => {
+  it("says a plugin the host's registry carries is registered", async () => {
+    const { useCase } = buildUseCase({
+      manifestRepo: manifestWithClaudePlugin("aidd-framework"),
+      hostRegistries: registryCarrying([REF]),
+    });
+
+    const result = await useCase.execute(runOptions());
+
+    expect(result.setup.hostRegistration.entries[0]?.answer).toBe("registered");
+  });
+
+  // #703 itself, through the use-case: the declaration is fine and the host will drop it.
+  it("says a plugin the registry lacks is not registered, and names the file", async () => {
+    const { useCase } = buildUseCase({
+      manifestRepo: manifestWithClaudePlugin("aidd-framework"),
+      hostRegistries: registryCarrying([]),
+    });
+
+    const entry = (await useCase.execute(runOptions())).setup.hostRegistration.entries[0];
+
+    expect(entry?.answer).toBe("not-registered");
+    expect(entry?.detail).toContain(REGISTRY);
+  });
+
+  it("cannot ask any registry about a plugin recorded without a marketplace", async () => {
+    const { useCase } = buildUseCase({
+      manifestRepo: manifestWithClaudePlugin(undefined),
+      hostRegistries: registryCarrying([REF]),
+    });
+
+    expect((await useCase.execute(runOptions())).setup.hostRegistration.entries[0]?.answer).toBe(
+      "unanswerable"
+    );
+  });
+
+  /**
+   * Verified against the built binary before it was fixed: it printed
+   * `Cannot read properties of undefined (reading 'map')` and died. Nothing loaded the
+   * manifest from `check` until this fact existed, so that crash is one the diagnostic put
+   * on its own path — and a damaged manifest is exactly when someone runs `check`.
+   */
+  it("survives a manifest it cannot parse, and says so instead of dying", async () => {
+    const { useCase } = buildUseCase({
+      manifestRepo: new ThrowingManifestRepository(
+        new TypeError("Cannot read properties of undefined (reading 'map')")
+      ),
+    });
+
+    const registration = (await useCase.execute(runOptions())).setup.hostRegistration;
+
+    expect(registration.manifestUnreadable).toContain("map");
+    expect(registration.entries).toEqual([]);
   });
 });

--- a/cli/tests/application/use-cases/telemetry/diagnose-telemetry-use-case.unit.test.ts
+++ b/cli/tests/application/use-cases/telemetry/diagnose-telemetry-use-case.unit.test.ts
@@ -8,6 +8,8 @@ import { DiagnoseTelemetryUseCase } from "../../../../src/application/use-cases/
 import type { TelemetryCodexHookTrust } from "../../../../src/domain/models/telemetry-claim.js";
 import type { AiToolId } from "../../../../src/domain/models/tool-ids.js";
 import type { HookTrustReader } from "../../../../src/domain/ports/hook-trust-reader.js";
+import type { HostPluginRegistryReader } from "../../../../src/domain/ports/host-plugin-registry-reader.js";
+import type { ManifestRepository } from "../../../../src/domain/ports/manifest-repository.js";
 import type { RunJournal } from "../../../../src/domain/ports/run-journal-reader.js";
 import type {
   LocalCostCandidateRecord,
@@ -82,6 +84,8 @@ function buildUseCase(options: {
   journals?: readonly RunJournal[];
   readers?: ReadonlyMap<AiToolId, SessionCostReader>;
   hookTrustReader?: StubHookTrustReader;
+  manifestRepo?: ManifestRepository;
+  hostRegistries?: ReadonlyMap<AiToolId, HostPluginRegistryReader>;
 }) {
   const evidence = options.evidence ?? new StubEvidenceReader();
   const journalReader = new InMemoryRunJournalReader();
@@ -97,7 +101,13 @@ function buildUseCase(options: {
     hookTrustReader,
     new InMemoryPersonIdentityStore(),
     new InMemoryTelemetrySink(),
-    new FakeCurrentVersion("9.9.9-check")
+    new FakeCurrentVersion("9.9.9-check"),
+    options.manifestRepo ?? {
+      load: async () => null,
+      save: async () => {},
+      delete: async () => {},
+    },
+    options.hostRegistries ?? new Map()
   );
   return { useCase, evidence, hookTrustReader };
 }

--- a/cli/tests/application/use-cases/telemetry/diagnose-telemetry-use-case.unit.test.ts
+++ b/cli/tests/application/use-cases/telemetry/diagnose-telemetry-use-case.unit.test.ts
@@ -106,6 +106,7 @@ function buildUseCase(options: {
     new InMemoryTelemetrySink(),
     new FakeCurrentVersion("9.9.9-check"),
     options.manifestRepo ?? {
+      path: "/test-project/.aidd/manifest.json",
       load: async () => null,
       save: async () => {},
       delete: async () => {},
@@ -416,6 +417,7 @@ describe("the versions check reports", () => {
  * actually produces: `Manifest`'s parser maps over fields it does not guard. Written as a
  * real implementation of the port rather than a cast, so it cannot drift from it. */
 class ThrowingManifestRepository implements ManifestRepository {
+  readonly path = "/test-project/.aidd/manifest.json";
   constructor(private readonly failure: Error) {}
   async load(): Promise<Manifest | null> {
     throw this.failure;

--- a/cli/tests/domain/models/telemetry-host-registration.unit.test.ts
+++ b/cli/tests/domain/models/telemetry-host-registration.unit.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildHostRegistration,
+  type TelemetryHostRegistrationEvidence,
+} from "../../../src/domain/models/telemetry-setup.js";
+
+const REGISTRY = "/home/dev/.claude/plugins/installed_plugins.json";
+
+function evidence(
+  overrides: Partial<TelemetryHostRegistrationEvidence> = {}
+): TelemetryHostRegistrationEvidence {
+  return {
+    tool: "claude",
+    plugins: [{ name: "aidd-telemetry", marketplace: "aidd-framework" }],
+    reading: { location: REGISTRY, refs: new Map([["aidd-telemetry@aidd-framework", true]]) },
+    ...overrides,
+  };
+}
+
+function only(input: TelemetryHostRegistrationEvidence) {
+  const entry = buildHostRegistration([input]).entries[0];
+  if (entry === undefined) throw new Error("expected exactly one entry");
+  return entry;
+}
+
+describe("what a host's own registry says about a plugin AIDD installed", () => {
+  it("is registered when the registry carries its ref", () => {
+    expect(only(evidence()).answer).toBe("registered");
+  });
+
+  // The #703 failure itself: the declaration is perfectly good and the host drops it,
+  // because the host consults its registry and nothing else.
+  it("is not registered when the registry was read and lacks the ref", () => {
+    const entry = only(evidence({ reading: { location: REGISTRY, refs: new Map() } }));
+
+    expect(entry.answer).toBe("not-registered");
+    expect(entry.detail).toContain(REGISTRY);
+    expect(entry.detail).toContain("orphaned");
+  });
+
+  // Folding this into `registered` would report a plugin that will not load as one that
+  // will, which is the whole defect being fixed, one layer down.
+  it("tells a disabled registration from an absent one", () => {
+    const reading = {
+      location: REGISTRY,
+      refs: new Map([["aidd-telemetry@aidd-framework", false]]),
+    };
+
+    expect(only(evidence({ reading })).answer).toBe("registered-disabled");
+  });
+
+  it("is unanswerable when the registry could not be read, never `not-registered`", () => {
+    const reading = { location: REGISTRY, unreadable: "ENOENT" };
+    const entry = only(evidence({ reading }));
+
+    expect(entry.answer).toBe("unanswerable");
+    expect(entry.detail).toContain("ENOENT");
+  });
+
+  it("is unanswerable for a host nothing here knows how to ask", () => {
+    expect(only(evidence({ reading: undefined })).answer).toBe("unanswerable");
+  });
+
+  // Every measured host keys its registry on `<plugin>@<marketplace>`, so a plugin with no
+  // marketplace recorded cannot be looked up anywhere — unanswerable at the source, not a
+  // lookup that came back empty.
+  it("is unanswerable when no ref can be built at all, and names no ref", () => {
+    const entry = only(evidence({ plugins: [{ name: "hand-copied" }] }));
+
+    expect(entry.answer).toBe("unanswerable");
+    expect(entry.ref).toBeUndefined();
+  });
+
+  it("names every registry it consulted once, whatever each answered", () => {
+    const result = buildHostRegistration([
+      evidence(),
+      evidence({ plugins: [{ name: "aidd-dev", marketplace: "aidd-framework" }] }),
+    ]);
+
+    expect(result.locationsChecked).toEqual([REGISTRY]);
+  });
+
+  it("reports no entry, and no location, for a project with nothing installed", () => {
+    expect(buildHostRegistration([])).toEqual({ entries: [], locationsChecked: [] });
+  });
+});

--- a/cli/tests/domain/models/telemetry-host-registration.unit.test.ts
+++ b/cli/tests/domain/models/telemetry-host-registration.unit.test.ts
@@ -61,6 +61,25 @@ describe("what a host's own registry says about a plugin AIDD installed", () => 
     expect(only(evidence({ reading: undefined })).answer).toBe("unanswerable");
   });
 
+  /**
+   * Two silences, two different things for a person to do, so never one sentence. A tool
+   * that drives its own CLI keeps a registry somebody could go and measure; a tool that
+   * declares no native activation has none to look for. Getting these the wrong way round
+   * sends someone hunting for a file that does not exist, or tells them nothing is knowable
+   * about a file that is sitting there.
+   */
+  it("says a declared registry is unmeasured, not that none exists", () => {
+    const entry = only(evidence({ reading: undefined, declaresNativeActivation: true }));
+
+    expect(entry.detail).toContain("has established its shape");
+  });
+
+  it("says a host declaring no registry has none to read", () => {
+    const entry = only(evidence({ reading: undefined, declaresNativeActivation: false }));
+
+    expect(entry.detail).toContain("declares no plugin registry");
+  });
+
   // Every measured host keys its registry on `<plugin>@<marketplace>`, so a plugin with no
   // marketplace recorded cannot be looked up anywhere — unanswerable at the source, not a
   // lookup that came back empty.

--- a/cli/tests/domain/models/telemetry-host-registration.unit.test.ts
+++ b/cli/tests/domain/models/telemetry-host-registration.unit.test.ts
@@ -71,16 +71,16 @@ describe("what a host's own registry says about a plugin AIDD installed", () => 
     expect(entry.ref).toBeUndefined();
   });
 
-  it("names every registry it consulted once, whatever each answered", () => {
+  it("gives every plugin its own entry, across tools", () => {
     const result = buildHostRegistration([
       evidence(),
       evidence({ plugins: [{ name: "aidd-dev", marketplace: "aidd-framework" }] }),
     ]);
 
-    expect(result.locationsChecked).toEqual([REGISTRY]);
+    expect(result.entries.map((e) => e.plugin)).toEqual(["aidd-telemetry", "aidd-dev"]);
   });
 
-  it("reports no entry, and no location, for a project with nothing installed", () => {
-    expect(buildHostRegistration([])).toEqual({ entries: [], locationsChecked: [] });
+  it("reports no entry for a project with nothing installed", () => {
+    expect(buildHostRegistration([])).toEqual({ entries: [] });
   });
 });

--- a/cli/tests/e2e/telemetry-host-registration.e2e.test.ts
+++ b/cli/tests/e2e/telemetry-host-registration.e2e.test.ts
@@ -1,0 +1,123 @@
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { CLI_PATH, pathWithoutAidd } from "./helpers.js";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * #703 end to end, on the built binary: a project whose plugins are declared, and a host
+ * registry that carries one of them and not the other.
+ *
+ * The point of running it here rather than only in unit tests is the cost of the answer. The
+ * whole design exists so this question is answerable **before** anyone has spent a session:
+ * no AI tool on `PATH`, no network, no account, no money — only files already on disk. If
+ * that ever stopped being true, it would stop here first.
+ */
+const PLUGIN_SOURCE = { kind: "github", repo: "ai-driven-dev/framework" } as const;
+
+function pluginEntry(name: string, marketplace?: string) {
+  return {
+    name,
+    source: PLUGIN_SOURCE,
+    version: "1.0.0",
+    strict: true,
+    files: {},
+    ...(marketplace === undefined ? {} : { marketplace }),
+  };
+}
+
+describe("check says whether the host will load what aidd installed", () => {
+  let projectDir: string;
+  let fakeHome: string;
+
+  beforeEach(async () => {
+    const root = await mkdtemp(join(tmpdir(), "aidd-host-registration-e2e-"));
+    projectDir = join(root, "project");
+    fakeHome = join(root, "home");
+    await mkdir(join(projectDir, ".aidd"), { recursive: true });
+    await mkdir(join(fakeHome, ".claude", "plugins"), { recursive: true });
+    await writeFile(
+      join(projectDir, ".aidd", "config.json"),
+      JSON.stringify({ telemetry: { enabled: true } })
+    );
+    await writeFile(
+      join(projectDir, ".aidd", "manifest.json"),
+      JSON.stringify({
+        version: 1,
+        tools: {
+          claude: {
+            files: [],
+            mergeFiles: [],
+            plugins: [
+              pluginEntry("aidd-telemetry", "aidd-framework"),
+              pluginEntry("aidd-dev", "aidd-framework"),
+              pluginEntry("hand-copied"),
+            ],
+          },
+        },
+      })
+    );
+    // Only the first is registered, and it names this project — which is how `aidd` installs,
+    // at project scope (`claude-cli-adapter.ts`'s own `--scope project`).
+    await writeFile(
+      join(fakeHome, ".claude", "plugins", "installed_plugins.json"),
+      JSON.stringify({
+        version: 1,
+        plugins: {
+          "aidd-telemetry@aidd-framework": [{ scope: "project", projectPath: projectDir }],
+        },
+      })
+    );
+  });
+
+  afterEach(async () => {
+    await rm(join(projectDir, ".."), { recursive: true, force: true });
+  });
+
+  it("names each plugin's answer, with no AI tool on PATH and nothing to spend", async () => {
+    const { stdout } = await execFileAsync(process.execPath, [CLI_PATH, "telemetry", "check"], {
+      cwd: projectDir,
+      env: {
+        PATH: pathWithoutAidd(),
+        HOME: fakeHome,
+        AIDD_TELEMETRY_DIR: join(fakeHome, "telemetry"),
+      },
+    });
+
+    expect(stdout).toContain("plugins registered");
+    // The failure #703 is about: declared, and the host will drop it as orphaned.
+    expect(stdout).toContain("claude/aidd-dev: not-registered");
+    // No marketplace recorded, so no registry keys on it — unanswerable, never "not there".
+    expect(stdout).toContain("claude/hand-copied: unanswerable");
+    expect(stdout).toContain("claude/aidd-telemetry: registered");
+    // Problem first: a person who reads one line reads the one they must act on.
+    expect(stdout.indexOf("aidd-dev")).toBeLessThan(stdout.indexOf("aidd-telemetry: registered"));
+  });
+
+  it("does not count a registration made for a different project", async () => {
+    await writeFile(
+      join(fakeHome, ".claude", "plugins", "installed_plugins.json"),
+      JSON.stringify({
+        version: 1,
+        plugins: {
+          "aidd-telemetry@aidd-framework": [{ scope: "project", projectPath: "/somewhere/else" }],
+        },
+      })
+    );
+
+    const { stdout } = await execFileAsync(process.execPath, [CLI_PATH, "telemetry", "check"], {
+      cwd: projectDir,
+      env: {
+        PATH: pathWithoutAidd(),
+        HOME: fakeHome,
+        AIDD_TELEMETRY_DIR: join(fakeHome, "telemetry"),
+      },
+    });
+
+    expect(stdout).toContain("claude/aidd-telemetry: not-registered");
+  });
+});

--- a/cli/tests/helpers/ports/in-memory-manifest-repository.ts
+++ b/cli/tests/helpers/ports/in-memory-manifest-repository.ts
@@ -6,6 +6,7 @@ import type { ManifestRepository } from "../../../src/domain/ports/manifest-repo
  * Holds a single Manifest | null — no disk I/O.
  */
 export class InMemoryManifestRepository implements ManifestRepository {
+  readonly path = "/test-project/.aidd/manifest.json";
   private manifest: Manifest | null;
 
   constructor(seed: Manifest | null = null) {

--- a/cli/tests/helpers/ports/in-memory-manifest-repository.ts
+++ b/cli/tests/helpers/ports/in-memory-manifest-repository.ts
@@ -6,11 +6,15 @@ import type { ManifestRepository } from "../../../src/domain/ports/manifest-repo
  * Holds a single Manifest | null — no disk I/O.
  */
 export class InMemoryManifestRepository implements ManifestRepository {
-  readonly path = "/test-project/.aidd/manifest.json";
+  /** Derived from the same root the test drives the use case with, never a fixed literal:
+   * this exists so a diagnostic can name the real file, and a double naming a fictional one
+   * would let that go wrong with every test still green. */
+  readonly path: string;
   private manifest: Manifest | null;
 
-  constructor(seed: Manifest | null = null) {
+  constructor(seed: Manifest | null = null, projectRoot = "/test-project") {
     this.manifest = seed;
+    this.path = `${projectRoot}/.aidd/manifest.json`;
   }
 
   async load(): Promise<Manifest | null> {

--- a/cli/tests/infrastructure/adapters/host-plugin-registry-reader-adapter.integration.test.ts
+++ b/cli/tests/infrastructure/adapters/host-plugin-registry-reader-adapter.integration.test.ts
@@ -235,6 +235,43 @@ describe("Codex's own config.toml", () => {
     ).toBe(true);
   });
 
+  /**
+   * A header spelled inside a multi-line string is not a table, and TOML forbids the real
+   * one being defined twice — so exactly one of the two occurrences is real, and which comes
+   * first decides nothing. Both orders are asserted because each was, at one point, the one
+   * the scanner got wrong: last-write-wins let the fake override the real, and the
+   * first-wins that replaced it let the fake win when it came first.
+   */
+  it.each([
+    [
+      "before the real table",
+      '[projects."/p"]\nnotes = """\n[plugins."aidd-telemetry@aidd-framework"]\nenabled = true\n"""\n\n[plugins."aidd-telemetry@aidd-framework"]\nenabled = false\n',
+    ],
+    [
+      "after the real table",
+      '[plugins."aidd-telemetry@aidd-framework"]\nenabled = false\n\n[projects."/p"]\nnotes = """\n[plugins."aidd-telemetry@aidd-framework"]\nenabled = true\n"""\n',
+    ],
+  ])("ignores a header inside a multi-line string, %s", async (_where, content) => {
+    await write(PATH, content);
+
+    expect(
+      (await readerFor("codex").read(PROJECT)).refs?.get("aidd-telemetry@aidd-framework")
+    ).toBe(false);
+  });
+
+  // A string that opens and closes on one line leaves the scanner outside it, so the tables
+  // after it are still read.
+  it("stays outside a multi-line string that opens and closes on one line", async () => {
+    await write(
+      PATH,
+      '[projects."/p"]\nnotes = """one line"""\n\n[plugins."aidd-telemetry@aidd-framework"]\nenabled = false\n'
+    );
+
+    expect(
+      (await readerFor("codex").read(PROJECT)).refs?.get("aidd-telemetry@aidd-framework")
+    ).toBe(false);
+  });
+
   // `enabled` belongs to the table it sits under, never to the one before it.
   it("does not read the next table's enabled as this table's", async () => {
     await write(PATH, '[plugins."a@m"]\n[plugins."b@m"]\nenabled = false\n');

--- a/cli/tests/infrastructure/adapters/host-plugin-registry-reader-adapter.integration.test.ts
+++ b/cli/tests/infrastructure/adapters/host-plugin-registry-reader-adapter.integration.test.ts
@@ -1,0 +1,154 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { AiToolId } from "../../../src/domain/models/tool-ids.js";
+import { hostPluginRegistryReaders } from "../../../src/infrastructure/adapters/host-plugin-registry-reader-adapter.js";
+
+/**
+ * Every fixture below is written from the shape recorded in this task's own spec, never
+ * copied from a real file: the machine that was measured carries hashed experiment keys,
+ * absolute project paths and a list of somebody's marketplaces, none of which belongs in a
+ * public repository. Only the shape was ever needed.
+ */
+let home: string;
+
+beforeEach(async () => {
+  home = await mkdtemp(join(tmpdir(), "aidd-host-registry-"));
+});
+
+afterEach(async () => {
+  await rm(home, { recursive: true, force: true });
+});
+
+async function write(relative: string, content: string): Promise<void> {
+  const path = join(home, relative);
+  await mkdir(join(path, ".."), { recursive: true });
+  await writeFile(path, content, "utf8");
+}
+
+function readerFor(tool: AiToolId) {
+  const reader = hostPluginRegistryReaders(home).get(tool);
+  if (reader === undefined) throw new Error(`no reader declared for ${tool}`);
+  return reader;
+}
+
+describe("Claude Code's own installed_plugins.json", () => {
+  const PATH = ".claude/plugins/installed_plugins.json";
+
+  it("reads every ref it carries, and records each as enabled — Claude keeps no such flag", async () => {
+    await write(
+      PATH,
+      JSON.stringify({
+        version: 1,
+        plugins: {
+          "aidd-telemetry@aidd-framework": [{ scope: "project", version: "0.1.0" }],
+          "aidd-dev@aidd-framework": [{ scope: "user", version: "0.1.0" }],
+        },
+      })
+    );
+
+    const reading = await readerFor("claude").read();
+
+    expect(reading.refs?.get("aidd-telemetry@aidd-framework")).toBe(true);
+    expect(reading.refs?.size).toBe(2);
+  });
+
+  // An empty map is a real answer — the file opened and carries nothing — and it must stay
+  // reachable only from a file that actually opened.
+  it("reads an empty registry as an empty answer, not as unreadable", async () => {
+    await write(PATH, JSON.stringify({ version: 1, plugins: {} }));
+
+    const reading = await readerFor("claude").read();
+
+    expect(reading.refs?.size).toBe(0);
+    expect(reading.unreadable).toBeUndefined();
+  });
+
+  it("says it could not read an absent registry, and carries no refs at all", async () => {
+    const reading = await readerFor("claude").read();
+
+    expect(reading.refs).toBeUndefined();
+    expect(reading.unreadable).toBe("ENOENT");
+  });
+
+  /**
+   * Not hypothetical, and the reason this distinction exists at all: Copilot's own
+   * `~/.copilot/config.json` opens with two `//` lines, so a registry that looks like JSON
+   * and turns out to be JSONC is a file a reader really does meet. It must say it could not
+   * read the file — reporting "no plugins registered" here would invent the exact fact this
+   * feature exists to stop inventing.
+   */
+  it("reads a JSONC registry as unreadable, never as carrying no plugins", async () => {
+    await write(PATH, '// managed automatically\n{ "version": 1, "plugins": {} }\n');
+
+    const reading = await readerFor("claude").read();
+
+    expect(reading.refs).toBeUndefined();
+    expect(reading.unreadable).toBeDefined();
+  });
+
+  it("reads a registry with no plugins object as unreadable rather than empty", async () => {
+    await write(PATH, JSON.stringify({ version: 1 }));
+
+    const reading = await readerFor("claude").read();
+
+    expect(reading.refs).toBeUndefined();
+  });
+});
+
+describe("Codex's own config.toml", () => {
+  const PATH = ".codex/config.toml";
+
+  it("finds its plugin tables among the arbitrary ones around them", async () => {
+    await write(
+      PATH,
+      [
+        '[projects."/somewhere/else"]',
+        'trust_level = "trusted"',
+        "",
+        '[plugins."aidd-telemetry@aidd-framework"]',
+        "enabled = true",
+        "",
+        '[plugins."aidd-dev@aidd-framework"]',
+        "enabled = false",
+        "",
+        '[hooks.state."aidd-telemetry@aidd-framework:hooks/hooks.json:session_start:0:0"]',
+        'trusted_hash = "abc"',
+        "",
+      ].join("\n")
+    );
+
+    const reading = await readerFor("codex").read();
+
+    expect(reading.refs?.get("aidd-telemetry@aidd-framework")).toBe(true);
+    expect(reading.refs?.get("aidd-dev@aidd-framework")).toBe(false);
+    expect(reading.refs?.size).toBe(2);
+  });
+
+  // A table with no `enabled` is a shape nobody has produced — 27 of 27 carried one on the
+  // machine measured — and between "the host listed this plugin" and "the host listed it
+  // and said nothing", the listing is the fact.
+  it("treats a table with no enabled line as enabled", async () => {
+    await write(PATH, '[plugins."aidd-telemetry@aidd-framework"]\n');
+
+    expect((await readerFor("codex").read()).refs?.get("aidd-telemetry@aidd-framework")).toBe(true);
+  });
+
+  it("says it could not read an absent config, and carries no refs", async () => {
+    const reading = await readerFor("codex").read();
+
+    expect(reading.refs).toBeUndefined();
+    expect(reading.unreadable).toBe("ENOENT");
+  });
+});
+
+// Measured and deliberate: its `installedPlugins` read empty on a machine that had run
+// installs, and its file is JSONC. Nobody has established that this array is the registry a
+// Copilot install writes to, so nothing here claims to read it — and the diagnostic reports
+// Copilot unanswerable rather than confidently wrong.
+describe("a host with no reader", () => {
+  it("declares none for Copilot, rather than guessing at its file", () => {
+    expect(hostPluginRegistryReaders(home).has("copilot")).toBe(false);
+  });
+});

--- a/cli/tests/infrastructure/adapters/host-plugin-registry-reader-adapter.integration.test.ts
+++ b/cli/tests/infrastructure/adapters/host-plugin-registry-reader-adapter.integration.test.ts
@@ -11,6 +11,8 @@ import { hostPluginRegistryReaders } from "../../../src/infrastructure/adapters/
  * absolute project paths and a list of somebody's marketplaces, none of which belongs in a
  * public repository. Only the shape was ever needed.
  */
+const PROJECT = "/repo/mine";
+
 let home: string;
 
 beforeEach(async () => {
@@ -36,22 +38,82 @@ function readerFor(tool: AiToolId) {
 describe("Claude Code's own installed_plugins.json", () => {
   const PATH = ".claude/plugins/installed_plugins.json";
 
-  it("reads every ref it carries, and records each as enabled — Claude keeps no such flag", async () => {
+  it("counts a ref installed for this project, and one installed for the machine", async () => {
     await write(
       PATH,
       JSON.stringify({
         version: 1,
         plugins: {
-          "aidd-telemetry@aidd-framework": [{ scope: "project", version: "0.1.0" }],
-          "aidd-dev@aidd-framework": [{ scope: "user", version: "0.1.0" }],
+          "aidd-telemetry@aidd-framework": [{ scope: "project", projectPath: PROJECT }],
+          "aidd-dev@aidd-framework": [{ scope: "user" }],
         },
       })
     );
 
-    const reading = await readerFor("claude").read();
+    const reading = await readerFor("claude").read(PROJECT);
 
     expect(reading.refs?.get("aidd-telemetry@aidd-framework")).toBe(true);
-    expect(reading.refs?.size).toBe(2);
+    expect(reading.refs?.get("aidd-dev@aidd-framework")).toBe(true);
+  });
+
+  /**
+   * The blocker an independent check found, and the reason the first version of this reader
+   * was wrong: it mapped every key to `true`, on a doc claim that the entries "record scope,
+   * install path and version, none of which decides whether the plugin loads". Read across
+   * all 115 entries rather than the first one, they also carry `projectPath`, on 100 of
+   * them. And `aidd` registers every plugin at project scope
+   * (`claude-cli-adapter.ts`'s `PROJECT_SCOPE_ARGS`), so this is the ordinary case, not an
+   * exotic one: without this, running `check` in one project reports a plugin installed for
+   * a different project as one this host will load here.
+   */
+  it("does not count a ref installed only for another project", async () => {
+    await write(
+      PATH,
+      JSON.stringify({
+        version: 1,
+        plugins: {
+          "aidd-telemetry@aidd-framework": [{ scope: "project", projectPath: "/repo/theirs" }],
+        },
+      })
+    );
+
+    const reading = await readerFor("claude").read(PROJECT);
+
+    expect(reading.refs?.has("aidd-telemetry@aidd-framework")).toBe(false);
+    // Read, and answering — the ref is absent from a map that exists, which is
+    // `not-registered`, never the `unanswerable` an unread registry produces.
+    expect(reading.unreadable).toBeUndefined();
+  });
+
+  it("counts a ref carrying one entry for this project among entries for others", async () => {
+    await write(
+      PATH,
+      JSON.stringify({
+        version: 1,
+        plugins: {
+          "aidd-telemetry@aidd-framework": [
+            { scope: "project", projectPath: "/repo/theirs" },
+            { scope: "project", projectPath: PROJECT },
+          ],
+        },
+      })
+    );
+
+    expect((await readerFor("claude").read(PROJECT)).refs?.size).toBe(1);
+  });
+
+  // An entry naming neither a scope nor a project is evidence of nothing, and guessing from
+  // it is the habit this whole file exists to break.
+  it("ignores an entry that names neither a scope nor a project", async () => {
+    await write(
+      PATH,
+      JSON.stringify({
+        version: 1,
+        plugins: { "aidd-telemetry@aidd-framework": [{ version: "1" }] },
+      })
+    );
+
+    expect((await readerFor("claude").read(PROJECT)).refs?.size).toBe(0);
   });
 
   // An empty map is a real answer — the file opened and carries nothing — and it must stay
@@ -59,14 +121,14 @@ describe("Claude Code's own installed_plugins.json", () => {
   it("reads an empty registry as an empty answer, not as unreadable", async () => {
     await write(PATH, JSON.stringify({ version: 1, plugins: {} }));
 
-    const reading = await readerFor("claude").read();
+    const reading = await readerFor("claude").read(PROJECT);
 
     expect(reading.refs?.size).toBe(0);
     expect(reading.unreadable).toBeUndefined();
   });
 
   it("says it could not read an absent registry, and carries no refs at all", async () => {
-    const reading = await readerFor("claude").read();
+    const reading = await readerFor("claude").read(PROJECT);
 
     expect(reading.refs).toBeUndefined();
     expect(reading.unreadable).toBe("ENOENT");
@@ -82,7 +144,7 @@ describe("Claude Code's own installed_plugins.json", () => {
   it("reads a JSONC registry as unreadable, never as carrying no plugins", async () => {
     await write(PATH, '// managed automatically\n{ "version": 1, "plugins": {} }\n');
 
-    const reading = await readerFor("claude").read();
+    const reading = await readerFor("claude").read(PROJECT);
 
     expect(reading.refs).toBeUndefined();
     expect(reading.unreadable).toBeDefined();
@@ -91,7 +153,7 @@ describe("Claude Code's own installed_plugins.json", () => {
   it("reads a registry with no plugins object as unreadable rather than empty", async () => {
     await write(PATH, JSON.stringify({ version: 1 }));
 
-    const reading = await readerFor("claude").read();
+    const reading = await readerFor("claude").read(PROJECT);
 
     expect(reading.refs).toBeUndefined();
   });
@@ -119,24 +181,72 @@ describe("Codex's own config.toml", () => {
       ].join("\n")
     );
 
-    const reading = await readerFor("codex").read();
+    const reading = await readerFor("codex").read(PROJECT);
 
     expect(reading.refs?.get("aidd-telemetry@aidd-framework")).toBe(true);
     expect(reading.refs?.get("aidd-dev@aidd-framework")).toBe(false);
     expect(reading.refs?.size).toBe(2);
   });
 
-  // A table with no `enabled` is a shape nobody has produced — 27 of 27 carried one on the
-  // machine measured — and between "the host listed this plugin" and "the host listed it
-  // and said nothing", the listing is the fact.
+  // A table with no `enabled` is a shape Codex does not produce — every plugin table on the
+  // machine measured carried one — and between "the host listed this plugin" and "the host
+  // listed it and said nothing", the listing is the fact. Asserted against the next table
+  // rather than end-of-file, so it cannot pass by conflating "no key" with "no more input".
   it("treats a table with no enabled line as enabled", async () => {
-    await write(PATH, '[plugins."aidd-telemetry@aidd-framework"]\n');
+    await write(
+      PATH,
+      '[plugins."aidd-telemetry@aidd-framework"]\n[plugins."other@elsewhere"]\nenabled = true\n'
+    );
 
-    expect((await readerFor("codex").read()).refs?.get("aidd-telemetry@aidd-framework")).toBe(true);
+    expect(
+      (await readerFor("codex").read(PROJECT)).refs?.get("aidd-telemetry@aidd-framework")
+    ).toBe(true);
+  });
+
+  /**
+   * The four shapes that read `enabled = false` as an enabled plugin when this scanned one
+   * line past the header instead of the table's body. Each one is a file Codex may write or
+   * a person may edit, and each turned the answer into its exact opposite — a host that will
+   * not load the plugin reported as one that will.
+   */
+  it.each([
+    ["a blank line before it", "\nenabled = false\n"],
+    ["a comment line before it", "# why\nenabled = false\n"],
+    ["another key before it", 'version = "1"\nenabled = false\n'],
+    ["a trailing comment on it", "enabled = false # turned off\n"],
+  ])("finds enabled = false with %s", async (_shape, body) => {
+    await write(PATH, `[plugins."aidd-telemetry@aidd-framework"]\n${body}`);
+
+    expect(
+      (await readerFor("codex").read(PROJECT)).refs?.get("aidd-telemetry@aidd-framework")
+    ).toBe(false);
+  });
+
+  // The mirror failure: a header carrying its own trailing comment matched nothing, so a
+  // plugin that is registered reported as absent — a false alarm rather than a false calm.
+  it("finds a plugin whose header carries a trailing comment", async () => {
+    await write(
+      PATH,
+      '[plugins."aidd-telemetry@aidd-framework"] # installed by hand\nenabled = true\n'
+    );
+
+    expect(
+      (await readerFor("codex").read(PROJECT)).refs?.get("aidd-telemetry@aidd-framework")
+    ).toBe(true);
+  });
+
+  // `enabled` belongs to the table it sits under, never to the one before it.
+  it("does not read the next table's enabled as this table's", async () => {
+    await write(PATH, '[plugins."a@m"]\n[plugins."b@m"]\nenabled = false\n');
+
+    const refs = (await readerFor("codex").read(PROJECT)).refs;
+
+    expect(refs?.get("a@m")).toBe(true);
+    expect(refs?.get("b@m")).toBe(false);
   });
 
   it("says it could not read an absent config, and carries no refs", async () => {
-    const reading = await readerFor("codex").read();
+    const reading = await readerFor("codex").read(PROJECT);
 
     expect(reading.refs).toBeUndefined();
     expect(reading.unreadable).toBe("ENOENT");

--- a/cli/tests/infrastructure/adapters/host-plugin-registry-reader-adapter.integration.test.ts
+++ b/cli/tests/infrastructure/adapters/host-plugin-registry-reader-adapter.integration.test.ts
@@ -253,12 +253,54 @@ describe("Codex's own config.toml", () => {
   });
 });
 
-// Measured and deliberate: its `installedPlugins` read empty on a machine that had run
-// installs, and its file is JSONC. Nobody has established that this array is the registry a
-// Copilot install writes to, so nothing here claims to read it — and the diagnostic reports
-// Copilot unanswerable rather than confidently wrong.
-describe("a host with no reader", () => {
-  it("declares none for Copilot, rather than guessing at its file", () => {
-    expect(hostPluginRegistryReaders(home).has("copilot")).toBe(false);
+/**
+ * Every shape below was driven live under a sandboxed home on 2026-09-03, against
+ * `GitHub Copilot CLI 1.0.82`: `copilot plugin marketplace add <dir>` then
+ * `copilot plugin install <plugin>@<marketplace>` then `copilot plugin uninstall <plugin>`.
+ * The fixtures are that file's shape, never its contents.
+ */
+describe("Copilot's own settings.json", () => {
+  const PATH = ".copilot/settings.json";
+
+  it("reads the refs its enabledPlugins carries", async () => {
+    await write(
+      PATH,
+      JSON.stringify({
+        extraKnownMarketplaces: { "aidd-framework": { source: { source: "directory" } } },
+        enabledPlugins: { "aidd-telemetry@aidd-framework": true },
+      })
+    );
+
+    expect(
+      (await readerFor("copilot").read(PROJECT)).refs?.get("aidd-telemetry@aidd-framework")
+    ).toBe(true);
+  });
+
+  // `copilot plugin uninstall` writes `false` and keeps the key — measured, and it makes
+  // registered-but-off an ordinary state on this host rather than a Codex peculiarity.
+  it("reads an uninstalled plugin as registered and disabled, not as absent", async () => {
+    await write(
+      PATH,
+      JSON.stringify({ enabledPlugins: { "aidd-telemetry@aidd-framework": false } })
+    );
+
+    expect(
+      (await readerFor("copilot").read(PROJECT)).refs?.get("aidd-telemetry@aidd-framework")
+    ).toBe(false);
+  });
+
+  // A settings file exists from the first `copilot` run and gains `enabledPlugins` only on
+  // the first install, so its absence is "carries none" — a real answer, not a failed read.
+  it("reads a settings file with no enabledPlugins as carrying none", async () => {
+    await write(PATH, JSON.stringify({ extraKnownMarketplaces: {} }));
+
+    const reading = await readerFor("copilot").read(PROJECT);
+
+    expect(reading.refs?.size).toBe(0);
+    expect(reading.unreadable).toBeUndefined();
+  });
+
+  it("says it could not read an absent settings file", async () => {
+    expect((await readerFor("copilot").read(PROJECT)).unreadable).toBe("ENOENT");
   });
 });

--- a/plugins/aidd-telemetry/skills/02-check/actions/02-diagnose.md
+++ b/plugins/aidd-telemetry/skills/02-check/actions/02-diagnose.md
@@ -86,6 +86,7 @@ judging anything.
 | A plugin the host never registered | its `plugins registered` line is relayed as `not-registered`, naming the registry file, and appears before any plugin that is fine |
 | A plugin whose host registry could not be read | its line is relayed as `unanswerable`, never as `not-registered` |
 | A project with no plugin recorded | the row says so in one sentence, and is never relayed as a failure |
+| The AIDD manifest could not be read | the row names the file and the reason, and no plugin line is relayed — never read as "no plugin recorded" |
 | Measurement is off | the stated half is relayed, then that single line, and the run stops before checking anything |
 | Not a git repository | the stated half is relayed, then that single line, and the run stops before checking anything — never read as "hook fired FAIL" |
 | A healthy install | all four claims read `ok`, each carrying what it was read from |

--- a/plugins/aidd-telemetry/skills/02-check/actions/02-diagnose.md
+++ b/plugins/aidd-telemetry/skills/02-check/actions/02-diagnose.md
@@ -23,9 +23,17 @@ judging anything.
    It takes no arguments and reads the current project.
 2. **Relay what is in place first, always.** Before any verdict it states whether
    measurement is allowed and from which file, whose choice that was, whether an identity
-   is attached, where records would land, and whether the recorder is declared — never a
-   count or a figure. This is not a claim and carries no `ok`/`FAIL`/`--`; present it even
-   when what follows stops immediately.
+   is attached, where records would land, whether the recorder is declared, whether each
+   installed plugin is registered with its host, and which builds produced what is being
+   read — never a count or a figure. This is not a claim and carries no `ok`/`FAIL`/`--`;
+   present it even when what follows stops immediately.
+   - **`plugins registered` is per plugin, and its lines are already ordered.** What will
+     not load comes first. Relay them in the order printed and never roll them into one
+     sentence: "some plugins are not registered" is not something a person can act on.
+     `not-registered` means the host was asked and does not carry it — it will drop the
+     declaration as orphaned. `registered-disabled` means the host carries it and declines
+     it. `unanswerable` means nothing was established, and it is never relayed as
+     "not registered".
 3. **Measurement off stops here.** After the stated half, if the next line says measurement
    is off, relay that line and stop — there is nothing to check until it is turned on, and
    no failure to report. The output is never only that one line: what is in place still
@@ -41,8 +49,10 @@ judging anything.
    "no run file" at all.** Which of four readings applies is decided by reading, never
    guessed from the absence itself:
    - The recorder is declared (the stated half already named where), and no run file has
-     appeared anywhere: reads `--`, nothing to evaluate — a declaration is not proof the
-     hook will fire, only that it was asked for.
+     appeared anywhere: reads `--`, nothing to evaluate. A declaration is not proof the hook
+     will fire, and the stated half's own `plugins registered` row is where that is
+     answered — a plugin the host never registered is dropped as orphaned however well it is
+     declared. Read that row before treating this one as a mystery.
    - The recorder is declared nowhere this build checks, and no run file has appeared
      anywhere: reads `FAIL`, naming the recorder itself as declared nowhere.
    - The stated half's own `recorder declared` row itself said "could not be read": reads
@@ -73,6 +83,9 @@ judging anything.
 | Case | Pass |
 | --- | --- |
 | Any run | what is in place is relayed first, and is never itself `ok`/`FAIL`/`--` |
+| A plugin the host never registered | its `plugins registered` line is relayed as `not-registered`, naming the registry file, and appears before any plugin that is fine |
+| A plugin whose host registry could not be read | its line is relayed as `unanswerable`, never as `not-registered` |
+| A project with no plugin recorded | the row says so in one sentence, and is never relayed as a failure |
 | Measurement is off | the stated half is relayed, then that single line, and the run stops before checking anything |
 | Not a git repository | the stated half is relayed, then that single line, and the run stops before checking anything — never read as "hook fired FAIL" |
 | A healthy install | all four claims read `ok`, each carrying what it was read from |


### PR DESCRIPTION
## 🎯 What & why

`aidd telemetry check` could say a plugin was **declared**. It could not say the host had **registered** it — and only the second decides. A host loads a plugin once it appears in its own user-global registry, whatever a project's settings declare; a declared entry it does not find there is dropped as orphaned, on a line nobody passes `--debug-file` to see. Everything else reports healthy. That is #703, and it is the installer's version of the failure this whole layer exists to remove.

The model already named the hole. `TelemetryRecorderDeclarationSetup`'s own doc said its fact *"states only that a declaration was found, never that it works"*. That paragraph now points at the answer.

## 🛠️ How it works

A new setup row, `plugins registered`, sibling to `recorder declared` — the two halves of "will this load". It costs **no session, no network, no account and no money**: every fact comes from files already on disk, which is the whole point of answering before anyone has spent anything.

**Read from AIDD's own manifest, never from a settings file.** `mergeEnabledPlugins` iterates the manifest and skips silently twice — a plugin recording no marketplace, a marketplace that does not resolve. A plugin installed under either never reaches a settings file, so comparing settings against a registry would find both sides absent and read it as agreement while the plugin never loads.

**Three hosts answer, each measured rather than assumed.** All three key their registry on the same `<plugin>@<marketplace>` string the CLI already writes:

| Host | File | Read as |
| --- | --- | --- |
| Claude Code | `~/.claude/plugins/installed_plugins.json` | JSON, and **scoped to this project** |
| Codex | `~/.codex/config.toml` | line-scanned, outside multi-line strings |
| Copilot | `~/.copilot/settings.json` | JSON, `enabledPlugins` |

Cursor and OpenCode declare no native activation, so they have no registry to look for — a different sentence from a host whose registry exists and is unmeasured.

**Four answers, none folded into another:** `registered`, `registered-disabled`, `not-registered`, `unanswerable`. The last is not a soft version of the third — a registry that cannot be parsed has said nothing, and printing that as "not registered" invents a fact.

## 🧪 How to verify

```bash
cd cli && pnpm test:unit && pnpm test:integration && pnpm test:e2e
node --test "scripts/__tests__/*.test.js"
node scripts/check-cli-layering.mjs && node scripts/check-markdown-links.js
```

At `336252cb`: CLI **3,322** across 303 files, plugin **317** across 19, all green; tsc, biome, knip, jscpd, layering and link checks clean.

End to end, with no AI tool on `PATH`:

```
plugins registered    1 of 2 will not load, or could not be answered
    claude/aidd-dev: not-registered — …/installed_plugins.json does not carry
        aidd-dev@aidd-framework — claude will drop the declaration as orphaned
    claude/aidd-telemetry: registered — …/installed_plugins.json
```

## ⚠️ Heads-up

**Found by running, not by reading.** Each survived a green suite:

- **A crash this change put on its own path.** `Manifest`'s parser maps over fields it does not guard, so a hand-edited `.aidd/manifest.json` throws. Nothing loaded the manifest from `check` before; a damaged manifest is exactly when someone runs it. Now its own line, naming the file.
- **A measurement generalised from one entry.** The Claude reader ignored `projectPath` on a doc claim that the entries decide nothing about loading. Read across all 115 entries, 100 carry one — and `aidd` registers every plugin at project scope, so `check` in one project reported a plugin installed for another as loadable here.
- **A path comparison only the e2e could catch.** `/var` is a symlink to `/private/var`: Claude writes the resolved path, the CLI holds the invoked one, and raw string equality called a registered plugin missing.
- **A guard that inverted what it protected.** Keeping the first occurrence of a Codex ref was justified by "TOML forbids defining a table twice, so a second header is necessarily not one" — which proves one of the two is fake and never which. A header inside a `"""` block before the real table won, and a disabled plugin read as registered. The scanner skips multi-line strings now, which makes the ordering rule true rather than asserted.
- **Copilot's registry is not the file that looks like it.** `~/.copilot/config.json` really is JSONC and its `installedPlugins` really is empty on a machine that has run installs — and neither matters. Driven live against Copilot CLI 1.0.82 under a sandboxed home, `plugin install` writes `~/.copilot/settings.json`, and `uninstall` sets the ref to `false` rather than deleting it.

**Three independent checks**, scoring 62, 84 and 78. The third's dip is honest: it measures a defect the second's repair introduced. Three of the four behaviour defects across all three were **false sentences beside code that looked right** — which is why every pass verified justifications against the repository, not only code against the plan.

**What this does not do.** The seam test proves the activator and the diagnostic name one ref; the registry side of that test is a literal, because closing the loop needs a host binary on `PATH` and the contract forbids one. And a fifth answer — telling "the host does not carry it" from "it never reached `enabledPlugins`" — is designed, argued and not built: it needs a declared-refs accessor the evidence port does not expose, for a distinction between two flavours of one outcome.

## 🔗 Linked issue

Closes #703

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWNxk63AGKkqE8HRqHLjGp
