### PR TITLE
fix(framework): a test that writes into this repository's own .git

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -28,7 +28,11 @@ pre-commit:
           echo "ℹ️  node not available; skipping scripts-tests"
           exit 0
         fi
-        node --test 'scripts/__tests__/*.test.js'
+        # Wrapped, because a suite that writes into this repository's own .git/hooks passes
+        # every assertion and destroys an install nothing can restore — `.git` is in no
+        # history. The wrapper passes the suite's own exit code through untouched.
+        node scripts/check-tests-leave-git-alone.js -- \
+          node --test 'scripts/__tests__/*.test.js'
     skill-frontmatter:
       glob: "plugins/*/skills/*/SKILL.md"
       run: |

--- a/scripts/__tests__/tests-leave-git-alone.test.js
+++ b/scripts/__tests__/tests-leave-git-alone.test.js
@@ -1,0 +1,211 @@
+const assert = require("node:assert/strict");
+const { spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  snapshotDirectory,
+  describeChanges,
+} = require("../check-tests-leave-git-alone.js");
+
+const GUARD = path.resolve(__dirname, "..", "check-tests-leave-git-alone.js");
+
+/**
+ * The guard that would have caught a test writing into the repository's own hooks.
+ *
+ * It happened: on 2026-09-03 the trailer-repair suite's `git init` inherited this
+ * repository's exported `GIT_DIR`, so its stub `prepare-commit-msg` and stub delegate
+ * landed in the real `.git/hooks`, replacing an install that had stood since 22 August.
+ * Every test passed. `aidd telemetry check` reported it hours later, by which point the
+ * original was gone — `.git/hooks` is in no history.
+ *
+ * `CLEAN_ENV` in that one suite fixes that one suite. This is the invariant instead, and it
+ * is deliberately narrower than "tests must strip GIT_*": some tests query the real
+ * repository on purpose (`git ls-files` over the tree). Reading it is fine. Changing it is
+ * never fine.
+ */
+
+function withDir(run) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "aidd-git-alone-"));
+  try {
+    return run(dir);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ── the snapshot ───────────────────────────────────────────────────────────
+
+test("a directory that does not exist snapshots as absent, never as empty", () => {
+  withDir((dir) => {
+    const missing = snapshotDirectory(path.join(dir, "nope"));
+
+    assert.equal(missing, null);
+  });
+});
+
+test("a snapshot carries every file's size and mode, not only its name", () => {
+  withDir((dir) => {
+    fs.writeFileSync(path.join(dir, "pre-commit"), "#!/bin/sh\n", { mode: 0o755 });
+
+    const shot = snapshotDirectory(dir);
+
+    assert.deepEqual(Object.keys(shot), ["pre-commit"]);
+    assert.equal(shot["pre-commit"].size, 10);
+    assert.equal(typeof shot["pre-commit"].mode, "number");
+  });
+});
+
+// ── what counts as a change ────────────────────────────────────────────────
+
+test("an untouched directory reports no change", () => {
+  withDir((dir) => {
+    fs.writeFileSync(path.join(dir, "pre-commit"), "#!/bin/sh\n");
+    const before = snapshotDirectory(dir);
+
+    assert.deepEqual(describeChanges(before, snapshotDirectory(dir)), []);
+  });
+});
+
+test("a file whose content changed is reported, even at the same size", () => {
+  withDir((dir) => {
+    const at = path.join(dir, "prepare-commit-msg");
+    fs.writeFileSync(at, "aaaaaaaaaa");
+    const before = snapshotDirectory(dir);
+    fs.writeFileSync(at, "bbbbbbbbbb");
+
+    const changes = describeChanges(before, snapshotDirectory(dir));
+
+    assert.equal(changes.length, 1);
+    assert.match(changes[0], /prepare-commit-msg/u);
+  });
+});
+
+// This is the exact shape of the leak: a real hook replaced by a shorter stub.
+test("a hook replaced by a stub is reported as changed", () => {
+  withDir((dir) => {
+    const at = path.join(dir, "prepare-commit-msg");
+    fs.writeFileSync(at, `#!/bin/sh\nsh "${dir}/aidd-session-trailer.sh" "$@"\n`, { mode: 0o755 });
+    const before = snapshotDirectory(dir);
+    fs.writeFileSync(at, "#!/bin/sh\n");
+
+    const changes = describeChanges(before, snapshotDirectory(dir));
+
+    assert.equal(changes.length, 1);
+    assert.match(changes[0], /prepare-commit-msg/u);
+  });
+});
+
+test("a file that appeared is reported as added", () => {
+  withDir((dir) => {
+    const before = snapshotDirectory(dir);
+    fs.writeFileSync(path.join(dir, "aidd-session-trailer.sh"), "#!/bin/sh\nexit 0\n");
+
+    const changes = describeChanges(before, snapshotDirectory(dir));
+
+    assert.equal(changes.length, 1);
+    assert.match(changes[0], /added.*aidd-session-trailer\.sh/u);
+  });
+});
+
+test("a file that disappeared is reported as removed, never ignored", () => {
+  withDir((dir) => {
+    const at = path.join(dir, "pre-push");
+    fs.writeFileSync(at, "#!/bin/sh\n");
+    const before = snapshotDirectory(dir);
+    fs.unlinkSync(at);
+
+    const changes = describeChanges(before, snapshotDirectory(dir));
+
+    assert.equal(changes.length, 1);
+    assert.match(changes[0], /removed.*pre-push/u);
+  });
+});
+
+// A mode change alone is what turned the leaked hook inert: git silently ignores a
+// `prepare-commit-msg` it cannot execute, so losing the bit is losing the feature.
+test("a mode change alone is reported", () => {
+  withDir((dir) => {
+    const at = path.join(dir, "prepare-commit-msg");
+    fs.writeFileSync(at, "#!/bin/sh\n", { mode: 0o755 });
+    fs.chmodSync(at, 0o755);
+    const before = snapshotDirectory(dir);
+    fs.chmodSync(at, 0o644);
+
+    const changes = describeChanges(before, snapshotDirectory(dir));
+
+    assert.equal(changes.length, 1);
+    assert.match(changes[0], /mode/u);
+  });
+});
+
+test("a directory that was absent and now exists is a change, not a fresh baseline", () => {
+  withDir((dir) => {
+    const hooks = path.join(dir, "hooks");
+    const before = snapshotDirectory(hooks);
+    fs.mkdirSync(hooks);
+    fs.writeFileSync(path.join(hooks, "pre-commit"), "x");
+
+    const changes = describeChanges(before, snapshotDirectory(hooks));
+
+    assert.equal(changes.length, 1);
+    assert.match(changes[0], /appeared/u);
+  });
+});
+
+// ── the guard, run for real ────────────────────────────────────────────────
+
+test("a command that leaves the watched directory alone passes the guard through", () => {
+  withDir((dir) => {
+    fs.writeFileSync(path.join(dir, "pre-commit"), "#!/bin/sh\n");
+
+    const run = spawnSync(process.execPath, [GUARD, "--watch", dir, "--", "true"], {
+      encoding: "utf8",
+    });
+
+    assert.equal(run.status, 0, run.stderr);
+  });
+});
+
+test("a command that writes into the watched directory fails the guard, naming the file", () => {
+  withDir((dir) => {
+    const at = path.join(dir, "prepare-commit-msg");
+    fs.writeFileSync(at, `#!/bin/sh\nsh "${dir}/delegate.sh" "$@"\n`);
+
+    const run = spawnSync(
+      process.execPath,
+      [GUARD, "--watch", dir, "--", process.execPath, "-e", `require("fs").writeFileSync(${JSON.stringify(at)}, "#!/bin/sh\\n")`],
+      { encoding: "utf8" }
+    );
+
+    assert.equal(run.status, 1);
+    assert.match(run.stderr + run.stdout, /prepare-commit-msg/u);
+  });
+});
+
+// The guard reports the command's own failure, never replaces it: a red suite must stay red
+// with its own exit code, or the guard becomes a way to lose test failures.
+test("a failing command keeps its own exit code when nothing was touched", () => {
+  withDir((dir) => {
+    // Exit 3, not 1: the guard's own failure code is 1, so asserting on 1 would hold
+    // whether the code was passed through or invented.
+    const run = spawnSync(
+      process.execPath,
+      [GUARD, "--watch", dir, "--", process.execPath, "-e", "process.exit(3)"],
+      { encoding: "utf8" }
+    );
+
+    assert.equal(run.status, 3);
+  });
+});
+
+test("the guard refuses to run with no command, rather than passing vacuously", () => {
+  withDir((dir) => {
+    const run = spawnSync(process.execPath, [GUARD, "--watch", dir], { encoding: "utf8" });
+
+    assert.equal(run.status, 2);
+    assert.match(run.stderr, /command/iu);
+  });
+});

--- a/scripts/__tests__/tests-leave-git-alone.test.js
+++ b/scripts/__tests__/tests-leave-git-alone.test.js
@@ -126,19 +126,22 @@ test("a file that disappeared is reported as removed, never ignored", () => {
 
 // A mode change alone is what turned the leaked hook inert: git silently ignores a
 // `prepare-commit-msg` it cannot execute, so losing the bit is losing the feature.
+//
+// Compared on two snapshots built by hand, never by `chmod`. Windows records no execute bit
+// — every writable file reports `0o666` whatever it was chmod'ed to — so a filesystem round
+// trip there produces no mode change to notice, and the test would be measuring the platform
+// instead of the comparison. The comparison is pure; only *producing* a mode change needs a
+// filesystem that keeps one.
 test("a mode change alone is reported", () => {
-  withDir((dir) => {
-    const at = path.join(dir, "prepare-commit-msg");
-    fs.writeFileSync(at, "#!/bin/sh\n", { mode: 0o755 });
-    fs.chmodSync(at, 0o755);
-    const before = snapshotDirectory(dir);
-    fs.chmodSync(at, 0o644);
+  const same = { size: 10, hash: "deadbeefdeadbeef" };
 
-    const changes = describeChanges(before, snapshotDirectory(dir));
+  const changes = describeChanges(
+    { "prepare-commit-msg": { ...same, mode: 0o755 } },
+    { "prepare-commit-msg": { ...same, mode: 0o644 } }
+  );
 
-    assert.equal(changes.length, 1);
-    assert.match(changes[0], /mode/u);
-  });
+  assert.equal(changes.length, 1);
+  assert.match(changes[0], /mode 0755 -> 0644/u);
 });
 
 test("a directory that was absent and now exists is a change, not a fresh baseline", () => {
@@ -161,7 +164,7 @@ test("a command that leaves the watched directory alone passes the guard through
   withDir((dir) => {
     fs.writeFileSync(path.join(dir, "pre-commit"), "#!/bin/sh\n");
 
-    const run = spawnSync(process.execPath, [GUARD, "--watch", dir, "--", "true"], {
+    const run = spawnSync(process.execPath, [GUARD, "--watch", dir, "--", process.execPath, "-e", ""], {
       encoding: "utf8",
     });
 

--- a/scripts/check-tests-leave-git-alone.js
+++ b/scripts/check-tests-leave-git-alone.js
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+/**
+ * check-tests-leave-git-alone.js - Runs a command and fails when it changed the
+ * repository's own git hooks.
+ *
+ * On 2026-09-03 the trailer-repair suite's `git init` inherited this repository's exported
+ * `GIT_DIR`, so its stub `prepare-commit-msg` and stub delegate landed in the real
+ * `.git/hooks`, replacing an install that had stood since 22 August. Every test passed.
+ * `aidd telemetry check` reported it hours later, by which point the original was gone:
+ * `.git/hooks` is in no history, so there was nothing to restore it from.
+ *
+ * Stripping `GIT_*` in that one suite fixes that one suite. This is the invariant instead,
+ * and it is deliberately narrower than "a test must strip `GIT_*`" — some tests query the
+ * real repository on purpose, walking the tree with `git ls-files`. Reading it is fine.
+ * Changing it never is.
+ *
+ * The command's own exit code is passed through untouched: a red suite must stay red with
+ * its own code, or this becomes a way to lose test failures.
+ *
+ * Usage:
+ *   node scripts/check-tests-leave-git-alone.js -- node --test 'scripts/__tests__/*.test.js'
+ *   node scripts/check-tests-leave-git-alone.js --watch <dir> -- <command...>
+ */
+
+const { spawnSync, execFileSync } = require("node:child_process");
+const { createHash } = require("node:crypto");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const ROOT = path.resolve(__dirname, "..");
+
+const USAGE_EXIT = 2;
+const CHANGED_EXIT = 1;
+
+/** The hooks directory git actually runs from, resolved the way git resolves it — a
+ * worktree's `.git` is a file, and `core.hooksPath` moves the directory outright, so
+ * neither can be assumed to be `<root>/.git/hooks`. */
+function repositoryHooksDir() {
+  try {
+    return execFileSync("git", ["rev-parse", "--path-format=absolute", "--git-path", "hooks"], {
+      cwd: ROOT,
+      encoding: "utf8",
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Every entry directly in `dir`, with what it takes to notice a change: the content hash,
+ * the size, the mode, and a symlink's target.
+ *
+ * `null` — never an empty object — when the directory does not exist. A directory that
+ * appears where there was none is a change, and an absent-reads-as-empty snapshot would
+ * call that nothing.
+ */
+function snapshotDirectory(dir) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+
+  const shot = {};
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isSymbolicLink()) {
+      shot[entry.name] = { link: fs.readlinkSync(full) };
+      continue;
+    }
+    if (!entry.isFile()) {
+      shot[entry.name] = { directory: true };
+      continue;
+    }
+    const stat = fs.statSync(full);
+    shot[entry.name] = {
+      size: stat.size,
+      mode: stat.mode & 0o777,
+      // The hash, not the size alone: the leak that prompted this replaced a hook with a
+      // stub, and two different scripts can be the same length.
+      hash: createHash("sha256").update(fs.readFileSync(full)).digest("hex").slice(0, 16),
+    };
+  }
+  return shot;
+}
+
+function describeEntry(name, before, after) {
+  if (before.link !== undefined || after.link !== undefined) {
+    return before.link === after.link ? null : `changed (symlink target): ${name}`;
+  }
+  if (before.hash !== after.hash) return `changed (content): ${name}`;
+  if (before.size !== after.size) return `changed (size): ${name}`;
+  if (before.mode !== after.mode) {
+    const octal = (m) => `0${(m ?? 0).toString(8)}`;
+    return `changed (mode ${octal(before.mode)} -> ${octal(after.mode)}): ${name}`;
+  }
+  return null;
+}
+
+/** What changed between two snapshots, as lines a person can act on. */
+function describeChanges(before, after) {
+  if (before === null && after === null) return [];
+  if (before === null) return [`the watched directory appeared: ${Object.keys(after).join(", ")}`];
+  if (after === null) return ["the watched directory disappeared"];
+
+  const changes = [];
+  for (const name of Object.keys(after)) {
+    if (before[name] === undefined) changes.push(`added: ${name}`);
+  }
+  for (const name of Object.keys(before)) {
+    if (after[name] === undefined) {
+      changes.push(`removed: ${name}`);
+      continue;
+    }
+    const change = describeEntry(name, before[name], after[name]);
+    if (change !== null) changes.push(change);
+  }
+  return changes;
+}
+
+/** `--watch <dir>` any number of times, then `--`, then the command. */
+function parseArgs(argv) {
+  const watch = [];
+  let index = 0;
+  while (index < argv.length && argv[index] !== "--") {
+    if (argv[index] === "--watch" && argv[index + 1] !== undefined) {
+      watch.push(argv[index + 1]);
+      index += 2;
+      continue;
+    }
+    return { error: `Unexpected argument: ${argv[index]}` };
+  }
+  const command = argv.slice(index + 1);
+  if (command.length === 0) return { error: "No command given after `--`; nothing to run." };
+  return { watch, command };
+}
+
+function runCli(argv = process.argv.slice(2), logger = console.error) {
+  const parsed = parseArgs(argv);
+  if (parsed.error !== undefined) {
+    logger(`❌ ${parsed.error}`);
+    logger("  Usage: check-tests-leave-git-alone.js [--watch <dir>]... -- <command...>");
+    return USAGE_EXIT;
+  }
+
+  const watched = parsed.watch.length > 0 ? parsed.watch : [repositoryHooksDir()].filter(Boolean);
+  if (watched.length === 0) {
+    logger("❌ No directory to watch, and git could not name this repository's hooks path.");
+    return USAGE_EXIT;
+  }
+
+  const before = watched.map((dir) => [dir, snapshotDirectory(dir)]);
+  const [command, ...rest] = parsed.command;
+  const run = spawnSync(command, rest, { stdio: "inherit" });
+
+  const problems = before.flatMap(([dir, shot]) =>
+    describeChanges(shot, snapshotDirectory(dir)).map((change) => `${dir}\n    ${change}`)
+  );
+
+  if (problems.length > 0) {
+    logger(`\n❌ that run changed ${problems.length} thing(s) under a watched directory`);
+    for (const problem of problems) logger(`  ${problem}`);
+    logger("  A test must never write into this repository's own git directory.");
+    logger("  Git exports GIT_DIR and friends into everything it spawns: strip GIT_* from the");
+    logger("  environment a test hands to git, or the test operates on this repository.");
+    return CHANGED_EXIT;
+  }
+
+  return run.status === null ? CHANGED_EXIT : run.status;
+}
+
+module.exports = { snapshotDirectory, describeChanges, parseArgs, repositoryHooksDir, runCli };
+
+if (require.main === module) process.exit(runCli());


### PR DESCRIPTION
## 🎯 What & why

A test suite wrote into this repository's own `.git/hooks` and every assertion passed. This
adds the invariant that would have caught it.

## 🛠️ How it works

**What happened, because the guard is shaped by it.** On 2026-09-03 the trailer-repair
suite's `git init` inherited this repository's exported `GIT_DIR`, so its stub
`prepare-commit-msg` and stub delegate landed in the real `.git/hooks`, replacing an install
that had stood since 22 August. `aidd telemetry check` reported it hours later — *"0 of the
last 20 commits carry it; prepare-commit-msg is not executable, so git ignores it"* — by
which point the original was gone. **`.git/hooks` is in no history**, so there was nothing to
restore it from.

Stripping `GIT_*` in that one suite fixes that one suite. This is the invariant instead, and
it is deliberately **narrower** than "a test must strip `GIT_*`": some tests walk the real
repository on purpose with `git ls-files`. Reading it is fine. Changing it never is.

[`scripts/check-tests-leave-git-alone.js`](scripts/check-tests-leave-git-alone.js) snapshots
the hooks directory **git actually resolves** — a worktree's `.git` is a file and
`core.hooksPath` moves the directory, so neither can be assumed to be `<root>/.git/hooks` —
runs the command, and compares.

- **Content by hash, not size.** The leak replaced a hook with a stub; two scripts can be the
  same length.
- **Mode alone counts.** Losing the execute bit is what made the leaked hook inert: git
  ignores a `prepare-commit-msg` it cannot run and only *hints* about it.
- **An absent directory snapshots as `null`, never `{}`.** A directory appearing where there
  was none is a change, and absent-reads-as-empty would call that nothing.
- **The command's exit code passes through untouched.** A red suite must stay red with its own
  code, or this becomes a way to lose test failures.

Wired into `pre-commit` by wrapping the existing `scripts-tests` command.

## 🧪 How to verify

Replay the real leak — the command exits 0, the guard exits 1:

```bash
node scripts/check-tests-leave-git-alone.js -- node -e '
const {execFileSync}=require("child_process"),fs=require("fs"),path=require("path");
const h=execFileSync("git",["rev-parse","--path-format=absolute","--git-path","hooks"],{encoding:"utf8"}).trim();
fs.writeFileSync(path.join(h,"prepare-commit-msg"),"#!/bin/sh\n");'
```

```
❌ that run changed 1 thing(s) under a watched directory
    changed (content): prepare-commit-msg
```

Then restore with `aidd telemetry on --yes`, and run the suite through it:

```bash
node scripts/check-tests-leave-git-alone.js -- node --test 'scripts/__tests__/*.test.js'
```

**357 tests pass through the wrapper**, so no suite touches the real `.git` today.

Tests first, then the code, then **six mutations — absent read as empty, no hash, no mode,
removal ignored, a change with no consequence, an empty command tolerated. Each is killed by
the single test named for it**, verified by name rather than by count.

## ⚠️ Heads-up

Only the hooks directory is watched. `.git/config`, refs and the index are not — a test that
rewrites those is a different guard, and this one does not pretend to cover it.

## ✅ I certify

- [ ] **I DO CERTIFY I READ EACH LINE OF THE PULL REQUEST BECAUSE I AM A SOFTWARE ENGINEER, NOT A AI PUPPY.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWNxk63AGKkqE8HRqHLjGp
