### PR TITLE
fix(framework): a context reference in a form its tool cannot resolve

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,16 +40,16 @@ Project docs, memory, specs, and plans live in `aidd_docs/`.
 
 <!-- aidd_project_memory:start -->
 
-@aidd_docs/memory/architecture.md
-@aidd_docs/memory/backlog.md
-@aidd_docs/memory/cli.md
-@aidd_docs/memory/codebase-map.md
-@aidd_docs/memory/coding-assertions.md
-@aidd_docs/memory/deployment.md
-@aidd_docs/memory/ecosystem.md
-@aidd_docs/memory/project-brief.md
-@aidd_docs/memory/testing.md
-@aidd_docs/memory/vcs.md
+[aidd_docs/memory/architecture.md](aidd_docs/memory/architecture.md)
+[aidd_docs/memory/backlog.md](aidd_docs/memory/backlog.md)
+[aidd_docs/memory/cli.md](aidd_docs/memory/cli.md)
+[aidd_docs/memory/codebase-map.md](aidd_docs/memory/codebase-map.md)
+[aidd_docs/memory/coding-assertions.md](aidd_docs/memory/coding-assertions.md)
+[aidd_docs/memory/deployment.md](aidd_docs/memory/deployment.md)
+[aidd_docs/memory/ecosystem.md](aidd_docs/memory/ecosystem.md)
+[aidd_docs/memory/project-brief.md](aidd_docs/memory/project-brief.md)
+[aidd_docs/memory/testing.md](aidd_docs/memory/testing.md)
+[aidd_docs/memory/vcs.md](aidd_docs/memory/vcs.md)
 
 <!-- read on demand, not auto-loaded -->
 - aidd_docs/memory/internal/decisions/a-price-table-is-the-destination-s.md

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -63,6 +63,20 @@ pre-commit:
           exit 0
         fi
         node scripts/check-context-imports.js
+    context-reference-form:
+      # The whole repository's answer, not the staged files': the hook rewrites
+      # every target at once, so a partial view could call one file clean while
+      # its sibling drifted in the same session.
+      glob:
+        - "{CLAUDE,AGENTS,copilot-instructions}.md"
+        - "**/{CLAUDE,AGENTS,copilot-instructions}.md"
+        - "plugins/aidd-context/hooks/update_memory.js"
+      run: |
+        if ! command -v node >/dev/null 2>&1; then
+          echo "ℹ️  node not available; skipping context-reference-form"
+          exit 0
+        fi
+        node scripts/check-context-reference-form.js
     markdown-links:
       glob: "**/*.md"
       run: |

