### PR TITLE
test(framework): the read path, met at a hundred sessions

### DIFF
--- a/aidd_docs/tasks/2026_09/2026_09_03_telemetry-at-scale/backlog-link.json
+++ b/aidd_docs/tasks/2026_09/2026_09_03_telemetry-at-scale/backlog-link.json
@@ -1,0 +1,5 @@
+{
+  "backlog": "ai-driven-dev/framework#694",
+  "written_at": "2026-09-03T11:20:00Z",
+  "written_by": "hand"
+}

--- a/aidd_docs/tasks/2026_09/2026_09_03_telemetry-at-scale/build-scale-sink.mjs
+++ b/aidd_docs/tasks/2026_09/2026_09_03_telemetry-at-scale/build-scale-sink.mjs
@@ -1,0 +1,115 @@
+/**
+ * Builds a synthetic telemetry sink at the scale #694 asks about: a year of day
+ * files holding a hundred journalled sessions, then reports what it wrote.
+ *
+ * Every identifier is generated. Nothing is copied from a real store: this runs
+ * against a sandbox directory, never `~/.config/aidd/telemetry`.
+ */
+import { mkdirSync, rmSync, writeFileSync, statSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+const dir = process.argv[2];
+const SESSIONS = Number(process.argv[3] ?? 100);
+const DAYS = Number(process.argv[4] ?? 365);
+const REQUESTS_PER_SESSION = Number(process.argv[5] ?? 30);
+
+if (!dir) throw new Error("usage: build-scale-sink.mjs <dir> [sessions] [days] [requests]");
+
+rmSync(dir, { recursive: true, force: true });
+mkdirSync(dir, { recursive: true });
+
+const MODELS = ["claude-opus-5", "claude-sonnet-5", "gpt-5.4", "claude-haiku-4-5-20251001"];
+const TOOLS = ["claude", "codex", "copilot", "opencode"];
+const STEPS = [
+  "aidd-dev:01-plan",
+  "aidd-dev:02-implement",
+  "aidd-dev:05-review",
+  "aidd-vcs:01-commit",
+  "aidd-context:10-learn",
+];
+
+/** Deterministic, so two runs measure the same sink. */
+let seed = 20260903;
+const next = (n) => (seed = (seed * 1103515245 + 12345) % 2147483648) % n;
+
+const day = (index) => {
+  const d = new Date(Date.UTC(2025, 8, 4) + index * 86400000);
+  return d.toISOString().slice(0, 10);
+};
+
+// The hundred sessions are spread over the year, not piled on one day: a period
+// read that only ever meets one dense file measures the wrong thing.
+const sessionDay = Array.from({ length: SESSIONS }, (_, s) => Math.floor((s * DAYS) / SESSIONS));
+
+const linesByDay = new Map();
+const push = (index, record) => {
+  const key = day(index);
+  if (!linesByDay.has(key)) linesByDay.set(key, []);
+  linesByDay.get(key).push(JSON.stringify(record));
+};
+
+let records = 0;
+let tokens = 0;
+
+for (let s = 0; s < SESSIONS; s += 1) {
+  const dayIndex = sessionDay[s];
+  const vendorId = `0000${s}`.slice(-5).padStart(8, "s") + "-0000-4000-8000-000000000000";
+  const tool = TOOLS[s % TOOLS.length];
+  const project = `project-${s % 4}`;
+
+  for (let r = 0; r < REQUESTS_PER_SESSION; r += 1) {
+    const input = 200 + next(4000);
+    const output = 50 + next(2000);
+    const cacheRead = next(60000);
+    const cacheCreation = next(9000);
+    tokens += input + output + cacheRead + cacheCreation;
+    records += 1;
+
+    push(dayIndex, {
+      kind: "request",
+      vendor_id: vendorId,
+      vendor_field: "session_id",
+      turn_id: `${vendorId}-turn-${r}`,
+      turn_field: "request_id",
+      model: MODELS[(s + r) % MODELS.length],
+      event_timestamp: `${day(dayIndex)}T${String(8 + (r % 12)).padStart(2, "0")}:00:00Z`,
+      input_tokens: input,
+      output_tokens: output,
+      cache_read_tokens: cacheRead,
+      cache_creation_tokens: cacheCreation,
+      sink_schema_version: 2,
+      provenance: "local-read",
+      tool,
+      project_id: project,
+      project_field: "repo_path_hash",
+      step_attribution: r % 3 === 0 ? "unattributed" : "tool-stated",
+      ...(r % 3 === 0 ? {} : { step: STEPS[(s + r) % STEPS.length] }),
+    });
+  }
+}
+
+// Every day of the year carries a file, empty days included: a reader that skips
+// absent files is not the same code path as one that opens 365 of them.
+for (let index = 0; index < DAYS; index += 1) {
+  const key = day(index);
+  const lines = linesByDay.get(key) ?? [];
+  writeFileSync(join(dir, `${key}.jsonl`), lines.length === 0 ? "" : `${lines.join("\n")}\n`);
+}
+
+const bytes = readdirSync(dir).reduce((sum, f) => sum + statSync(join(dir, f)).size, 0);
+console.log(
+  JSON.stringify(
+    {
+      dir,
+      dayFiles: DAYS,
+      sessions: SESSIONS,
+      records,
+      tokens,
+      megabytes: Number((bytes / 1024 / 1024).toFixed(2)),
+      firstDay: day(0),
+      lastDay: day(DAYS - 1),
+    },
+    null,
+    2
+  )
+);

--- a/aidd_docs/tasks/2026_09/2026_09_03_telemetry-at-scale/measurements.md
+++ b/aidd_docs/tasks/2026_09/2026_09_03_telemetry-at-scale/measurements.md
@@ -1,0 +1,106 @@
+# The read path, met at a hundred sessions
+
+What [#694](https://github.com/ai-driven-dev/framework/issues/694) asks to be written down
+rather than assumed acceptable: how long a period answers once the sink holds a year of day
+files and a hundred journalled sessions. Everything below was run on 2026-09-03.
+
+## Method
+
+`build-scale-sink.mjs`, beside this file, writes a sandbox sink and prints what it wrote.
+It is deterministic — a fixed seed, so two runs measure the same bytes — and every
+identifier is generated. It never reads or writes a real store.
+
+```bash
+node build-scale-sink.mjs /tmp/sink 100 365 30
+AIDD_TELEMETRY_DIR=/tmp/sink aidd telemetry report --from 2025-09-04 --to 2026-09-03
+```
+
+Sessions are spread across the year rather than piled on one day, and **every day of the
+year carries a file, empty days included**: a reader that skips absent files is not the same
+code path as one that opens 365 of them.
+
+Seven runs per figure, median reported with the spread. `HOME` is a sandbox and the project
+has measurement off, so nothing on this machine is touched.
+
+## What it costs
+
+Two scales, ten times apart.
+
+| Sink | Day files | Sessions | Records | Size | `report`, full year | Above the binary's own start |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1× | 365 | 100 | 3,000 | 1.49 MB | 238 ms | **49 ms** |
+| 10× | 365 | 1,000 | 30,000 | 14.87 MB | 316 ms | **127 ms** |
+
+`aidd --version` costs 189 ms on this machine and does nothing. That is the floor every
+figure above sits on, and subtracting it is the only way to see the read at all.
+
+**Ten times the records cost 2.6 times the read, not ten.** Opening 365 files is paid once
+whatever they hold, so the per-record cost is the smaller half at this scale. Nothing here
+grows with the *period* asked for either — the same year and the default seven days land
+within 3 ms of each other, because both open the same directory listing.
+
+| Command, 1× sink | Median | Min | Max |
+| --- | --- | --- | --- |
+| `report`, the full year | 232 ms | 227 ms | 247 ms |
+| `report --json`, the full year | 245 ms | 233 ms | 264 ms |
+| `report`, default 7 days | 229 ms | 225 ms | 235 ms |
+| `report --axis step` | 236 ms | 231 ms | 243 ms |
+| `telemetry check` | 206 ms | 204 ms | 209 ms |
+| `--version` (does nothing) | 189 ms | 187 ms | 193 ms |
+
+## What it answers
+
+Both sinks reconcile to the unit against what the generator wrote:
+
+| Sink | Generated | Reported |
+| --- | --- | --- |
+| 1× | 114,007,613 | 114,007,613 |
+| 10× | 1,137,292,186 | 1,137,292,186 |
+
+Sessions and requests come back exactly too: 100 / 3,000 and 1,000 / 30,000.
+
+And **every axis the report can print sums to that total**, in tokens and in requests both —
+checked against `--json` rather than read off the text, so no rounding hides a gap:
+
+| Axis | Rows | Tokens | Requests |
+| --- | --- | --- | --- |
+| `by_step` | 6 | = total | = total |
+| `by_model` | 4 | = total | = total |
+| `by_tool` | 5 | = total | = total |
+| `by_project` | 4 | = total | = total |
+| `by_task` | 1 | = total | = total |
+| `by_backlog` | 1 | = total | = total |
+| `by_flow` | 1 | = total | = total |
+| `by_day` | 365 | = total | = total |
+| `by_person` | 1 | = total | = total |
+| `attribution` | 3 | = total | = total |
+
+Ten independent groupings, one number. A hundred sessions is not where this arithmetic stops
+holding. Note `by_day` carries a row per day of the year, empty days included — its 365 rows
+summing exactly is the same claim as "nothing was dropped or double-counted across files".
+
+## What it refused, which is the more useful half
+
+The first build wrote `sink_schema_version: 1`. The current schema is 2, and the report
+said so:
+
+```
+  sessions                  nothing in this period
+  by day
+    365 days in this period
+  3,000 lines could not be read
+```
+
+Three thousand unreadable lines were reported as three thousand unreadable lines, not as a
+zero and not as an empty period. That is the failure mode #694 exists to make impossible,
+and it was demonstrated by accident before it was demonstrated on purpose.
+
+## What this does not prove
+
+- **Synthetic records.** Real lines carry the same fields, but a real store's size per record
+  could differ; the shape of the curve would not.
+- **One machine.** macOS 26.5, node v24.20.0, an SSD. A cold cache or a network-mounted
+  `AIDD_TELEMETRY_DIR` is another measurement, and a slower one.
+- **The write path.** This is the read alone. The turn-end walk has its own budget, measured
+  2026-08-22 and recorded in `2026_08/2026_08_21_telemetry-v1-close/measurements.md`.
+- **A real session.** No AI tool ran here. That is the remaining box on #694 and on #707.


### PR DESCRIPTION
## 🎯 What & why

[#694](https://github.com/ai-driven-dev/framework/issues/694) asks how long a period answers
once the sink holds a year of day files and a hundred journalled sessions, **and asks for the
number to be written down rather than assumed acceptable**. This measures it, at two scales
ten times apart, and commits the generator beside the numbers so the measurement can be
re-run rather than believed.

## 🛠️ How it works

`build-scale-sink.mjs` writes a sandbox sink and prints what it wrote. Deterministic seed, so
two runs measure the same bytes; every identifier generated; never reads or writes a real
store. Sessions are spread across the year rather than piled on one day, and **every day
carries a file, empty days included** — a reader that skips absent files is not the same code
path as one that opens 365 of them.

| Sink | Day files | Sessions | Records | Size | `report`, full year | Above the binary's own start |
| --- | --- | --- | --- | --- | --- | --- |
| 1× | 365 | 100 | 3,000 | 1.49 MB | 238 ms | **49 ms** |
| 10× | 365 | 1,000 | 30,000 | 14.87 MB | 316 ms | **127 ms** |

`aidd --version` costs 189 ms and does nothing. Subtracting that floor is the only way to see
the read at all. **Ten times the records cost 2.6 times the read, not ten** — opening 365 files
is paid once whatever they hold. The full year and the default seven days land within 3 ms of
each other, both opening one listing.

**Every axis sums to the total**, in tokens and in requests, checked against `--json` rather
than read off the text so no rounding hides a gap: `by_step`, `by_model`, `by_tool`,
`by_project`, `by_task`, `by_backlog`, `by_flow`, `by_day` (365 rows), `by_person`,
`attribution`. Ten independent groupings, one number. `by_day`'s 365 rows summing exactly is
the same claim as "nothing was dropped or double-counted across files".

Both sinks reconcile to the unit against what the generator wrote — 114,007,613 and
1,137,292,186.

## 🧪 How to verify

```bash
cd aidd_docs/tasks/2026_09/2026_09_03_telemetry-at-scale
node build-scale-sink.mjs /tmp/sink 100 365 30
HOME=/tmp/empty AIDD_TELEMETRY_DIR=/tmp/sink aidd telemetry report --from 2025-09-04 --to 2026-09-03
```

**The most useful result was an accident.** The first build wrote `sink_schema_version: 1`
where the schema is 2, and the report answered:

```
  sessions                  nothing in this period
  3,000 lines could not be read
```

Three thousand unreadable lines reported as three thousand unreadable lines — not a zero, not
an empty period. That is the failure mode #694 exists to make impossible, demonstrated before
it was demonstrated on purpose.

## ⚠️ Heads-up

Stated in the document rather than left implied: synthetic records, one machine (macOS 26.5,
node v24.20.0, an SSD), the read path only, and **no AI tool ran** — a real session is the
remaining box on #694 and on #707.

Three of #694's five acceptance boxes were already satisfied before this branch; the ticket
predates half of what now exists. This makes four.

## 🔗 Linked issue

Refs #694

## ✅ I certify

- [ ] **I DO CERTIFY I READ EACH LINE OF THE PULL REQUEST BECAUSE I AM A SOFTWARE ENGINEER, NOT A AI PUPPY.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWNxk63AGKkqE8HRqHLjGp