--- a/scripts/__tests__/check-context-reference-form.test.js
+++ b/scripts/__tests__/check-context-reference-form.test.js
@@ -1,0 +1,137 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const {
+  readDeclaredTargets,
+  referenceFormProblems,
+  checkFiles,
+} = require("../check-context-reference-form.js");
+
+/**
+ * The memory block's reference form, checked against the hook that writes it.
+ *
+ * `CLAUDE.md` takes `@aidd_docs/…` because Claude Code resolves that import.
+ * `AGENTS.md` takes a markdown link because the tools reading it — codex, cursor,
+ * opencode — do not: an `@` line there is inert text that loads nothing and says
+ * nothing. The hook has known this since #732; what was missing is anything that
+ * notices when a file drifts back, which is how the wrong form reached `next`
+ * inside an unrelated commit.
+ */
+
+const HOOK = `
+const TARGET_FILES = [
+  { path: "CLAUDE.md", syntax: "at" },
+  { path: "AGENTS.md", syntax: "link" },
+  { path: ".github/copilot-instructions.md", syntax: "link" },
+];
+`;
+
+function block(...lines) {
+  return [
+    "# Title",
+    "",
+    "<!-- aidd_project_memory:start -->",
+    "",
+    ...lines,
+    "",
+    "<!-- aidd_project_memory:end -->",
+    "",
+  ].join("\n");
+}
+
+const AT_LINE = "@aidd_docs/memory/architecture.md";
+const LINK_LINE = "[aidd_docs/memory/architecture.md](aidd_docs/memory/architecture.md)";
+
+// ── the hook's table is the source of truth ────────────────────────────────
+
+test("the declared form of each context file is read from the hook itself", () => {
+  assert.deepEqual(readDeclaredTargets(HOOK), [
+    { path: "CLAUDE.md", syntax: "at" },
+    { path: "AGENTS.md", syntax: "link" },
+    { path: ".github/copilot-instructions.md", syntax: "link" },
+  ]);
+});
+
+// A table this cannot read is an unknown, and an unknown is never a pass: the
+// check would go green on every file while comparing them against nothing.
+test("a hook whose table cannot be read is an error, never an empty pass", () => {
+  assert.throws(() => readDeclaredTargets("const TARGET_FILES = whatever;"), /TARGET_FILES/u);
+});
+
+// ── the form each file carries ─────────────────────────────────────────────
+
+test("a block written in the form its file declares raises nothing", () => {
+  assert.deepEqual(referenceFormProblems(block(AT_LINE), "at"), []);
+  assert.deepEqual(referenceFormProblems(block(LINK_LINE), "link"), []);
+});
+
+test("an @ import where a markdown link is declared is reported with its line", () => {
+  const problems = referenceFormProblems(block(AT_LINE), "link");
+
+  assert.equal(problems.length, 1);
+  assert.equal(problems[0].found, "at");
+  assert.equal(problems[0].reference, AT_LINE);
+  assert.equal(problems[0].line, 5);
+});
+
+test("a markdown link where an @ import is declared is reported too", () => {
+  const problems = referenceFormProblems(block(LINK_LINE), "at");
+
+  assert.equal(problems.length, 1);
+  assert.equal(problems[0].found, "link");
+});
+
+// Every reference in the block, not the first: a partially migrated file is the
+// shape a half-applied edit leaves behind, and stopping at the first hides it.
+test("every reference in the block is checked, not only the first", () => {
+  const mixed = block(LINK_LINE, AT_LINE, AT_LINE);
+
+  assert.equal(referenceFormProblems(mixed, "link").length, 2);
+});
+
+// ── what is deliberately not a problem ─────────────────────────────────────
+
+test("a context file with no memory block is not a problem", () => {
+  assert.deepEqual(referenceFormProblems("# Title\n\nprose only\n", "link"), []);
+});
+
+// The block also carries prose, comments and a read-on-demand list. Only lines
+// that are a reference are judged; anything else is none of this check's business.
+test("prose and html comments inside the block are not references", () => {
+  const content = block(
+    LINK_LINE,
+    "<!-- read on demand, not auto-loaded -->",
+    "- aidd_docs/memory/internal/decisions/a-decision.md",
+    "some prose about the bank",
+  );
+
+  assert.deepEqual(referenceFormProblems(content, "link"), []);
+});
+
+// An unpaired marker is `update_memory.js`'s own reported failure; duplicating
+// the diagnosis here would give two voices for one fault.
+test("an unclosed block is left to the hook to report", () => {
+  const unclosed = "# Title\n\n<!-- aidd_project_memory:start -->\n\n" + AT_LINE + "\n";
+
+  assert.deepEqual(referenceFormProblems(unclosed, "link"), []);
+});
+
+// ── the files on disk ──────────────────────────────────────────────────────
+
+test("a file the hook declares but the repository does not have is skipped", () => {
+  const problems = checkFiles([{ path: "does-not-exist.md", syntax: "link" }], {
+    readFileIfPresent: () => null,
+  });
+
+  assert.deepEqual(problems, []);
+});
+
+test("each problem names the file it was found in", () => {
+  const problems = checkFiles([{ path: "AGENTS.md", syntax: "link" }], {
+    readFileIfPresent: () => block(AT_LINE),
+  });
+
+  assert.equal(problems.length, 1);
+  assert.equal(problems[0].file, "AGENTS.md");
+  assert.equal(problems[0].expected, "link");
+});

--- a/scripts/check-context-reference-form.js
+++ b/scripts/check-context-reference-form.js
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+/**
+ * check-context-reference-form.js - Fails when a context file's memory block
+ * carries a reference in a form its own tool cannot resolve.
+ *
+ * `CLAUDE.md` takes `@aidd_docs/…` because Claude Code resolves that import.
+ * `AGENTS.md`, and the copilot instructions file, take markdown links because the
+ * tools reading them do not: an `@` line there is inert text that loads nothing
+ * and reports nothing.
+ *
+ * `plugins/aidd-context/hooks/update_memory.js` already writes the right form.
+ * What was missing is anything that notices a file drifting back to the wrong
+ * one — through an older copy of that hook still cached on a machine, or a stale
+ * edit swept into an unrelated commit. Both have happened.
+ *
+ * The expected form is read from the hook's own `TARGET_FILES`, never restated
+ * here: a second copy of that table could disagree with the one that writes.
+ *
+ * Usage:
+ *   node scripts/check-context-reference-form.js
+ */
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const ROOT = path.resolve(__dirname, "..");
+const HOOK = path.join(ROOT, "plugins", "aidd-context", "hooks", "update_memory.js");
+
+const BLOCK_OPEN = "<!-- aidd_project_memory:start -->";
+const BLOCK_CLOSE = "<!-- aidd_project_memory:end -->";
+
+const TARGET_ENTRY = /\{\s*path:\s*"([^"]+)"\s*,\s*syntax:\s*"(at|link)"\s*\}/gu;
+const AT_REFERENCE = /^@(\S+)$/u;
+const LINK_REFERENCE = /^\[[^\]]+\]\([^)]+\)$/u;
+
+/** The hook's own table of which file takes which form. Throws rather than
+ * returning nothing: a table that cannot be read makes every comparison below
+ * vacuous, and a check that passes because it compared against nothing is worse
+ * than no check. */
+function readDeclaredTargets(hookSource) {
+  const targets = [...hookSource.matchAll(TARGET_ENTRY)].map(([, file, syntax]) => ({
+    path: file,
+    syntax,
+  }));
+  if (targets.length === 0) {
+    throw new Error(
+      `No TARGET_FILES entries found in ${path.relative(ROOT, HOOK)}. ` +
+        "The hook's table is this check's source of truth; it cannot run without it."
+    );
+  }
+  return targets;
+}
+
+/** The form of one line, or `null` when the line is not a reference at all —
+ * prose, an html comment and the read-on-demand list all share the block. */
+function referenceForm(line) {
+  if (AT_REFERENCE.test(line)) return "at";
+  if (LINK_REFERENCE.test(line)) return "link";
+  return null;
+}
+
+/** Every reference in the memory block whose form is not the declared one.
+ *
+ * A file with no block, and one whose markers are unpaired, both yield nothing:
+ * `update_memory.js` reports the unpaired case itself, and two voices for one
+ * fault help nobody. */
+function referenceFormProblems(content, expected) {
+  const lines = content.split("\n");
+  const opensAt = lines.findIndex((line) => line.includes(BLOCK_OPEN));
+  if (opensAt === -1) return [];
+  const closesAt = lines.findIndex((line, index) => index > opensAt && line.includes(BLOCK_CLOSE));
+  if (closesAt === -1) return [];
+
+  const problems = [];
+  for (let index = opensAt + 1; index < closesAt; index += 1) {
+    const found = referenceForm(lines[index].trim());
+    if (found !== null && found !== expected) {
+      problems.push({ line: index + 1, reference: lines[index].trim(), found });
+    }
+  }
+  return problems;
+}
+
+function readFileIfPresent(relPath) {
+  const full = path.join(ROOT, relPath);
+  return fs.existsSync(full) ? fs.readFileSync(full, "utf8") : null;
+}
+
+/** A declared file the repository does not have is skipped: the hook writes to
+ * whichever of them exist, and a project carrying only one is a normal state. */
+function checkFiles(targets, io = { readFileIfPresent }) {
+  const problems = [];
+  for (const target of targets) {
+    const content = io.readFileIfPresent(target.path);
+    if (content === null) continue;
+    for (const problem of referenceFormProblems(content, target.syntax)) {
+      problems.push({ file: target.path, expected: target.syntax, ...problem });
+    }
+  }
+  return problems;
+}
+
+function reportProblems(problems, logger = console.error, successLogger = console.log) {
+  if (problems.length === 0) {
+    successLogger("✅ context references carry the form their tool resolves");
+    return;
+  }
+  logger(`❌ ${problems.length} reference(s) in a form the reading tool cannot resolve`);
+  for (const problem of problems) {
+    logger(`  ${problem.file}:${problem.line}  ${problem.reference}`);
+    logger(`    declares "${problem.expected}", found "${problem.found}"`);
+  }
+  logger("  Run the aidd-context memory refresh, or fix the block by hand.");
+}
+
+function runCli() {
+  const targets = readDeclaredTargets(fs.readFileSync(HOOK, "utf8"));
+  const problems = checkFiles(targets);
+  reportProblems(problems);
+  return problems.length === 0 ? 0 : 1;
+}
+
+module.exports = {
+  readDeclaredTargets,
+  referenceForm,
+  referenceFormProblems,
+  checkFiles,
+  reportProblems,
+  runCli,
+};
+
+if (require.main === module) process.exit(runCli());


### PR DESCRIPTION
## 🎯 What & why

`AGENTS.md` carried ten `@aidd_docs/…` lines. Codex, Cursor and OpenCode do not resolve that
import — it is inert text that loads nothing and reports nothing. This restores the markdown
links and adds the check that notices when a context file drifts back.

## 🛠️ How it works

**Two ways it drifts, both observed today, and one code path covers neither by naming them.**
A machine still holding the released `aidd-context@2.7.0` hook rewrites the block to `@` on
every session start, because that older copy declares `at` for `AGENTS.md` — the fix landed
in #732 under a `chore`, which release-please does not version-bump, so no machine has it.
And a stale edit sitting in the index rides into an unrelated commit; that is literally how
the wrong form reached `next`, inside [#749](https://github.com/ai-driven-dev/framework/pull/749).

[`scripts/check-context-reference-form.js`](scripts/check-context-reference-form.js) reads
`TARGET_FILES` from `update_memory.js` itself rather than restating the table, so the rule and
the writer cannot disagree. A table it cannot parse **throws**: a check that goes green because
it compared against nothing is worse than no check.

Only lines that are a reference are judged — the block also carries prose, an html comment and
the read-on-demand list. An unpaired marker yields nothing here: `update_memory.js` reports
that itself, and two voices for one fault help nobody.

Wired into `pre-commit` beside `context-imports`, and answering for the whole repository rather
than the staged files: the hook rewrites every target at once, so a partial view could call one
file clean while its sibling drifted in the same session.

## 🧪 How to verify

```bash
node --test 'scripts/__tests__/check-context-reference-form.test.js'   # 11
node scripts/check-context-reference-form.js                           # exit 0
node --test 'scripts/__tests__/*.test.js'                              # 344
```

On `next` before this branch, that second command prints the failure it exists for:

```
❌ 10 reference(s) in a form the reading tool cannot resolve
  AGENTS.md:43  @aidd_docs/memory/architecture.md
    declares "link", found "at"
```

**Tests first, then the code, then the mutation for each guard** — the form comparison, the
unreadable table, the stop-at-first, and what counts as a reference. All four die, each under
the test named for it, and M2 and M3 kill exactly one test each.

## ⚠️ Heads-up

**The root cause is still open.** The corrected hook cannot reach anyone: `aidd-context` is
pinned at 2.7.0, the only commit since that release touched it is a `chore`, and release-please
bumps on `feat`/`fix` alone. Until a legitimate change lands in `plugins/aidd-context/`, every
machine keeps the old hook and this check is what stops the drift from being committed. I did
not manufacture a version bump to work around it.

## 🔗 Linked issue

Refs #619

## ✅ I certify

- [ ] **I DO CERTIFY I READ EACH LINE OF THE PULL REQUEST BECAUSE I AM A SOFTWARE ENGINEER, NOT A AI PUPPY.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWNxk63AGKkqE8HRqHLjGp
