### PR TITLE
feat(cli): the report answers the same from anywhere, and says how it knows

### DIFF
--- a/aidd_docs/product/cost-report-contract.md
+++ b/aidd_docs/product/cost-report-contract.md
@@ -129,7 +129,33 @@ real count is the ordinary case of reporting from a project whose switch never c
 work, never a contradiction (see "Attributing records to a task" for the same scope split
 elsewhere in this object).
 
-Every object carries `cost_report_version`, currently `10`.
+Every object carries `cost_report_version`, currently `12`.
+
+Bumped from `11` when **`by_task`'s `attribution` stopped being always `"declared"`**. A
+record no declaration covers is now named after the one task folder its session wrote into,
+marked `"inferred"`, so one task can hold two rows — one per route — the same
+`(name × attribution)` shape `by_task`'s neighbour `by_step` has always had. A consumer that
+read `attribution` as a constant, or `by_task` as one row per task, misreads this version;
+summing every row's `totals` still reconciles to the period total. Two bounds make the route
+sound and both are load-bearing: a session that wrote into **two** task folders infers
+nothing, since there is no reason to choose between them; and a record outside the span its
+own journal witnessed infers nothing either — measured, a session whose journal was lost and
+recreated witnessed four minutes while the sink held its records from seven days back, and
+without that bound all seven days would have been attributed to a folder it touched today.
+Nothing new is captured for this: `file_written` was already written by the hook at turn end.
+
+Bumped from `10` when the reasons a `by_task` or `by_backlog` row can carry gained a
+fourth, **`"no-journal"`**. It separates a fact about the read from a fact about the work:
+until then, a record whose session had no usable run journal was given `"no-declaration"`,
+which asserts that the session declared no task. Measured on
+2026-09-04, running the report from a subdirectory of the repository put 100% of a period
+into `"no usable task declaration in this session"` while every journal sat one directory
+up, unread — the reader anchored at the process working directory and the hook that writes
+a journal anchors at the repository root. The reader now anchors where the writer does, and
+this reason covers what the anchor cannot reach: a project whose journals are on another
+machine, a period read outside any checkout, a session whose journal was removed. A
+consumer that switched exhaustively on the three previous reasons must add this one; every
+row's `totals` still reconciles to the period total exactly as before.
 
 Bumped from `9` when **`by_agent`** joined the top-level breakdowns. It exists because that
 is where the spend is: measured on a live session, ten subagent transcripts held 432M of its
@@ -159,9 +185,10 @@ which task a record belongs to, and resolved once per task rather than once per 
 Bumped from `5` when the row
 `by_task` gives for a record that fell in no declared interval stopped being a single row
 and became up to three, one per `reason` actually present in the period
-(`"no-declaration"`, `"precedes-declaration"`, `"journal-silent"` — see "Attributing
-records to a task" and the `by_task` section below). A consumer that read "the one row
-with no `task`" as a single, whole-period fact would misread this version; summing every
+(`"no-declaration"`, `"precedes-declaration"`, `"journal-silent"`, joined at version `11`
+by `"no-journal"` — see "Attributing records to a task" and the `by_task` section
+below). A consumer that read "the one row with no `task`" as a single, whole-period fact
+would misread this version; summing every
 row's `totals` still reconciles to the period total exactly as before, only the count and
 identity of rows with no `task` changes. Bumped from `4` when `by_task`
 joined the top-level breakdowns (a consumer summing every breakdown's `requests` against
@@ -187,7 +214,7 @@ one. Adding a field you may ignore is not a bump; changing what an existing fiel
 
 ```jsonc
 {
-  "cost_report_version": 8,
+  "cost_report_version": 12,
   "period": { "from_day": "2026-07-01", "to_day": "2026-07-31" },
   "measurement_enabled": true,                  // this project's own switch, right now — see Versioning
   "task": "2026_08/2026_08_21_cost-reporter",   // absent unless --task was given
@@ -200,7 +227,7 @@ one. Adding a field you may ignore is not a bump; changing what an existing fiel
   "by_model":   [{ "model": "gpt-5.6-sol", "totals": {} }],  // a row with no "model" names none known
   "by_tool":    [{ "tool": "codex", "coverage": "covered", "reason": "…", "capability": {}, "totals": {}, "session_totals": {} }],  // session_totals absent unless the tool has one (Copilot, today)
   "by_project": [{ "project": "acme/widgets", "totals": {} }],   // a row with no `project` names none known
-  "by_task":    [{ "task": "2026_08/2026_08_21_cost-reporter", "attribution": "declared", "totals": {} }, { "reason": "precedes-declaration", "totals": {} }],  // a row with no `task` carries `reason` instead, naming which of three facts applies; up to three such rows
+  "by_task":    [{ "task": "2026_08/2026_08_21_cost-reporter", "attribution": "declared", "totals": {} }, { "reason": "precedes-declaration", "totals": {} }],  // a row with no `task` carries `reason` instead, naming which of four facts applies; up to four such rows
   "by_backlog": [{ "backlog": "ai-driven-dev/framework#661", "totals": {} }, { "declaration": "none", "totals": {} }, { "declaration": "unreadable", "totals": {} }, { "reason": "precedes-declaration", "totals": {} }],  // a row with no `backlog` carries `declaration` (a known task naming none, or one whose declaration could not be read) or `reason` (a record in no task at all) — never both, never neither
   "by_flow":    [{ "flow": "aidd-orchestrator:01-sdlc", "started_at": "2026-07-01T09:00:00Z", "totals": {} }, { "flow": "aidd-orchestrator:01-sdlc", "started_at": "2026-07-01T11:00:00Z", "totals": {} }, { "totals": {} }],  // two runs of the same skill are two rows, told apart by `started_at`; the last row is work that fell in no flow interval at all
   "by_day":     [{ "day": "2026-07-01", "totals": {} }],         // every day in the period, in order, gaps included
@@ -240,9 +267,10 @@ ordered largest first, with a stable tie-break, so the biggest thing is the firs
 read. Ordered by `cost_micro_usd` where a row has one, and by all four token counters
 summed where it does not — never by `input_tokens` and `output_tokens` alone, which every
 tool here dwarfs with cache. `by_task` places every row for what fell in no declared
-interval last regardless of size, in `reason`'s own fixed order (`"no-declaration"`,
-`"precedes-declaration"`, `"journal-silent"`) — the same convention `by_person` gives its
-own no-identifier row, a reader sees tasks before the remainder, and the remainder in the
+interval last regardless of size, in `reason`'s own fixed order (`"no-journal"`,
+`"no-declaration"`, `"precedes-declaration"`, `"journal-silent"`) — the same convention
+`by_person` gives its own no-identifier row, a reader sees tasks before the remainder, and
+the remainder in the
 same order every time. `by_backlog` places its own named rows first, then the row for a
 known task declaring none, then the row for one whose declaration could not be read, then
 every `reason` row in that same fixed order. `by_flow` carries no such tail: the row for
@@ -282,16 +310,25 @@ ever matches, and a record lands in exactly one row.
 `attribution` is present, and always `"declared"`, on every row that carries a `task` —
 travelling with the row rather than assumed, so a consumer never has to know which route a
 breakdown reads. A row for what fell in no declared interval carries `reason` instead of
-`task` and `attribution`, naming which of three distinct facts applies — never one label
-standing in for all three, and never more than one row per reason:
+`task` and `attribution`, naming which distinct fact applies — never one label standing in
+for all of them, and never more than one row per reason. The first names a fact about the
+read, the rest facts about the work:
+
+`attribution` says which route named the task, and is present only on a row that names one:
+
+| `attribution` | What it means |
+| --- | --- |
+| `"declared"` | A `task_declared` interval in that record's session covers the record's own moment. |
+| `"inferred"` | No declared interval covers it, its session wrote into exactly one task folder, and its own journal witnessed the moment. Weaker on purpose: the journal never said this record was that task's, only that the session touched that task and nothing else. |
 
 | `reason` | What it means |
 | --- | --- |
+| `"no-journal"` | No usable run journal reached this record's session. Either none was read for it at all — the journals are on another machine, the period was read from outside any checkout, the session's own journal was removed — or one was read and could not be used, its `session_start` header torn, so nothing here knows which session its lines belong to. Never says the work declared nothing. |
 | `"no-declaration"` | This record's session never declared a task at all. |
 | `"precedes-declaration"` | A task was declared, but some declared interval in this session starts *after* this record's own moment — true both for a record before the session's very first declaration and for one landing in the gap a `turn_end` leaves between two declarations. That gap is real, but it is the journal still going, never the journal falling silent. |
 | `"journal-silent"` | A task was declared, every declared interval starts at or before this record's moment, and none of them reaches it — the journal's own declared coverage ran out before this record's moment did. |
 
-Up to three such rows can appear in one period — one per reason actually present, never
+Up to four such rows can appear in one period — one per reason actually present, never
 fewer, and never two different gaps collapsed into one row the way a single, undifferentiated
 "no declared interval" row used to read before `cost_report_version` `6`. A session whose
 declaration could not be read produces the same `"no-declaration"` row a session that never

--- a/aidd_docs/product/cost-report-contract.md
+++ b/aidd_docs/product/cost-report-contract.md
@@ -59,9 +59,11 @@ never a way to keep only one person's records. `by_backlog` is an eighth, also w
 filter of its own — see **`by_backlog`** below — regrouping `by_task`'s own rows one level
 up, by what each task's folder declares. `by_flow` is a ninth, also with no filter of its
 own — see **`by_flow`** below — grouping by which orchestrated run the journal's own step
-sequence names, never a second capture. `aidd telemetry report` also takes
-`--axis <name>` (`total`, `day`, `step`, `model`, `task`, `backlog`, `flow`, `tool`,
-`project` or `person`), which picks one of those arrays and renders it alone as a small
+sequence names, never a second capture. `by_agent` is a tenth, also with no filter of its
+own — see **`by_agent`** below — grouping by which agent ran, the main thread carrying its
+own row rather than an absence. `aidd telemetry report` also takes
+`--axis <name>` (`total`, `day`, `step`, `model`, `agent`, `task`, `backlog`, `flow`,
+`tool`, `project` or `person`), which picks one of those arrays and renders it alone as a small
 pasteable artefact instead of the whole object — a convenience for copying one figure out,
 not a second way to group. Every figure `--axis` can show is already in the plain `--json`
 object; only the one-artefact-at-a-time rendering is what it adds. A name outside the ten
@@ -127,7 +129,21 @@ real count is the ordinary case of reporting from a project whose switch never c
 work, never a contradiction (see "Attributing records to a task" for the same scope split
 elsewhere in this object).
 
-Every object carries `cost_report_version`, currently `8` — bumped from `7` when `by_flow`
+Every object carries `cost_report_version`, currently `10`.
+
+Bumped from `9` when **`by_agent`** joined the top-level breakdowns. It exists because that
+is where the spend is: measured on a live session, ten subagent transcripts held 432M of its
+466M tokens, and every one of their lines names its agent (`attributionAgent`, 100% of
+subagent tokens) where almost none names a skill (2.7%). That is why `by_step` can read a
+few percent while a session's real cost sits elsewhere — the host names a skill on the main
+thread alone, and no reader can invent one. `by_agent` needs no new capture: `agent_name` was
+already on the record. A row with no `agent` is the main thread's own, never "no agent" — a
+session starts there. On every tool but Claude Code the field is never set at all, so that
+one row carries the whole period, which is the truth for a route that names no subagents.
+
+Bumped from `8` to `9` when `attribution` gained a fourth value, `prompt-matched`.
+
+Bumped from `7` to `8` when `by_flow`
 joined the top-level breakdowns (a consumer summing every breakdown's `requests` against
 `totals.requests` now has a seventh breakdown to include). `by_flow` groups by which
 orchestrated run the journal's own step sequence already names — no skill declares that it

--- a/aidd_docs/product/metrics-contract.md
+++ b/aidd_docs/product/metrics-contract.md
@@ -696,6 +696,27 @@ ignores it exactly as it would any other field it does not recognize.
   all — its route does not name subagents as a concept, so its absence there
   says nothing about whether one ran.
 
+#### `prompt_id`
+- **Type**: string.
+- **Present**: conditional — Claude Code only, and only where its transcript
+  lets the prompt be resolved.
+- **Meaning**: the prompt this billed call belongs to. A billed call and the
+  prompt that caused it never share a transcript line: measured on a real
+  810-record session, zero lines carry both `requestId` and `promptId`, only
+  `type: "user"` lines carry the second, and all 209 lines bearing counters
+  reach one by following `parentUuid` — three hops in the median. The reader
+  walks that chain and stores what it finds.
+- **Why it exists**: the run journal writes the same identifier on `step_start`
+  (Claude Code hands its hooks `prompt_id`, stored there under the name
+  `turn_id`). Matching the two joins a step to a record exactly, rather than
+  inferring it from which interval each moment happens to fall in — the only
+  route that stays true when two tasks advance at once, since two prompts remain
+  two prompts however their moments overlap. Two tasks inside **one** prompt stay
+  indivisible: a billed amount cannot be split without inventing a ratio.
+- **If absent**: the chain reached no line naming a prompt — a transcript
+  truncated mid-write, or a host whose files carry no such identifier, which is
+  every tool but Claude Code today. Never read as "no prompt ran".
+
 #### `duration_ms`
 - **Type**: number.
 - **Present**: conditional — measured so far only on Claude Code's export

--- a/aidd_docs/tasks/2026_09/2026_09_04_a-written-file-names-a-task/plan.md
+++ b/aidd_docs/tasks/2026_09/2026_09_04_a-written-file-names-a-task/plan.md
@@ -1,0 +1,94 @@
+---
+status: done
+---
+
+# A written file names a task, and says that is how it knows
+
+## Frame
+
+### What is missing
+
+`by_task` reads one of the two signals a run journal holds.
+
+| Journal line | Read by `by_task` |
+| --- | --- |
+| `task_declared` | yes |
+| `file_written` | no |
+
+Measured on the one session in the sink with a complete journal: 1045 of 1073 records fall
+inside a declared interval, 97.4%. The remaining 27 all sit between `session_start`
+(05:21:27) and the first declaration (05:59:09) — 38 minutes of work before the flow named
+its ticket. That session wrote into exactly one task folder for its whole life.
+
+So those 27 records have an answer nobody is reading. The type that would carry it already
+exists: `TaskAttributionSource = "declared" | "inferred"`, and `CostReportTaskRow` already
+carries an `attribution` field — today always `"declared"`, which makes it a field that
+distinguishes nothing.
+
+### Why this was refused before, and what changed
+
+`by_task` refuses written paths deliberately, and a test locks the refusal: the `--task`
+filter's own inferred route attributes a **whole session**, which can place one session
+under two task rows at once. That objection is sound and is not being overruled. Two bounds
+answer it, and both are required:
+
+1. **One folder or none.** A session that wrote into two task folders infers nothing — two
+   candidates, no reason to choose. It keeps the reason row it has today.
+2. **Inside the journal's own witnessed span.** Without this bound, this very session would
+   attribute seven days of records to a task folder created today: its journal was lost and
+   recreated at 09:54 while the sink holds its records back to 2026-08-28. Measured, not
+   imagined. A record outside the span the journal actually witnessed stays unattributed.
+
+### Decisions
+
+**A task with both routes is two rows, not one.** The same task can hold declared records
+and inferred ones — 1045 and 27 in the measured session. One row carrying the weaker
+attribution would state something false about the 1045. Two rows follow the convention
+`by_step` already uses, whose rows are `(step × attribution)` pairs; the accumulator mirrors
+`addToStepGroup` line for line rather than inventing a second way to key a pair.
+
+**Nothing is asked of a skill or of the model.** `file_written` is written by the hook at
+turn end, from a walk of the task tree. This route consumes what is already captured.
+
+**The envelope rises to 12.** `by_task`'s `attribution` stops being always `"declared"`; a
+consumer that read it as constant misreads this version.
+
+## Phases
+
+| # | Phase | Proves |
+| --- | --- | --- |
+| 1 | A session's witnessed span reaches the report | a record outside it can be refused |
+| 2 | One written folder names the records no declaration covers | 97.4% becomes 100%, marked `inferred` |
+| 3 | The contract says both | envelope version, contract document, display |
+
+Test first at every phase; each guard ships with the mutation that proves it.
+
+## Result
+
+Measured on the one session in a real sink with a complete journal, 1073 requests:
+
+```
+declared 1045 + inferred 28 = 1073   (100.0%)   reste 0
+```
+
+97.4% before, 100.0% after. Nothing was asked of a skill or of the model: `file_written` was
+already written by the hook at turn end.
+
+Two bounds carried the change, and both fired on real data:
+
+- **One folder or none.** Unit-guarded, and proven end to end on a session that writes into
+  two task folders and therefore keeps `precedes-declaration`.
+- **Inside the journal's witnessed span.** On the same sink, one session's journal was lost
+  and recreated: 28,079 records from the seven days before it stay unattributed, exactly as
+  they should. Without the bound they would have been named after a folder that session
+  touched today.
+
+A third fact turned up while measuring and is fixed here rather than left: a journal moment
+is a **second** (`nowIso()` strips the milliseconds) while a record carries them, so a record
+landing inside the very second the journal last wrote was being refused by a rounding
+artefact. It cost exactly one record of 1073 — the difference between 99.9% and 100.0%.
+
+Nine mutations, each killed by the test that names it. `pnpm test` — build included — 311
+files, 3450 tests. Contract at `cost_report_version` 12, its worked example pinned to the
+emitted version, and every reason now required as a table row rather than a mention
+anywhere in the prose.

--- a/aidd_docs/tasks/2026_09/2026_09_04_the-reader-finds-the-journal/plan.md
+++ b/aidd_docs/tasks/2026_09/2026_09_04_the-reader-finds-the-journal/plan.md
@@ -1,0 +1,128 @@
+---
+status: done
+---
+
+# The reader finds the journal, and says so when it cannot
+
+## Frame
+
+### The observed fault
+
+`aidd telemetry report --days 30 --json` answers differently depending on the directory it
+is run from, on the same machine, against the same sink and the same journals.
+
+| run from | requests | `by_task` |
+| --- | --- | --- |
+| `cli/` | 1106 | one row, `"reason": "no-declaration"`, 100% |
+| the repository root | 29207 | four named tasks, 3.1% |
+
+Neither number is the interesting part. The `reason` is: `"no-declaration"` is a positive
+claim about the work — *this session declared no task*. What actually happened is that the
+reader never found the journal directory at all. An unknown was reported as a zero, which
+is the one thing this project's own rules refuse.
+
+### The cause, measured
+
+The hook that writes a journal and the CLI that reads it do not anchor at the same place.
+
+| | anchor | code |
+| --- | --- | --- |
+| writer | the repository root | `getRepoLocation(cwd)` → `git rev-parse --show-toplevel`, then `<root>/aidd_docs/runs` (`plugins/aidd-telemetry/hooks/lib/repo.cjs:310`) |
+| reader | the process working directory | `projectRoot: process.cwd()` (`cli/src/application/commands/global-options.ts:16`), then `join(projectRoot, DOCS_DIR, RUNS_SUBDIR)` (`cli/src/infrastructure/adapters/run-journal-reader-adapter.ts:193`) |
+
+Run from `cli/`, the reader looks in `cli/aidd_docs/runs`, which does not exist. `readdir`
+throws, `list()` answers `[]`, no session has an interval, and `taskUnattributedReason`
+returns `"no-declaration"` because `intervals.length === 0` is the only branch it has.
+
+### Two faults, not one
+
+Fixing the anchor alone would leave the lie in place for every case the anchor cannot
+reach: a repository with no `aidd_docs/runs` at all, a report run outside any repository, a
+sink holding records from a project whose journals are on another machine. In each, a
+person is still told the work declared no task.
+
+So the fix is in two parts, and the second is the one that matters:
+
+1. The reader anchors where the writer anchored.
+2. A record whose session has **no journal at all** is its own reason, distinct from a
+   record whose session has a journal that declared nothing.
+
+### Decisions
+
+**The anchor is found by walking up for `.git`, not by shelling out to git.** The writer
+uses `git rev-parse --show-toplevel`; the reader reaches the same directory by walking up
+from `projectRoot` for a `.git` entry — a file for a linked worktree, a directory for a
+main checkout, both accepted. No subprocess on a read path that runs on every report, and
+the same answer for every layout this repository is developed in. `AIDD_RUNS_DIR` still
+overrides both, unchanged.
+
+**Only the journal reader's anchor moves, not `projectRoot` itself.** `projectRoot` also
+drives the manifest, auth and the marketplace; moving it would relocate plugin
+installation, which is a different change with a different blast radius. That the project
+marketplace source `"path": "."` also resolves against the process cwd is a separate
+finding, named here and not fixed here.
+
+**The new reason is per record, not a period-level field.** `read` already carries
+`identity_unusable` for a period-level unknown, and a second field beside it would say
+"some session somewhere had no journal" — true and useless. `TaskUnattributedReason` is
+already the vocabulary for *why this record belongs to no task*; a fourth value is the
+existing mechanism, not a parallel one. `Record<TaskUnattributedReason, string>` in
+`cost-report-display.ts:44` makes the compiler enumerate every consumer.
+
+**The journal is not moved to the user profile.** It was considered and refused:
+
+- the journal holds repository-relative paths (`aidd_docs/tasks/2026_09/…`), anchored by
+  `taskFolderRelativePath(repoRoot, …)`; outside the repository they resolve to nothing;
+- two worktrees of one repository would share one directory, and one task path would name
+  two different trees — this very change is being written in such a worktree;
+- it fixes neither fault: an empty global directory still cannot tell "no journal" from
+  "no declaration".
+
+The real tension it was meant to answer stays, and is stated rather than solved: the sink
+is per user, the journal is per repository, so records made in project B and read from
+project A have no journal and never will. `by_project` already separates them, and after
+this change they read `"no-journal"`, which is what they are.
+
+**The step and flow axes are out of scope, and the reason is not symmetry.** Their
+`unattributed` row asserts nothing about the work — it says this layer could not place the
+record, which stays true whether a journal was missing or silent. Only `by_task` and
+`by_backlog` make a positive claim that can be false.
+
+## Phases
+
+| # | Phase | Proves |
+| --- | --- | --- |
+| 1 | The reader anchors at the repository root | a report run from a subdirectory finds the journal |
+| 2 | A session with no journal is its own reason | `"no-journal"` never reads as `"no-declaration"` |
+| 3 | The contract says both | envelope version, contract document, artefact and display labels |
+
+Each phase is test-first: the test is written, run, and watched to fail for the reason it
+names, before the code that satisfies it exists. Each guard ships with the mutation that
+proves it.
+
+## Check
+
+An independent checker read the plan, the diff and the repository, and returned six findings
+and a verdict of not shippable. Every one was reproduced before being acted on, and every one
+is now closed:
+
+| # | Finding | What it actually was | Closed by |
+| --- | --- | --- | --- |
+| 1 | Moving only the journal reader desynchronizes the backlog reader | Real, and worse than the fault being fixed: from a subdirectory `by_task` named the task while `by_backlog` said that task declared no backlog item. Reproduced as `expected 'none' to be 'declared'` | `repositoryRootAbove` extracted to `infrastructure/repository-root.ts` and applied to `TaskBacklogAdapter` too, with its own test and mutation |
+| 2 | Four consumers of the version were missed and the suite is red | Real. `npx vitest run` does not build, and the e2e tier runs `dist/cli.js` — the project's gate is `pnpm test` (`pnpm build && vitest run`). The green reported was against a stale binary | Two e2e expectations and the envelope fixture updated; every later gate run through `pnpm test` |
+| 3 | The new reason claims more than it knows | Real. A journal whose `session_start` header is torn is read and then dropped (`report-cost-use-case.ts:102`), so its records reach this reason. "No journal was read at all" was false for that case, where the old label had been true | Reworded to "no usable run journal" in the label, the type and the contract, and pinned by a test that refuses the old wording |
+| 4 | Eight doc sentences the diff itself falsified | Real. `Record<TaskUnattributedReason, string>` forces the compiler to enumerate consumers; it cannot enumerate prose | All eight corrected |
+| 5 | The cost skill's report template offers no cell for the fourth reason | Real, and its version paragraph was three bumps stale | Template and paragraph brought to version 11; the pinned claim count raised 17 → 18 with its reason |
+| 6, 7 | "the three, and only three" heading four bullets; two unwrapped lines | Real, cosmetic | Reworded and rewrapped |
+
+Two guards were added that would have caught what slipped: the contract document's own
+worked example is now pinned to the emitted version (it had drifted to `8` while the prose
+said `10`), and the wording of the new reason is pinned against the claim the checker
+proved false.
+
+## Result
+
+Ten axes, every one reconciling to the period total exactly, measured on a copy of a real
+machine's sink with the built binary. The report now answers identically from the repository
+root and from a subdirectory, and says `"no-journal"` — not `"no-declaration"` — where it
+had no usable journal to read.

--- a/cli/src/application/display/cost-report-artefact.ts
+++ b/cli/src/application/display/cost-report-artefact.ts
@@ -35,6 +35,7 @@ export const ARTEFACT_AXES = [
   "day",
   "step",
   "model",
+  "agent",
   "task",
   "backlog",
   "flow",
@@ -51,6 +52,8 @@ const NOTHING_IN_SELECTION = "nothing in this selection";
 const SESSION_TOTAL_LABEL = "session total, not requests";
 const NO_KNOWN_PROJECT = "no known project";
 const NO_KNOWN_MODEL = "no known model";
+// Not "no agent": the main thread is where a session starts, not an absence.
+const MAIN_THREAD = "the main thread";
 // Distinct on purpose, per the contract's own three-way shape: an unresolved row names an
 // identity that is real but unplaced, and repeats once per such identity since each is its
 // own row; the no-identity row is singular and says nobody opted in at all. Neither label
@@ -325,6 +328,17 @@ function flowArtefact(envelope: CostReportEnvelope): string {
   ].join("\n");
 }
 
+function agentArtefact(envelope: CostReportEnvelope): string {
+  return table(
+    envelope,
+    "by agent",
+    "Agent",
+    envelope.by_agent.map(
+      (row) => `| ${row.agent ?? MAIN_THREAD} | ${figure(row.totals, envelope)} |`
+    )
+  );
+}
+
 function modelArtefact(envelope: CostReportEnvelope): string {
   return table(
     envelope,
@@ -401,6 +415,7 @@ const BUILDERS: Record<ArtefactAxis, (envelope: CostReportEnvelope) => string> =
   day: dayArtefact,
   step: stepArtefact,
   model: modelArtefact,
+  agent: agentArtefact,
   task: taskArtefact,
   backlog: backlogArtefact,
   flow: flowArtefact,

--- a/cli/src/application/display/cost-report-display.ts
+++ b/cli/src/application/display/cost-report-display.ts
@@ -38,10 +38,16 @@ export const TASK_ATTRIBUTION_LABELS: Record<TaskAttributionSource, string> = {
   inferred: "inferred from a written file",
 };
 
-/** What each of the three reasons a record fell in no declared interval is called where a
- * person reads it - never one label standing in for all three, which is the fault this
- * breakdown exists to avoid (see `CostReportTaskRow`). */
+/** What each reason a record fell in no declared interval is called where a person reads
+ * it - never one label standing in for all of them, which is the fault this breakdown
+ * exists to avoid (see `CostReportTaskRow`).
+ *
+ * The first names a fact about the read, the rest facts about the work, and the wording
+ * keeps them apart: "no usable run journal" says this layer never had a journal it could
+ * attach to this session - none read, or one read whose header was torn - where "no usable
+ * task declaration" says it had one and found no declaration in it. */
 export const TASK_UNATTRIBUTED_LABELS: Record<TaskUnattributedReason, string> = {
+  "no-journal": "no usable run journal for this session",
   "no-declaration": "no usable task declaration in this session",
   "precedes-declaration": "before the next task this session declares",
   "journal-silent": "the journal falls silent before this record",
@@ -406,7 +412,7 @@ function printProjects(
   }
 }
 
-/** One row per task a record's own moment fell inside, plus up to three rows for what fell
+/** One row per task a record's own moment fell inside, plus up to four rows for what fell
  * in none - one per reason present, always after every named task and in
  * `TASK_UNATTRIBUTED_REASONS`' own fixed order, the same placement `byPeople` gives its own
  * no-identifier row. Carries the attribution beside a named row for the same reason
@@ -427,7 +433,7 @@ function printTasks(output: CLIOutput, rows: readonly CostReportTaskRow[], basis
 }
 
 /** One row per backlog item a task in the period declared, plus the two rows for a known
- * task that named none or could not be read, plus up to three reason rows for a record in
+ * task that named none or could not be read, plus up to four reason rows for a record in
  * no task at all - the same tail order `printTasks` gives its own remainder. No attribution
  * column: unlike a task's closed interval, a backlog row rests on one route only. */
 function printBacklog(

--- a/cli/src/application/display/cost-report-display.ts
+++ b/cli/src/application/display/cost-report-display.ts
@@ -28,6 +28,7 @@ import type { CLIOutput } from "../output.js";
  * reading would be a fact this layer invented. */
 export const ATTRIBUTION_LABELS: Record<StepAttributionSource, string> = {
   "tool-stated": "stated by the tool",
+  "prompt-matched": "matched on the prompt",
   "journal-interval": "from a journal interval",
   unattributed: "unattributed",
 };
@@ -56,11 +57,15 @@ export const BACKLOG_DECLARATION_LABELS: Record<"none" | "unreadable", string> =
 };
 
 /** Printed where a figure is genuinely not known, never as `$0.00`. A tool whose own files
- * carry no amount has an unknown cost, not a free one. */
-const UNKNOWN_AMOUNT = "amount unknown";
+ * carry no amount has an unknown cost, not a free one. Exported so another renderer of the
+ * same report — the interactive telemetry screen — prints the identical words rather than
+ * a second literal that could drift from this one. */
+export const UNKNOWN_AMOUNT = "amount unknown";
 /** A covered tool with no records, and a wholly unfiltered period with none at all.
  * Distinct from both an unknown amount and a zero: this one really did measure nothing,
- * and saying so is the only reading the records support. */
+ * and saying so is the only reading the records support. Not exported: every reader outside
+ * this module reaches this string through `nothingLabel`, which decides between this and
+ * `NOTHING_IN_SELECTION` — never through the literal itself. */
 const NOTHING_MEASURED = "nothing in this period";
 /** The same zero, under a selection narrower than the whole period. `task` and every
  * generic filter already narrow the record set before any breakdown is computed, so a
@@ -81,18 +86,21 @@ const NO_KNOWN_MODEL = "no known model";
 // render.cjs's own MAX_PRINTED_DAYS: the byte-compare e2e test holds the two to it.
 const MAX_PRINTED_DAYS = 31;
 
-function formatCount(value: number): string {
+/** Exported alongside `formatAmount` and `totalTokens` so the interactive telemetry screen
+ * renders the same figures this text report does, rather than a second formatting routine
+ * that could read a count differently from this one. */
+export function formatCount(value: number): string {
   return value.toLocaleString("en-US");
 }
 
-function formatAmount(microUsd: number): string {
+export function formatAmount(microUsd: number): string {
   return `$${fromMicroUsd(microUsd).toFixed(2)}`;
 }
 
 /** Every token a record counted, across the four disjoint counters — a tool's `input` is
  * exclusive of its cache figures on every reader here, so adding them counts nothing
- * twice. */
-function totalTokens(totals: CostTotals): number {
+ * twice. Exported for the same reason `formatCount` is. */
+export function totalTokens(totals: CostTotals): number {
   return (
     (totals.inputTokens ?? 0) +
     (totals.outputTokens ?? 0) +
@@ -103,14 +111,18 @@ function totalTokens(totals: CostTotals): number {
 
 /** What a share is taken of. Cost where the period has one, tokens where it does not — a
  * period made only of tools that carry no amount still breaks down, by the quantity it
- * does have. Named in the output so nobody has to guess which. */
-function shareBasis(totals: CostTotals): { readonly label: string; readonly of: number } {
+ * does have. Named in the output so nobody has to guess which. Exported so the interactive
+ * telemetry screen takes a row's share by the identical rule this text report already
+ * applies to every breakdown, rather than a second percentage rule that could drift from
+ * this one. */
+export function shareBasis(totals: CostTotals): { readonly label: string; readonly of: number } {
   return totals.costMicroUsd === undefined
     ? { label: "of tokens", of: totalTokens(totals) }
     : { label: "of cost", of: totals.costMicroUsd };
 }
 
-function shareOf(totals: CostTotals, basis: number, useCost: boolean): string {
+/** Exported for the same reason `shareBasis` is. */
+export function shareOf(totals: CostTotals, basis: number, useCost: boolean): string {
   if (basis === 0) return "  - ";
   const part = useCost ? (totals.costMicroUsd ?? 0) : totalTokens(totals);
   return `${Math.round((part / basis) * 100)
@@ -118,8 +130,21 @@ function shareOf(totals: CostTotals, basis: number, useCost: boolean): string {
     .padStart(3)}%`;
 }
 
+/** A label, in a column of `width` — and always followed by something.
+ *
+ * `padEnd` returns a longer string unchanged, so a label wider than the column would run
+ * straight into whatever comes after it: a real project id is the repository's own remote,
+ * and `git@github.com:…/framework.git` printed as `…framework.git100%`. Measured on a live
+ * report; no fixture had ever carried an identifier that long. Exported so every
+ * column-padded reader of a label — this file's own `pad`, and the interactive telemetry
+ * screen's row list, whose own attribution-carrying labels (F2) are wider still — shares
+ * this one guarantee rather than each risking the same collision at its own width. */
+export function padTo(label: string, width: number): string {
+  return label.length >= width ? `${label} ` : label.padEnd(width);
+}
+
 function pad(label: string): string {
-  return label.padEnd(LABEL_WIDTH);
+  return padTo(label, LABEL_WIDTH);
 }
 
 /** `task` and the four generic filters both narrow the record set before any breakdown
@@ -131,7 +156,12 @@ function hasSelection(report: Pick<CostReport, "task" | "filters">): boolean {
   return report.task !== undefined || report.filters !== undefined;
 }
 
-function nothingLabel(report: Pick<CostReport, "task" | "filters">): string {
+/** Never a bare `0` and never `NOTHING_MEASURED` under a selection: `task` and the four
+ * generic filters both narrow the record set before any breakdown runs, so a zero under
+ * either reads as the selection's own doing, not the period's. Exported so the interactive
+ * telemetry screen tells the two absences apart the identical way this text report already
+ * does, rather than a second rule that could drift from this one. */
+export function nothingLabel(report: Pick<CostReport, "task" | "filters">): string {
   return hasSelection(report) ? NOTHING_IN_SELECTION : NOTHING_MEASURED;
 }
 
@@ -157,8 +187,10 @@ function unknownReason(filter: CostReportFilterName): string {
 
 /** What a filter matching nothing says, told apart from a period that genuinely holds no
  * work: that case never reaches here, since the report only ever carries an
- * `emptySelection` when a filter - not the period itself - is what emptied it. */
-function emptySelectionMessage({
+ * `emptySelection` when a filter - not the period itself - is what emptied it. Exported so
+ * the interactive telemetry screen names the same culprit in the same words, rather than a
+ * second rendering of `CostReportEmptySelection` that could disagree with this one. */
+export function emptySelectionMessage({
   filter,
   value,
   known,
@@ -172,9 +204,20 @@ function emptySelectionMessage({
 
 /** Never a bare `0`: a period nothing was measured in reads as "nothing in this period"
  * (or selection), the same refusal `requests` already makes below - a session count is no
- * less a claim about what was measured than a request count is. */
-function sessionsFigure(report: CostReport): string {
+ * less a claim about what was measured than a request count is. Exported for the same
+ * reason `formatCount` is. */
+export function sessionsFigure(report: CostReport): string {
   return report.sessions === 0 ? nothingLabel(report) : formatCount(report.sessions);
+}
+
+/** Cache reads' share of `tokens`, rounded to a whole percent - `0` when there are no
+ * tokens to divide, never `NaN`. `tokens` arrives as a parameter rather than being
+ * recomputed here: every caller already has its own `totalTokens(totals)` at hand, and
+ * this stays the one place the rounding happens rather than a formula copied at each call
+ * site. Exported so the interactive telemetry screen reads the same figure through this one
+ * function rather than a second copy that could drift from it. */
+export function cacheReadSharePercent(totals: CostTotals, tokens: number): number {
+  return tokens === 0 ? 0 : Math.round(((totals.cacheReadTokens ?? 0) / tokens) * 100);
 }
 
 function printTotals(output: CLIOutput, report: CostReport): void {
@@ -185,7 +228,7 @@ function printTotals(output: CLIOutput, report: CostReport): void {
     return;
   }
   const tokens = totalTokens(totals);
-  const cacheShare = tokens === 0 ? 0 : Math.round(((totals.cacheReadTokens ?? 0) / tokens) * 100);
+  const cacheShare = cacheReadSharePercent(totals, tokens);
   output.print(`  ${pad("sessions")}${sessionsFigure(report)}`);
   output.print(`  ${pad("requests")}${formatCount(totals.requests)}`);
   output.print(`  ${pad("tokens")}${formatCount(tokens)}    ${cacheShare}% cache`);

--- a/cli/src/application/display/cost-report-display.ts
+++ b/cli/src/application/display/cost-report-display.ts
@@ -79,6 +79,8 @@ const SESSION_TOTAL_LABEL = "session total, not requests";
 const LABEL_WIDTH = 26;
 const NO_KNOWN_PROJECT = "no known project";
 const NO_KNOWN_MODEL = "no known model";
+// Not "no agent": the main thread is where a session starts, not an absence.
+const MAIN_THREAD = "the main thread";
 
 // A year asked for by day is 365 rows - the envelope always carries every one of them, but
 // a terminal is not the place to read that many. Above this, the text rendering names the
@@ -362,6 +364,22 @@ function printStepsAndAttribution(output: CLIOutput, report: CostReport, basis: 
   printAttributionRows(output, report.attributionMix, basis.of, basis.useCost);
 }
 
+/** Printed straight after the steps, because it answers what they cannot: on a session that
+ * delegates, the step axis names a few percent and this one names the rest. Measured — ten
+ * subagent files held 432M of a live session's 466M tokens. */
+function printAgents(output: CLIOutput, report: CostReport, basis: Basis): void {
+  if (report.byAgents.length === 0) return;
+  output.print("");
+  output.print(`  by agent    ${basis.label}`);
+  for (const row of report.byAgents) {
+    const name = row.agent ?? MAIN_THREAD;
+    const share = shareOf(row.totals, basis.of, basis.useCost);
+    output.print(
+      `    ${padTo(name, LABEL_WIDTH)}${share}   ${figureFor(row.totals, basis.useCost)}`
+    );
+  }
+}
+
 function printModels(output: CLIOutput, report: CostReport, basis: Basis): void {
   if (report.byModels.length === 0) return;
   output.print("");
@@ -512,6 +530,7 @@ function printBreakdowns(output: CLIOutput, report: CostReport): void {
   };
   printTaskAttribution(output, report, basis);
   printStepsAndAttribution(output, report, basis);
+  printAgents(output, report, basis);
   printModels(output, report, basis);
   printProjects(output, report.byProjects, basis);
   printTasks(output, report.byTasks, basis);

--- a/cli/src/application/use-cases/telemetry/diagnose-telemetry-use-case.ts
+++ b/cli/src/application/use-cases/telemetry/diagnose-telemetry-use-case.ts
@@ -4,7 +4,11 @@ import {
   SESSION_TRAILER_TOKEN,
 } from "../../../domain/formats/commit-session-trailer.js";
 import { resolveSessionAnchor } from "../../../domain/models/session-anchor.js";
-import { attributeMoment, buildStepIntervals } from "../../../domain/models/step-attribution.js";
+import {
+  attributeMoment,
+  buildStepIntervals,
+  type StepAttributionSource,
+} from "../../../domain/models/step-attribution.js";
 import {
   diagnoseTelemetryClaims,
   type TelemetryClaim,
@@ -333,7 +337,7 @@ export class DiagnoseTelemetryUseCase {
 function stampAttribution(
   record: { readonly step?: string; readonly event_timestamp?: string },
   intervals: ReturnType<typeof buildStepIntervals>
-): { readonly stepAttribution: "tool-stated" | "journal-interval" | "unattributed" } {
+): { readonly stepAttribution: StepAttributionSource } {
   if (record.step !== undefined) return { stepAttribution: "tool-stated" };
   return { stepAttribution: attributeMoment(intervals, record.event_timestamp).source };
 }

--- a/cli/src/application/use-cases/telemetry/report-cost-use-case.ts
+++ b/cli/src/application/use-cases/telemetry/report-cost-use-case.ts
@@ -11,6 +11,11 @@ import {
 } from "../../../domain/models/cost-report.js";
 import { buildFlowIntervals } from "../../../domain/models/flow-attribution.js";
 import type { ResolvedReportPeriod } from "../../../domain/models/report-period.js";
+import {
+  attributeMoment,
+  buildStepIntervals,
+  type StepInterval,
+} from "../../../domain/models/step-attribution.js";
 import { buildTaskIntervals } from "../../../domain/models/task-attribution.js";
 import {
   type TaskBacklogDeclaration,
@@ -201,6 +206,83 @@ function identityInputFields(
   };
 }
 
+/** Which skill each prompt opened, from the journal's own `step_start` lines.
+ *
+ * **First wins.** Three steps can open under one prompt — measured on a live session, where
+ * `aidd-orchestrator:01-sdlc`, `aidd-pm:04-spec` and `aidd-dev:01-plan` all carried
+ * `839ab4a8-…`. A prompt therefore names the step its work *began* in, and a later opener
+ * never rewrites it: taking the last would answer "plan" for the reasoning that produced the
+ * spec, which is a different claim and a wrong one. */
+function promptToSkill(journal: RunJournal): ReadonlyMap<string, string> {
+  const byPrompt = new Map<string, string>();
+  for (const boundary of journal.boundaries) {
+    if (boundary.type !== "step_start" || boundary.turn_id === undefined) continue;
+    if (!byPrompt.has(boundary.turn_id)) byPrompt.set(boundary.turn_id, boundary.skill);
+  }
+  return byPrompt;
+}
+
+/** The step a record's own prompt opened, where both sides name the same one.
+ *
+ * Outranks the interval, and says so: `prompt-matched` is an identifier two sources agree
+ * on, where `journal-interval` is an inference from moments. It is the only reading that
+ * stays true when two tasks advance at once — two prompts remain two prompts however their
+ * moments overlap. Two tasks inside *one* prompt stay indivisible: a billed amount cannot be
+ * split without inventing a ratio, and this returns the one step that prompt opened. */
+function matchOnPrompt(
+  record: TelemetrySinkRecord,
+  byPrompt: ReadonlyMap<string, string> | undefined
+): { readonly source: "prompt-matched"; readonly step: string } | null {
+  if (record.prompt_id === undefined || byPrompt === undefined) return null;
+  const step = byPrompt.get(record.prompt_id);
+  return step === undefined ? null : { source: "prompt-matched", step };
+}
+
+/** Every record's step, taken from the journal rather than from the record.
+ *
+ * **A judgement is derived; only an observation is trusted from disk.** `step_attribution`
+ * is written into the record when it is read, so a record stored before a rule was
+ * corrected keeps whatever that rule answered — for good. Measured on a live sink: it
+ * reported 91% `unattributed` while a fresh read of the very same session, under the same
+ * build, reported 0%. Nothing in the store was wrong when it was written; it was simply
+ * frozen at the moment the least was known about it.
+ *
+ * `tool-stated` is left alone. The tool naming a skill on the line carrying the counters is
+ * something it witnessed, not something anyone inferred, and no journal can improve on it.
+ *
+ * A session the period's journals say nothing about is left alone too — there is no
+ * interval to judge it against, and overwriting a stored answer with a blanker one would
+ * trade a stale reading for no reading at all. */
+function withDerivedStep(
+  records: readonly TelemetrySinkRecord[],
+  journals: readonly RunJournal[]
+): readonly TelemetrySinkRecord[] {
+  const bySession = new Map<string, readonly StepInterval[]>();
+  const skillByPrompt = new Map<string, ReadonlyMap<string, string>>();
+  for (const journal of journals) {
+    if (!journal.session) continue;
+    bySession.set(journal.session.vendor_id, buildStepIntervals(journal));
+    skillByPrompt.set(journal.session.vendor_id, promptToSkill(journal));
+  }
+
+  return records.map((record) => {
+    if (record.step_attribution === "tool-stated") return record;
+    const intervals = bySession.get(record.vendor_id);
+    if (intervals === undefined) return record;
+
+    const matched = matchOnPrompt(record, skillByPrompt.get(record.vendor_id));
+    const derived = matched ?? attributeMoment(intervals, record.event_timestamp);
+    // Rebuilt rather than spread over: a record that carried a step from an earlier reading
+    // must lose it when the journal no longer names one, and a spread would keep it.
+    const { step: _step, step_plugin: _plugin, ...rest } = record;
+    return {
+      ...rest,
+      step_attribution: derived.source,
+      ...(derived.step === undefined ? {} : { step: derived.step }),
+    };
+  });
+}
+
 /** Every gathered read, folded into the one shape `buildCostReport` wants - kept on its own
  * so `execute` reads as "gather, then assemble," not a wall of field assignments. */
 function toReportInput(
@@ -216,7 +298,7 @@ function toReportInput(
   return {
     fromDay,
     toDay,
-    records: read.records,
+    records: withDerivedStep(read.records, journals),
     journals: journals
       .map((journal) => toSessionJournal(journal, periodEndMs))
       .filter((journal) => journal !== null),
@@ -241,29 +323,53 @@ function toReportInput(
  * in particular no amount, since the rates live outside this repository and an amount is
  * only ever reported where a tool's own files already carried one.
  */
-/** Sessions the journal knows about that the period's stored records say nothing about,
- * and whose own session_start falls inside the period.
+/** Sessions holding at least one stored record a re-read could never be matched against.
  *
- * Both halves matter. Without the first, a report re-reads sessions already stored, for
- * nothing. Without the second, a report over one week would re-read every session a
- * repository has ever journalled, and the cost of catching up would grow with the age of
- * the project rather than with the length of the period asked about.
+ * A re-read is reconciled with what is stored on `turn_id`, and `groupByTurnId` indexes
+ * nothing without one — so re-reading such a session appends its records a second time.
+ * That was a documented edge while only unseen sessions were read; once every session in
+ * the period is, it would double a figure on every report.
  *
- * A session that genuinely billed nothing stays in this list, and is re-read on every
- * report over its own week. That is the honest cost of not keeping a second file recording
- * which sessions have already been looked at — a file whose only job would be to remember
- * an answer the sink can already be asked for. */
-function sessionsNotYetRead(
+ * Found by the reference week going from 7 requests to 10, not by reasoning: its transcripts
+ * are hand-written and carry no `requestId`. Claude Code writes one on every line — 0 of 810
+ * records without one on a live sink — but a host that does not must not be silently
+ * doubled, and "in general it has one" is not a guard. */
+function sessionsWithAnUnmatchableRecord(
+  stored: readonly TelemetrySinkRecord[]
+): ReadonlySet<string> {
+  const sessions = new Set<string>();
+  for (const record of stored) {
+    if (record.turn_id === undefined) sessions.add(record.vendor_id);
+  }
+  return sessions;
+}
+
+/** Every session the journal names whose own `session_start` falls inside the period.
+ *
+ * **Not "the ones the sink has never seen".** That was the rule until 2026-09-04, keyed on
+ * whether a session appeared in the stored records at all, and it froze a session the
+ * moment its first turn was stored: a session still running was declared read and never
+ * looked at again. Measured live — the sink held 285 records while the transcript had 541,
+ * and `report` caught up none of them. It answered with a plausible wrong figure, which is
+ * the one thing every other rule in this layer refuses.
+ *
+ * Re-reading costs little and is safe: `read-local-cost-use-case.ts` dedupes per `turn_id`
+ * and appends only what is missing, so the session-level gate was a second filter at the
+ * wrong granularity.
+ *
+ * The period bound is what keeps the cost from growing with the age of the project: without
+ * it a report over one week would re-read every session a repository has ever journalled. */
+function sessionsToCatchUp(
   stored: readonly TelemetrySinkRecord[],
   journals: readonly RunJournal[],
   fromMs: number,
   periodEndMs: number
 ): readonly string[] {
-  const known = new Set(stored.map((record) => record.vendor_id));
+  const unmatchable = sessionsWithAnUnmatchableRecord(stored);
   const missing: string[] = [];
   for (const journal of journals) {
     const session = journal.session;
-    if (session === undefined || known.has(session.vendor_id)) continue;
+    if (session === undefined || unmatchable.has(session.vendor_id)) continue;
     const atMs = Date.parse(session.at);
     // `periodEndMs` is the first instant *after* the period, which is why this is `>=` and
     // not `>`. Computing an end here rather than taking the one `periodEndMsOf` already
@@ -342,7 +448,7 @@ export class ReportCostUseCase {
     period: { from: Date; to: Date; periodEndMs: number }
   ): Promise<TelemetrySinkPeriodRead> {
     if (this.readLocalCost === undefined) return read;
-    const missing = sessionsNotYetRead(
+    const missing = sessionsToCatchUp(
       read.records,
       journals,
       period.from.getTime(),

--- a/cli/src/application/use-cases/telemetry/report-cost-use-case.ts
+++ b/cli/src/application/use-cases/telemetry/report-cost-use-case.ts
@@ -122,7 +122,10 @@ function witnessedSpan(journal: RunJournal): { fromMs: number; toMs: number } | 
   // landed inside the very second the journal last wrote. Measured, that rounding cost one
   // record of 1073 on a real session. The start needs no such widening: a truncated moment
   // already sits at the first instant of its own second.
-  return { fromMs: Math.min(...moments), toMs: Math.max(...moments) + LAST_MILLISECOND_OF_A_SECOND };
+  return {
+    fromMs: Math.min(...moments),
+    toMs: Math.max(...moments) + LAST_MILLISECOND_OF_A_SECOND,
+  };
 }
 
 function toSessionJournal(

--- a/cli/src/application/use-cases/telemetry/report-cost-use-case.ts
+++ b/cli/src/application/use-cases/telemetry/report-cost-use-case.ts
@@ -95,11 +95,42 @@ function declaredTools(): readonly CostReportToolDeclaration[] {
   });
 }
 
+/** The first and last moment a journal's own lines carry, or nothing when not one of them
+ * carries a moment this reader can parse. Every line kind counts, not only the kinds an
+ * interval opens or closes on: the question this answers is "was this journal open then",
+ * and a written file witnesses that as surely as a boundary does.
+ *
+ * Not capped at the period's end, unlike an unclosed interval. This span is only ever asked
+ * whether it contains a record's moment, and the sink never returns a record past the
+ * period end, so a clock-skewed line can widen the span past a moment no record can reach -
+ * it cannot pull one in. */
+const LAST_MILLISECOND_OF_A_SECOND = 999;
+
+function witnessedSpan(journal: RunJournal): { fromMs: number; toMs: number } | undefined {
+  const moments = [
+    ...journal.boundaries,
+    ...journal.taskDeclarations,
+    ...journal.filesWritten,
+    ...(journal.session ? [journal.session] : []),
+  ]
+    .map((line) => Date.parse(line.at))
+    .filter((atMs) => !Number.isNaN(atMs));
+  if (moments.length === 0) return undefined;
+  // The end is the end of the second the last line names, not that second's first instant.
+  // A journal moment IS a second - `nowIso()` in the writing hook strips the milliseconds
+  // - while a record carries them, so comparing the two as instants refuses a record that
+  // landed inside the very second the journal last wrote. Measured, that rounding cost one
+  // record of 1073 on a real session. The start needs no such widening: a truncated moment
+  // already sits at the first instant of its own second.
+  return { fromMs: Math.min(...moments), toMs: Math.max(...moments) + LAST_MILLISECOND_OF_A_SECOND };
+}
+
 function toSessionJournal(
   journal: RunJournal,
   periodEndMs: number
 ): CostReportSessionJournal | null {
   if (!journal.session) return null;
+  const span = witnessedSpan(journal);
   return {
     vendorId: journal.session.vendor_id,
     tool: journal.session.tool,
@@ -107,6 +138,7 @@ function toSessionJournal(
     writtenPaths: journal.filesWritten.map((written) => written.path),
     taskIntervals: buildTaskIntervals(journal, periodEndMs),
     flowIntervals: buildFlowIntervals(journal, periodEndMs),
+    ...(span === undefined ? {} : { witnessed: span }),
   };
 }
 
@@ -122,13 +154,21 @@ function distinctTaskIdentities(
 ): readonly TaskIdentity[] {
   const seen = new Set<TaskIdentity>();
   const identities: TaskIdentity[] = [];
+  const remember = (identity: TaskIdentity | null): void => {
+    if (identity === null || seen.has(identity)) return;
+    seen.add(identity);
+    identities.push(identity);
+  };
   for (const journal of journals) {
     for (const interval of buildTaskIntervals(journal, periodEndMs)) {
-      const identity = taskIdentityFromWrittenPath(interval.path);
-      if (identity !== null && !seen.has(identity)) {
-        seen.add(identity);
-        identities.push(identity);
-      }
+      remember(taskIdentityFromWrittenPath(interval.path));
+    }
+    // Written paths too, not declared intervals alone: a task the written-file route names
+    // has a folder like any other, and that folder can declare a backlog item. Resolving
+    // from declarations alone would send every inferred record to "this task declares no
+    // backlog item" - a claim about the task, produced by a lookup that never ran.
+    for (const written of journal.filesWritten) {
+      remember(taskIdentityFromWrittenPath(written.path));
     }
   }
   return identities;

--- a/cli/src/domain/formats/claude-code-transcript.ts
+++ b/cli/src/domain/formats/claude-code-transcript.ts
@@ -39,6 +39,9 @@ interface ClaudeUsage {
 interface ClaudeTranscriptLine {
   readonly type?: unknown;
   readonly sessionId?: unknown;
+  readonly uuid?: unknown;
+  readonly parentUuid?: unknown;
+  readonly promptId?: unknown;
   readonly requestId?: unknown;
   readonly isSidechain?: unknown;
   readonly timestamp?: unknown;
@@ -156,6 +159,51 @@ function buildRecord(
   };
 }
 
+/** One JSONL line as an object, or `null` for a blank or unparseable one. Shared by the
+ * billed-turn parser and the link walk, so a line either reaches both or neither. */
+function parseLine(line: string): ClaudeTranscriptLine | null {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+  try {
+    return JSON.parse(trimmed) as ClaudeTranscriptLine;
+  } catch {
+    return null;
+  }
+}
+
+function uuidOf(line: string): string | undefined {
+  const parsed = parseLine(line);
+  return parsed === null ? undefined : asString(parsed.uuid);
+}
+
+/** The prompt a line belongs to, found by walking `parentUuid` upward.
+ *
+ * A billed call and the prompt that caused it never share a line: measured on a real
+ * 810-record session, zero lines carry both `requestId` and `promptId`, only `type: "user"`
+ * lines carry the second, and all 209 lines bearing counters reach one this way — three hops
+ * in the median.
+ *
+ * `seen` bounds the walk instead of a hop count: a transcript is appended to by a live
+ * process and can be truncated mid-write, so a parent that points at a line which never
+ * arrived, or a cycle a damaged file leaves behind, must end the walk rather than search
+ * forever. A hop cap would also terminate, but it would silently stop answering for a
+ * legitimately deep chain, which is the kind of number nobody could ever justify. */
+function resolvePromptId(
+  startUuid: string | undefined,
+  parents: ReadonlyMap<string, string>,
+  prompts: ReadonlyMap<string, string>
+): string | undefined {
+  const seen = new Set<string>();
+  let current = startUuid;
+  while (current !== undefined && !seen.has(current)) {
+    const prompt = prompts.get(current);
+    if (prompt !== undefined) return prompt;
+    seen.add(current);
+    current = parents.get(current);
+  }
+  return undefined;
+}
+
 /** One parsed JSONL line, keyed by `message.id` — the identifier that ties together the
  * separate log lines one API call can produce. Mapping every such line to its own record
  * would count that single call's tokens more than once.
@@ -202,15 +250,42 @@ class ClaudeCodeTranscriptAccumulator implements TranscriptLineAccumulator {
   // position stays where the call first appeared, so the order a reader sees is the order
   // the calls happened.
   private readonly byKey = new Map<string, LocalCostCandidateRecord>();
+  // Which line each record came from, so its prompt can be resolved once every line has
+  // been seen — a parent almost always appears earlier, but nothing in the format promises
+  // it, and a walk run mid-stream would answer from a half-built map.
+  private readonly uuidByKey = new Map<string, string>();
+  // Every line's own links, gathered from *all* lines rather than only billed ones: the
+  // chain from a call to its prompt runs through lines that carry no counters at all.
+  private readonly parents = new Map<string, string>();
+  private readonly prompts = new Map<string, string>();
 
   push(line: string): void {
+    this.rememberLinks(line);
     const parsed = parseAssistantLine(line);
     if (!parsed) return;
     this.byKey.set(parsed.dedupeKey, parsed.record);
+    const uuid = uuidOf(line);
+    if (uuid !== undefined) this.uuidByKey.set(parsed.dedupeKey, uuid);
+  }
+
+  /** Parsed a second time, deliberately: `parseAssistantLine` answers `null` for every line
+   * that is not a billed assistant turn, and those are exactly the lines this walk needs. */
+  private rememberLinks(line: string): void {
+    const parsed = parseLine(line);
+    if (parsed === null) return;
+    const uuid = asString(parsed.uuid);
+    if (uuid === undefined) return;
+    const parent = asString(parsed.parentUuid);
+    if (parent !== undefined) this.parents.set(uuid, parent);
+    const prompt = asString(parsed.promptId);
+    if (prompt !== undefined) this.prompts.set(uuid, prompt);
   }
 
   build(): readonly LocalCostCandidateRecord[] {
-    return [...this.byKey.values()];
+    return [...this.byKey.entries()].map(([key, record]) => {
+      const promptId = resolvePromptId(this.uuidByKey.get(key), this.parents, this.prompts);
+      return promptId === undefined ? record : { ...record, prompt_id: promptId };
+    });
   }
 }
 

--- a/cli/src/domain/models/cost-report-envelope.ts
+++ b/cli/src/domain/models/cost-report-envelope.ts
@@ -18,6 +18,12 @@ import type { AiToolId } from "./tool-ids.js";
  * `sink_schema_version` exists on a stored line. Adding a field a consumer may ignore is
  * not a bump; changing what an existing field means is.
  *
+ * Bumped to 10: `by_agent` is a new top-level breakdown, and a consumer summing every
+ * breakdown's `requests` against `totals.requests` to check nothing was dropped now has one
+ * more to include. It exists because that is where the spend is: on a live session, ten
+ * subagent files held 432M of 466M tokens, every one of their lines naming its agent and
+ * almost none its skill.
+ *
  * Bumped to 9: `attribution` gains a fourth value, `prompt-matched`. A consumer that
  * understood the three before it — mapping them to labels, or switching exhaustively — meets
  * a value it has no case for, which is a misread rather than a field it may ignore. It ranks
@@ -71,7 +77,7 @@ import type { AiToolId } from "./tool-ids.js";
  * `by_project`'s `project` to optional back when that row was added.
  *
  * Bumped to 2: `by_project` and `by_day` are new top-level breakdowns. */
-export const COST_REPORT_ENVELOPE_VERSION = 9;
+export const COST_REPORT_ENVELOPE_VERSION = 10;
 
 /** Money as whole micro-dollars, the way the report carries it: an integer, so a consumer
  * summing several reports gets the same answer this one did. Divide by 1,000,000 for
@@ -174,6 +180,11 @@ export interface CostReportEnvelopeBacklogRow {
  * skill and `startedAt` when it opened, together telling apart two rows that share a name:
  * the same skill run twice in one session is two rows, never merged into one. Both are
  * absent on the one row for work that fell in no flow interval at all. */
+export interface CostReportEnvelopeAgentRow {
+  readonly agent?: string;
+  readonly totals: CostReportEnvelopeTotals;
+}
+
 export interface CostReportEnvelopeFlowRow {
   readonly flow?: string;
   readonly started_at?: string;
@@ -250,6 +261,8 @@ export interface CostReportEnvelope {
   readonly by_task: readonly CostReportEnvelopeTaskRow[];
   readonly by_backlog: readonly CostReportEnvelopeBacklogRow[];
   readonly by_flow: readonly CostReportEnvelopeFlowRow[];
+  /** One row per agent that ran, `agent` absent on the main thread's own row. */
+  readonly by_agent: readonly CostReportEnvelopeAgentRow[];
   /** Every day the period spans, always — a long period stays readable by how the text
    * rendering chooses to show it, never by what this envelope omits. */
   readonly by_day: readonly CostReportEnvelopeDayRow[];
@@ -347,6 +360,10 @@ function backlogRow(row: CostReport["byBacklog"][number]): CostReportEnvelopeBac
   };
 }
 
+function agentRow(row: CostReport["byAgents"][number]): CostReportEnvelopeAgentRow {
+  return { ...(row.agent === undefined ? {} : { agent: row.agent }), totals: totals(row.totals) };
+}
+
 function flowRow(row: CostReport["byFlows"][number]): CostReportEnvelopeFlowRow {
   return {
     ...(row.flow === undefined ? {} : { flow: row.flow }),
@@ -418,6 +435,7 @@ function breakdownFields(
   | "by_task"
   | "by_backlog"
   | "by_flow"
+  | "by_agent"
   | "by_day"
   | "by_person"
 > {
@@ -429,6 +447,7 @@ function breakdownFields(
     by_task: report.byTasks.map(taskRow),
     by_backlog: report.byBacklog.map(backlogRow),
     by_flow: report.byFlows.map(flowRow),
+    by_agent: report.byAgents.map(agentRow),
     by_day: report.byDays.map((row) => ({ day: row.day, totals: totals(row.totals) })),
     by_person: report.byPeople.map(personRow),
   };

--- a/cli/src/domain/models/cost-report-envelope.ts
+++ b/cli/src/domain/models/cost-report-envelope.ts
@@ -18,6 +18,23 @@ import type { AiToolId } from "./tool-ids.js";
  * `sink_schema_version` exists on a stored line. Adding a field a consumer may ignore is
  * not a bump; changing what an existing field means is.
  *
+ * Bumped to 12: `by_task`'s `attribution` stops being always `"declared"`. A record no
+ * declaration covers, in a session whose journal witnessed it and that wrote into exactly
+ * one task folder, is now named after that folder and marked `"inferred"` - so one task can
+ * hold two rows, one per route, the same `(name x attribution)` shape `by_step` already has.
+ * A consumer that read `attribution` as constant, or `by_task` as one row per task,
+ * misreads this version. Measured: on the one session with a complete journal, 1045 of 1073
+ * records fell inside a declared interval and the remaining 27 sat between `session_start`
+ * and the first declaration, 38 minutes of work before the flow named its ticket.
+ *
+ * Bumped to 11: a `by_task` or `by_backlog` row with no task gains a fourth possible
+ * `reason`, `no-journal`. A consumer that switched exhaustively on the three before it meets
+ * a value it has no case for, which is a misread rather than a field it may ignore. It
+ * separates a fact about the read from a fact about the work: a session with no journal read
+ * for it used to be given `no-declaration`, which asserts the session declared no task.
+ * Measured 2026-09-04 - a report run from a subdirectory put 100% of a period into that row
+ * while every journal sat one directory up, unread.
+ *
  * Bumped to 10: `by_agent` is a new top-level breakdown, and a consumer summing every
  * breakdown's `requests` against `totals.requests` to check nothing was dropped now has one
  * more to include. It exists because that is where the spend is: on a live session, ten
@@ -77,7 +94,7 @@ import type { AiToolId } from "./tool-ids.js";
  * `by_project`'s `project` to optional back when that row was added.
  *
  * Bumped to 2: `by_project` and `by_day` are new top-level breakdowns. */
-export const COST_REPORT_ENVELOPE_VERSION = 10;
+export const COST_REPORT_ENVELOPE_VERSION = 12;
 
 /** Money as whole micro-dollars, the way the report carries it: an integer, so a consumer
  * summing several reports gets the same answer this one did. Divide by 1,000,000 for
@@ -157,9 +174,11 @@ export interface CostReportEnvelopeProjectRow {
 }
 
 /** One framework task's figures, keyed on the closed interval a record's own moment falls
- * in - see `CostReportTaskRow`. `attribution` is present, and always `"declared"`, only
- * alongside `task`; a row for what fell in no declared interval carries `reason` instead,
- * naming which of three distinct facts applies - never both, and never neither. */
+ * in - see `CostReportTaskRow`. `attribution` is present only alongside `task`, and says
+ * which route named it: `"declared"` where a `task_declared` interval covers the record,
+ * `"inferred"` where the session wrote into exactly one task folder and no declaration
+ * covered it. One task can therefore carry two rows, one per route; a row for what fell in no declared interval carries `reason` instead,
+ * naming which distinct fact applies - never both, and never neither. */
 export interface CostReportEnvelopeTaskRow {
   readonly task?: string;
   readonly attribution?: TaskAttributionSource;

--- a/cli/src/domain/models/cost-report-envelope.ts
+++ b/cli/src/domain/models/cost-report-envelope.ts
@@ -18,6 +18,12 @@ import type { AiToolId } from "./tool-ids.js";
  * `sink_schema_version` exists on a stored line. Adding a field a consumer may ignore is
  * not a bump; changing what an existing field means is.
  *
+ * Bumped to 9: `attribution` gains a fourth value, `prompt-matched`. A consumer that
+ * understood the three before it — mapping them to labels, or switching exhaustively — meets
+ * a value it has no case for, which is a misread rather than a field it may ignore. It ranks
+ * above `journal-interval` and below `tool-stated`: an identifier two sources independently
+ * name is stronger than an inference from moments, weaker than the tool saying it outright.
+ *
  * Bumped to 8: `by_flow` is a new top-level breakdown - a consumer summing every
  * breakdown's `requests` against `totals.requests` to check nothing was dropped now has a
  * seventh breakdown to include, the same reasoning that bumped `by_backlog` in. Grouped
@@ -65,7 +71,7 @@ import type { AiToolId } from "./tool-ids.js";
  * `by_project`'s `project` to optional back when that row was added.
  *
  * Bumped to 2: `by_project` and `by_day` are new top-level breakdowns. */
-export const COST_REPORT_ENVELOPE_VERSION = 8;
+export const COST_REPORT_ENVELOPE_VERSION = 9;
 
 /** Money as whole micro-dollars, the way the report carries it: an integer, so a consumer
  * summing several reports gets the same answer this one did. Divide by 1,000,000 for

--- a/cli/src/domain/models/cost-report.ts
+++ b/cli/src/domain/models/cost-report.ts
@@ -165,14 +165,15 @@ export interface CostReportProjectRow {
  * never has to assume a strength this object does not state.
  *
  * A record that fell in no declared interval carries `reason` instead of `task` -
- * `TaskUnattributedReason` names which of three distinct facts applies, never one label
- * standing in for all three: no usable task declaration exists in that record's session; a
+ * `TaskUnattributedReason` names which distinct fact applies, never one label standing in
+ * for all of them: no usable journal reached that record's session at all; no usable task
+ * declaration exists in a session whose journal was read; a
  * task was declared but this record precedes it (whether every declaration, or the gap a `turn_end`
  * leaves before the next one); or a task was declared and the journal's own declared
  * coverage runs out before this record's moment. Never for a written file this breakdown
  * does not consult, and never split from a declaration the journal simply could not read:
  * the journal records a `task_declared` line or it does not, and those two read as
- * `"no-declaration"` alike. Up to three such rows can appear in one period, one per reason
+ * `"no-declaration"` alike. Up to four such rows can appear in one period, one per reason
  * actually present - never collapsed into one, since two different gaps are not one gap.
  * Sorted apart from every other breakdown: largest first among named tasks, with every
  * reason row last, in `TASK_UNATTRIBUTED_REASONS`' own fixed order, so a reader sees tasks
@@ -201,7 +202,7 @@ export interface CostReportTaskRow {
  *   still counted, here and in every other breakdown, exactly as `by_task` counts a record
  *   whose declaration could not be read.
  * - `reason` — the record belongs to no task at all, carrying the same
- *   `TaskUnattributedReason` `CostReportTaskRow` gives it; up to three such rows, one per
+ *   `TaskUnattributedReason` `CostReportTaskRow` gives it; up to four such rows, one per
  *   reason actually present, never collapsed into one. */
 export interface CostReportBacklogRow {
   readonly backlog?: string;
@@ -272,6 +273,19 @@ export interface CostReportSessionJournal {
   /** Straight from `buildFlowIntervals`, the same way `taskIntervals` comes from
    * `buildTaskIntervals` - built once per session, never re-derived per record. */
   readonly flowIntervals: readonly FlowInterval[];
+  /** The first and last moment this journal actually witnessed, from its own lines - the
+   * bound the written-file route infers inside and never outside.
+   *
+   * A journal witnesses only the time it was open for, which is not the time its session
+   * produced records: a journal lost and recreated mid-session witnesses the minutes since,
+   * while the sink still holds that session's records from days before. Measured on a live
+   * machine - one session's journal began at 09:54 while its own records ran back a week -
+   * and without this bound the written-file route would have attributed all seven days to a
+   * task folder that session touched today.
+   *
+   * Absent when no line in the journal carried a moment this reader could parse: nothing
+   * was witnessed, so nothing can be inferred. */
+  readonly witnessed?: { readonly fromMs: number; readonly toMs: number };
 }
 
 /** The four dimensions that narrow on an equal record field - `task` keeps its own route
@@ -602,11 +616,87 @@ function modelKeyOf(record: TelemetrySinkRecord): ModelKey {
 
 // The same idea, for the task a record's own moment fell inside - a record whose session
 // never declared one, whose moment falls before a declaration, or whose moment the
-// journal's own declared coverage has run out before, is its own group, keyed on *which* of
-// those three this record is, never dropped and never collapsed into one bucket. A plain
+// journal's own declared coverage has run out before - and one whose session no usable
+// journal ever reached - is its own group, keyed on *which* of those this record is, never
+// dropped and never collapsed into one bucket. A plain
 // string, unlike `NO_KNOWN_PROJECT` and `NO_KNOWN_MODEL`: `TaskIdentity` is always
 // `${month}/${name}`, which a reason string never is, so the two can never collide.
 type TaskRowKey = TaskIdentity | TaskUnattributedReason;
+
+/** How a record came to belong to a task, or why it belongs to none - the value every task
+ * axis keys on, computed once per record. A named membership carries `attribution` beside
+ * the identity rather than only the identity, because the same task holds records from both
+ * routes: on the session this route was measured against, 1045 records fell inside a
+ * declared interval and 27 preceded the first declaration entirely. One row carrying the
+ * weaker attribution would state something false about the 1045. */
+interface TaskGroup {
+  readonly task?: TaskIdentity;
+  readonly attribution?: TaskAttributionSource;
+  readonly reason?: TaskUnattributedReason;
+  readonly totals: TotalsAccumulator;
+}
+
+/** Mirrors `addToStepGroup`, which folds that axis' own pairs the same way. */
+function addToTaskGroup(
+  groups: Map<string, TaskGroup>,
+  row: TaskRow,
+  record: TelemetrySinkRecord
+): void {
+  const key = taskRowKeyOf(row);
+  const existing = groups.get(key);
+  if (existing) {
+    existing.totals.add(record);
+    return;
+  }
+  const created: TaskGroup =
+    typeof row === "string"
+      ? { reason: row, totals: new TotalsAccumulator() }
+      : { task: row.task, attribution: row.attribution, totals: new TotalsAccumulator() };
+  created.totals.add(record);
+  groups.set(key, created);
+}
+
+interface TaskMembershipRow {
+  readonly task: TaskIdentity;
+  readonly attribution: TaskAttributionSource;
+}
+
+type TaskRow = TaskMembershipRow | TaskUnattributedReason;
+
+const TASK_ROW_SEPARATOR = " ";
+
+/** Mirrors `stepRowKey`, which keys that axis' own `(name x attribution)` pairs the same
+ * way, rather than inventing a second way to key a pair. A `TaskIdentity` is always
+ * `${month}/${name}` and an attribution is never one, so a named key can never collide with
+ * a reason key. */
+function taskRowKeyOf(row: TaskRow): string {
+  return typeof row === "string" ? row : `${row.attribution}${TASK_ROW_SEPARATOR}${row.task}`;
+}
+
+/** The one task a session's written files name, when they name exactly one.
+ *
+ * Two written folders infer nothing: two candidates and no reason to choose between them.
+ * That refusal is what answers the objection that kept written paths out of this breakdown
+ * until now - the `--task` filter's own inferred route attributes a whole session, which can
+ * place one session under two task rows at once. Refusing is not a fallback here, it is the
+ * bound that makes the route sound. */
+function soleWrittenTaskOf(journal: CostReportSessionJournal | undefined): TaskIdentity | null {
+  if (journal === undefined) return null;
+  const identities = new Set(taskIdentitiesFromWrittenPaths(journal.writtenPaths));
+  if (identities.size !== 1) return null;
+  const [only] = identities;
+  return only ?? null;
+}
+
+/** Whether this journal witnessed `momentIso` at all - never an unbounded yes for a journal
+ * that carries no readable moment. */
+function witnessed(journal: CostReportSessionJournal | undefined, momentIso: string | undefined): boolean {
+  const span = journal?.witnessed;
+  if (span === undefined || momentIso === undefined) return false;
+  const momentMs = Date.parse(momentIso);
+  if (Number.isNaN(momentMs)) return false;
+  return momentMs >= span.fromMs && momentMs <= span.toMs;
+}
 
 // The same idea, one level above a task: a task whose folder declares no backlog item, or
 // whose declaration exists but could not be read, is its own group - never folded into
@@ -626,14 +716,19 @@ type BacklogRowKey =
  * `buildTaskIntervals`'s own output, never a second notion of when a task was running.
  * Unlike `declaredIntervalsForTask`, this keeps every task a session ever declared, not
  * only one: `byTasks` groups by whichever task a record's moment falls in, not by
- * membership in a single task asked for. */
+ * membership in a single task asked for.
+ *
+ * **Every journal gets an entry, including one that declared nothing.** The empty list and
+ * the absent key are two different facts and `taskRowOf` reads them as two: a key
+ * mapped to `[]` is a journal that was read and declared nothing, an absent key is a
+ * session no journal was read for at all. Skipping the empty ones - which this did until
+ * 2026-09-04 - collapsed both into `"no-declaration"`, so a report that never found the
+ * runs directory announced that the work had declared no task. */
 function allTaskIntervalsByVendorId(
   journals: readonly CostReportSessionJournal[]
 ): ReadonlyMap<string, readonly TaskInterval[]> {
   const byVendorId = new Map<string, readonly TaskInterval[]>();
-  for (const journal of journals) {
-    if (journal.taskIntervals.length > 0) byVendorId.set(journal.vendorId, journal.taskIntervals);
-  }
+  for (const journal of journals) byVendorId.set(journal.vendorId, journal.taskIntervals);
   return byVendorId;
 }
 
@@ -652,20 +747,34 @@ function allTaskIntervalsByVendorId(
  * being deleted as dead code. Reading such a moment the same as no interval covering it at
  * all is deliberate, not an invented fourth reason: a path this layer cannot turn into an
  * identity names no task a person could act on by name either. */
-function declaredTaskKeyOf(
+function taskRowOf(
   record: TelemetrySinkRecord,
-  intervalsByVendorId: ReadonlyMap<string, readonly TaskInterval[]>
-): TaskRowKey {
-  const intervals = intervalsByVendorId.get(record.vendor_id) ?? [];
+  intervalsByVendorId: ReadonlyMap<string, readonly TaskInterval[]>,
+  journalsByVendorId: ReadonlyMap<string, CostReportSessionJournal>
+): TaskRow {
+  const intervals = intervalsByVendorId.get(record.vendor_id);
+  // No entry at all means no journal was read for this session - never that it declared
+  // nothing. `allTaskIntervalsByVendorId` gives every journal it read an entry, so the two
+  // cases are distinguishable here and nowhere else.
+  if (intervals === undefined) return "no-journal";
   const interval = intervals.find((candidate) =>
     momentFallsWithin([candidate], record.event_timestamp)
   );
-  const identity = interval && taskIdentityFromWrittenPath(interval.path);
-  return identity ?? taskUnattributedReason(intervals, record.event_timestamp);
+  const declared = interval && taskIdentityFromWrittenPath(interval.path);
+  if (declared) return { task: declared, attribution: "declared" };
+  // Only now the weaker route, and only inside what this journal witnessed: a declaration
+  // that covers the record always wins, so this never overrides a stated fact with an
+  // inferred one.
+  const journal = journalsByVendorId.get(record.vendor_id);
+  const inferred = soleWrittenTaskOf(journal);
+  if (inferred !== null && witnessed(journal, record.event_timestamp)) {
+    return { task: inferred, attribution: "inferred" };
+  }
+  return taskUnattributedReason(intervals, record.event_timestamp);
 }
 
 /** Which `byBacklog` row a record's own task-row key belongs in - built from
- * `declaredTaskKeyOf`'s own output, never a second notion of which task a record fell
+ * `taskRowOf`'s own output, never a second notion of which task a record fell
  * inside. A reason (the record belongs to no task at all) passes straight through
  * unchanged, exactly as `by_task` gives it; a named task looks up its folder's declaration
  * once, in the map `ReportCostUseCase` already resolved for every distinct task identity
@@ -674,15 +783,15 @@ function declaredTaskKeyOf(
  * A named task missing from `declarations` is unreachable through this module's one
  * production caller - `report-cost-use-case.ts` resolves every task identity `byTasks` can
  * ever key on before this ever runs - but is read as `{ kind: "none" }` rather than
- * throwing or dropping the record, the same defensive default `declaredTaskKeyOf`'s own
+ * throwing or dropping the record, the same defensive default `taskRowOf`'s own
  * `interval.path` fallback documents: a caller a test can still construct must never lose a
  * record's figures to a gap in wiring this module cannot see from here. */
 function backlogKeyOf(
-  taskRowKey: TaskRowKey,
+  taskRow: TaskRow,
   declarations: ReadonlyMap<TaskIdentity, TaskBacklogDeclaration> | undefined
 ): BacklogRowKey {
-  if (isTaskUnattributedReason(taskRowKey)) return taskRowKey;
-  const declaration = declarations?.get(taskRowKey) ?? { kind: "none" as const };
+  if (typeof taskRow === "string") return taskRow;
+  const declaration = declarations?.get(taskRow.task) ?? { kind: "none" as const };
   if (declaration.kind === "none") return NO_BACKLOG_DECLARED;
   if (declaration.kind === "unreadable") return UNREADABLE_BACKLOG_DECLARATION;
   return declaration.link.backlog;
@@ -1040,7 +1149,7 @@ interface Groups {
   readonly attributions: Map<StepAttributionSource, TotalsAccumulator>;
   readonly taskAttributions: Map<TaskAttributionSource, TotalsAccumulator>;
   readonly projects: Map<ProjectKey, TotalsAccumulator>;
-  readonly tasks: Map<TaskRowKey, TotalsAccumulator>;
+  readonly tasks: Map<string, TaskGroup>;
   readonly backlog: Map<BacklogRowKey, TotalsAccumulator>;
   readonly flows: Map<FlowRowKey, TotalsAccumulator>;
   readonly people: Map<PersonRowKey, PersonGroup>;
@@ -1102,6 +1211,7 @@ function accumulateRequestRecord(
   membership: TaskMembership | null,
   taskIntervalsByVendorId: ReadonlyMap<string, readonly TaskInterval[]>,
   flowIntervalsByVendorId: ReadonlyMap<string, readonly FlowInterval[]>,
+  journalsByVendorId: ReadonlyMap<string, CostReportSessionJournal>,
   identity: PersonIdentity | null,
   taskBacklogDeclarations: ReadonlyMap<TaskIdentity, TaskBacklogDeclaration> | undefined
 ): void {
@@ -1112,9 +1222,9 @@ function accumulateRequestRecord(
   accumulateInto(groups.models, modelKeyOf(record), record);
   accumulateInto(groups.agents, agentKeyOf(record), record);
   accumulateInto(groups.projects, projectKeyOf(record), record);
-  const taskRowKey = declaredTaskKeyOf(record, taskIntervalsByVendorId);
-  accumulateInto(groups.tasks, taskRowKey, record);
-  accumulateInto(groups.backlog, backlogKeyOf(taskRowKey, taskBacklogDeclarations), record);
+  const taskRow = taskRowOf(record, taskIntervalsByVendorId, journalsByVendorId);
+  addToTaskGroup(groups.tasks, taskRow, record);
+  accumulateInto(groups.backlog, backlogKeyOf(taskRow, taskBacklogDeclarations), record);
   accumulateInto(groups.flows, flowKeyOf(record, flowIntervalsByVendorId), record);
   addToPersonGroup(groups.people, record, resolvePerson(identity, personRawIdOf(record)));
   const day = telemetrySinkRecordDayKey(record);
@@ -1135,6 +1245,7 @@ function accumulate(
   const groups = emptyGroups(fromDay, toDay);
   const taskIntervalsByVendorId = allTaskIntervalsByVendorId(journals);
   const flowIntervalsByVendorId = allFlowIntervalsByVendorId(journals);
+  const journalsByVendorId = new Map(journals.map((journal) => [journal.vendorId, journal]));
   for (const record of records) {
     if (record.kind === "session") {
       accumulateSessionRecord(groups, record);
@@ -1146,6 +1257,7 @@ function accumulate(
       membership,
       taskIntervalsByVendorId,
       flowIntervalsByVendorId,
+      journalsByVendorId,
       identity,
       taskBacklogDeclarations
     );
@@ -1169,7 +1281,8 @@ function attributionRows(
   }));
 }
 
-/** Both sources, always - the same reason `attributionRows` always gives all three: a
+/** Both sources, always - the same reason `attributionRows` always gives every one of its
+ * own: a
  * source that accounted for nothing is still a fact about this task, not an absent field. */
 function taskAttributionRows(
   taskAttributions: ReadonlyMap<TaskAttributionSource, TotalsAccumulator>
@@ -1218,22 +1331,26 @@ function isTaskUnattributedReason(key: string | symbol): key is TaskUnattributed
 /** Every task a record's own moment fell inside, largest first, then one row per reason
  * actually present for what fell in none - `TASK_UNATTRIBUTED_REASONS`' own fixed order,
  * always after every named task regardless of size, the same convention `personRows` gives
- * its own `none` row. Up to three such rows, never fewer than the reasons present: two
+ * its own `none` row. Up to four such rows, never fewer than the reasons present: two
  * different gaps collapsed into one row is the fault this breakdown exists to avoid. */
-function taskRows(tasks: ReadonlyMap<TaskRowKey, TotalsAccumulator>): readonly CostReportTaskRow[] {
+function taskRows(tasks: ReadonlyMap<string, TaskGroup>): readonly CostReportTaskRow[] {
   const named: CostReportTaskRow[] = [];
   const byReason = new Map<TaskUnattributedReason, CostReportTaskRow>();
-  for (const [key, accumulator] of tasks) {
-    if (isTaskUnattributedReason(key)) {
-      byReason.set(key, { reason: key, totals: accumulator.build() });
+  for (const group of tasks.values()) {
+    const totals = group.totals.build();
+    if (group.reason !== undefined) {
+      byReason.set(group.reason, { reason: group.reason, totals });
       continue;
     }
-    named.push({ task: key, attribution: "declared", totals: accumulator.build() });
+    if (group.task === undefined || group.attribution === undefined) continue;
+    named.push({ task: group.task, attribution: group.attribution, totals });
   }
+  // Tie-broken on the pair, not on the task alone: one task can hold both a declared row and
+  // an inferred one, and a tie-break blind to the attribution would order them arbitrarily.
   const sorted = bySize(
     named,
     (row) => row.totals,
-    (row) => row.task ?? ""
+    (row) => `${row.task ?? ""}/${row.attribution ?? ""}`
   );
   const reasonRows = TASK_UNATTRIBUTED_REASONS.map((reason) => byReason.get(reason)).filter(
     (row): row is CostReportTaskRow => row !== undefined

--- a/cli/src/domain/models/cost-report.ts
+++ b/cli/src/domain/models/cost-report.ts
@@ -77,6 +77,17 @@ export interface CostReportModelRow {
   readonly totals: CostTotals;
 }
 
+/** One agent's own share of a period, `agent` absent for the main thread.
+ *
+ * Where the spend actually is: measured on a live session, ten subagent files held 432M of
+ * its 466M tokens, and every one of their lines names its agent where almost none names a
+ * skill (100% against 2.7%). `by_step` reads a few percent not because the reader drops
+ * anything but because the host names a skill on the main thread alone. */
+export interface CostReportAgentRow {
+  readonly agent?: string;
+  readonly totals: CostTotals;
+}
+
 /** Why a tool contributes nothing, when it contributes nothing. `covered` with no records
  * is a tool that could have been read and did nothing in this period; `not-covered` is a
  * tool nothing here can read at all. A consumer prints the second as its reason, never as
@@ -371,6 +382,7 @@ export interface CostReport {
   readonly activeTimeSeconds?: number;
   readonly bySteps: readonly CostReportStepRow[];
   readonly byModels: readonly CostReportModelRow[];
+  readonly byAgents: readonly CostReportAgentRow[];
   readonly byTools: readonly CostReportToolRow[];
   readonly byProjects: readonly CostReportProjectRow[];
   readonly byTasks: readonly CostReportTaskRow[];
@@ -574,6 +586,15 @@ function projectKeyOf(record: TelemetrySinkRecord): ProjectKey {
 // than also folding in `""` - a rule this module has no evidence for yet.
 const NO_KNOWN_MODEL = Symbol("no known model");
 type ModelKey = string | typeof NO_KNOWN_MODEL;
+
+// The main thread's own row. A symbol for the same reason `NO_KNOWN_MODEL` is one: an agent
+// really can be named anything, so no string is safe to reserve.
+const NO_AGENT = Symbol("the main thread");
+type AgentKey = string | typeof NO_AGENT;
+
+function agentKeyOf(record: TelemetrySinkRecord): AgentKey {
+  return record.agent_name === undefined ? NO_AGENT : record.agent_name;
+}
 
 function modelKeyOf(record: TelemetrySinkRecord): ModelKey {
   return record.model === undefined ? NO_KNOWN_MODEL : record.model;
@@ -1013,6 +1034,7 @@ interface Groups {
   readonly totals: TotalsAccumulator;
   readonly steps: Map<string, StepGroup>;
   readonly models: Map<ModelKey, TotalsAccumulator>;
+  readonly agents: Map<AgentKey, TotalsAccumulator>;
   readonly tools: Map<AiToolId, TotalsAccumulator>;
   readonly toolSessionTotals: Map<AiToolId, TotalsAccumulator>;
   readonly attributions: Map<StepAttributionSource, TotalsAccumulator>;
@@ -1033,6 +1055,7 @@ function emptyGroups(fromDay: string, toDay: string): Groups {
     totals: new TotalsAccumulator(),
     steps: new Map(),
     models: new Map(),
+    agents: new Map(),
     tools: new Map(),
     toolSessionTotals: new Map(),
     attributions: new Map(),
@@ -1087,6 +1110,7 @@ function accumulateRequestRecord(
   accumulateInto(groups.attributions, record.step_attribution, record);
   accumulateInto(groups.tools, record.tool, record);
   accumulateInto(groups.models, modelKeyOf(record), record);
+  accumulateInto(groups.agents, agentKeyOf(record), record);
   accumulateInto(groups.projects, projectKeyOf(record), record);
   const taskRowKey = declaredTaskKeyOf(record, taskIntervalsByVendorId);
   accumulateInto(groups.tasks, taskRowKey, record);
@@ -1318,6 +1342,21 @@ function dayRows(days: ReadonlyMap<string, TotalsAccumulator>): readonly CostRep
   return [...days].map(([day, accumulator]) => ({ day, totals: accumulator.build() }));
 }
 
+/** Every agent that ran, largest first, plus one row for the main thread. */
+function agentRows(
+  agents: ReadonlyMap<AgentKey, TotalsAccumulator>
+): readonly CostReportAgentRow[] {
+  const rows: CostReportAgentRow[] = [...agents].map(([key, accumulator]) => ({
+    ...(key === NO_AGENT ? {} : { agent: key }),
+    totals: accumulator.build(),
+  }));
+  return bySize(
+    rows,
+    (row) => row.totals,
+    (row) => row.agent ?? ""
+  );
+}
+
 /** Every model a record named, largest first, plus one row for what named none. */
 function modelRows(
   models: ReadonlyMap<ModelKey, TotalsAccumulator>
@@ -1432,6 +1471,7 @@ function breakdownFields(
   CostReport,
   | "bySteps"
   | "byModels"
+  | "byAgents"
   | "byTools"
   | "byProjects"
   | "byTasks"
@@ -1443,6 +1483,7 @@ function breakdownFields(
   return {
     bySteps: stepRows(groups.steps),
     byModels: modelRows(groups.models),
+    byAgents: agentRows(groups.agents),
     byTools: toolRowsInScope(input, groups),
     byProjects: projectRows(groups.projects),
     byTasks: taskRows(groups.tasks),

--- a/cli/src/domain/models/cost-report.ts
+++ b/cli/src/domain/models/cost-report.ts
@@ -690,7 +690,10 @@ function soleWrittenTaskOf(journal: CostReportSessionJournal | undefined): TaskI
 
 /** Whether this journal witnessed `momentIso` at all - never an unbounded yes for a journal
  * that carries no readable moment. */
-function witnessed(journal: CostReportSessionJournal | undefined, momentIso: string | undefined): boolean {
+function witnessed(
+  journal: CostReportSessionJournal | undefined,
+  momentIso: string | undefined
+): boolean {
   const span = journal?.witnessed;
   if (span === undefined || momentIso === undefined) return false;
   const momentMs = Date.parse(momentIso);

--- a/cli/src/domain/models/step-attribution.ts
+++ b/cli/src/domain/models/step-attribution.ts
@@ -6,7 +6,11 @@ import type { RunJournal, RunJournalBoundary } from "../ports/run-journal-reader
  * inference. `unattributed` is a value returned here, never the caller's own omission —
  * an absent field would be read as "no step ran", which is the assertion nothing on a
  * transcript or a journal can support. */
-export type StepAttributionSource = "tool-stated" | "journal-interval" | "unattributed";
+export type StepAttributionSource =
+  | "tool-stated"
+  | "prompt-matched"
+  | "journal-interval"
+  | "unattributed";
 
 /** Strongest first, and fixed: a consumer reading a report should find the three in the
  * same order every time, whatever the records happened to contain. Ordering them by how
@@ -14,6 +18,7 @@ export type StepAttributionSource = "tool-stated" | "journal-interval" | "unattr
  * the one thing a stable contract must not do. */
 export const STEP_ATTRIBUTION_SOURCES: readonly StepAttributionSource[] = [
   "tool-stated",
+  "prompt-matched",
   "journal-interval",
   "unattributed",
 ];

--- a/cli/src/domain/models/task-attribution.ts
+++ b/cli/src/domain/models/task-attribution.ts
@@ -22,8 +22,18 @@ export type TaskAttributionSource = "declared" | "inferred";
 
 export const TASK_ATTRIBUTION_SOURCES: readonly TaskAttributionSource[] = ["declared", "inferred"];
 
-/** One declared interval, closed by whichever of a later declaration or a `turn_end` comes
- * next - or, unclosed, by the journal's own last recorded moment. Never left open-ended the
+/** One declared interval, closed by a later declaration - or, unclosed, by the journal's
+ * own last recorded moment.
+ *
+ * **A `turn_end` stopped closing one on 2026-09-04.** It is a pause, not a change of
+ * subject: a session declared a task at 05:59, paused at 06:02, and worked on that same
+ * task for three more hours. Closed at the pause, 78% of that session read "before the next
+ * task this session declares" while only 1.8% of its tokens truly preceded any declaration.
+ * Measured again after: 20% attributed became 96%, and the residue matched a hand count of
+ * the records before the first declaration, to the token.
+ *
+ * `turn_end` remains a *witness*, so an interval with nothing after it still ends at the
+ * same moment it used to - the same number, for the honest reason. Never left open-ended the
  * way `StepInterval` is: no tool exposes when a flow leaves a ticket, so a boundless interval
  * would attribute everything a long-running session goes on to do to the first ticket it
  * ever named, for as long as it keeps running - the failure this type exists to refuse. */
@@ -34,15 +44,14 @@ export interface TaskInterval extends ClosedInterval {
 /**
  * Journal lines in, bounded intervals out. `boundaries`, `taskDeclarations` and
  * `filesWritten` are merged and sorted by their own moment into one list, then walked once:
- * each `task_declared` closes at whichever of a later declaration or a `turn_end` comes
- * next. Unclosed, it is capped at that merged list's own last moment - a written file
+ * each `task_declared` closes at the next declaration. Unclosed, it is capped at that
+ * merged list's own last moment - a written file
  * included, never only the kinds an interval actually closes on - so a session that is
  * still running when a report is asked for, with a file written after its declaration and
  * no `turn_end` yet, is bounded by that write rather than collapsing to `[t, t)` and losing
  * everything after it. `RunJournalBoundary` itself carries no `file_written`: pairing one in
  * there would let it close a running *step* early (see `run-journal-reader.ts`), a risk this
- * merge never runs into because `closers` below is filtered to `task_declared` and
- * `turn_end` regardless of what else this list holds. A session that crashes and produces no
+ * merge never runs into because nothing below is treated as a closer at all. A session that crashes and produces no
  * further line at all still leaves nothing after the declaration itself to misattribute.
  *
  * Still never open-ended: widening the last-witnessed moment moves an unclosed interval's
@@ -81,7 +90,10 @@ export function buildTaskIntervals(
     [...journal.boundaries, ...journal.taskDeclarations, ...journal.filesWritten],
     periodEndMs,
     (boundary): boundary is RunJournalTaskDeclared => boundary.type === "task_declared",
-    (boundary) => boundary.type === "turn_end",
+    // Only a later declaration closes one. A `turn_end` is a pause, not a change of
+    // subject — it stays a *witness*, so an interval with nothing after it still ends at
+    // the same moment, for the honest reason. See this module's own doc comment.
+    () => false,
     (opener, startMs, endMs) =>
       taskIdentityFromWrittenPath(opener.path) === null
         ? null
@@ -101,9 +113,10 @@ export function buildTaskIntervals(
  *   declaration" rather than "none was ever declared" - the latter would be false for a
  *   session whose journal really does hold a line, just not a readable one.
  * - `"precedes-declaration"`: a task was declared, but some declared interval starts *after*
- *   this moment - true both for a record before the session's very first declaration and for
- *   one landing in the gap a `turn_end` leaves between two declarations, which is a real gap
- *   in coverage, never the journal falling silent (the journal keeps going right through it).
+ *   this moment. Since 2026-09-04 that means one thing only — a record before the session's
+ *   very first declaration. Intervals now run contiguously from each declaration to the
+ *   next, so the gap a `turn_end` used to leave between two of them no longer exists, and
+ *   the test that described it was deleted rather than reworded.
  * - `"journal-silent"`: a task was declared, every declared interval starts at or before this
  *   moment, and still none of them reaches it - the journal's own declared coverage ran out
  *   before this record's moment did. A record with no moment at all, or an unparseable one,

--- a/cli/src/domain/models/task-attribution.ts
+++ b/cli/src/domain/models/task-attribution.ts
@@ -101,11 +101,30 @@ export function buildTaskIntervals(
   );
 }
 
-/** Why a record's own moment falls in none of `intervals` - the three, and only three,
- * distinct facts a person acts on differently. Never called for a moment `momentFallsWithin`
+/** Why a record belongs to no task - the distinct facts a person acts on differently, and
+ * no more than those. This function itself answers only the three that are facts about the
+ * work; `"no-journal"`, the fact about the read, is decided by `declaredTaskKeyOf` before
+ * this is ever called. Never called for a moment `momentFallsWithin`
  * already reads as covered; that caller already knows which interval and needs no reason for
  * what it found.
  *
+ * - `"no-journal"`: no *usable* journal reached this record's session. Either none was read
+ *   for it at all, or one was read and could not be used - `report-cost-use-case.ts` drops
+ *   a journal whose `session_start` header is torn, since nothing then says which session
+ *   its lines belong to, and that shape is real (the adapter's own "keeps a session's
+ *   boundaries when its header line is torn" test produces it). "Usable" is the word this
+ *   reason turns on: saying "no journal existed" would be false for the second case, which
+ *   is the fault this reason exists to stop repeating one level down. Never produced by this
+ *   function, which is only ever asked about a session whose journal was usable -
+ *   `declaredTaskKeyOf` answers it before calling here, from the absence of an entry in its
+ *   own per-session map. It belongs in
+ *   this type all the same: it is one of the reasons a `by_task` row carries, and keeping it
+ *   in the same closed set is what makes `Record<TaskUnattributedReason, string>` force
+ *   every consumer to name it. The three below are facts about the work; this one is a fact
+ *   about the read, and merging it into `"no-declaration"` asserted that a session declared
+ *   nothing when the truth was that its journal was never found - measured on 2026-09-04,
+ *   where running the report from a subdirectory reported 100% "no usable task declaration"
+ *   for a period whose journals were all present one directory up.
  * - `"no-declaration"`: this session's journal yields no usable declared interval - either it
  *   never wrote a `task_declared` line at all, or it wrote one this reader cannot place in
  *   time (an `at` `timed()` cannot parse, dropped before it ever reaches `buildTaskIntervals`).
@@ -124,12 +143,17 @@ export function buildTaskIntervals(
  *   it is as unplaceable as one that arrived after that coverage lapsed. In practice a
  *   report never hands this function such a record - `report-cost-use-case.ts` splits an
  *   undated record off before any of this runs - but the function stays correct standalone. */
-export type TaskUnattributedReason = "no-declaration" | "precedes-declaration" | "journal-silent";
+export type TaskUnattributedReason =
+  | "no-journal"
+  | "no-declaration"
+  | "precedes-declaration"
+  | "journal-silent";
 
 /** Fixed and always in this order, the same reason `TASK_ATTRIBUTION_SOURCES` is: a reader
  * comparing two periods must find the reasons present listed the same way every time, never
  * ordered by how much of a period each accounted for. */
 export const TASK_UNATTRIBUTED_REASONS: readonly TaskUnattributedReason[] = [
+  "no-journal",
   "no-declaration",
   "precedes-declaration",
   "journal-silent",

--- a/cli/src/domain/models/telemetry-claim.ts
+++ b/cli/src/domain/models/telemetry-claim.ts
@@ -1,3 +1,4 @@
+import type { StepAttributionSource } from "./step-attribution.js";
 import type { AiToolId } from "./tool-ids.js";
 
 /**
@@ -90,7 +91,7 @@ export interface TelemetryClaimToolRead {
   readonly sessionFound: boolean;
   readonly hasIntervals: boolean;
   readonly records: readonly {
-    readonly stepAttribution: "tool-stated" | "journal-interval" | "unattributed";
+    readonly stepAttribution: StepAttributionSource;
   }[];
   readonly error?: string;
 }

--- a/cli/src/domain/models/telemetry-sink-record.ts
+++ b/cli/src/domain/models/telemetry-sink-record.ts
@@ -72,6 +72,21 @@ export interface TelemetrySinkRecord {
    * a tool, into one — see "One billed call, both routes" in metrics-contract.md. Never used
    * for the local-read re-read match `turn_id` exists for. */
   readonly billed_request_id?: string;
+  /** The prompt this billed call belongs to, where its tool's own files can say.
+   *
+   * A billed call and the prompt that caused it never share a transcript line — measured on
+   * a real 810-record session, zero lines carry both `requestId` and `promptId`, and only
+   * `type: "user"` lines carry the second. Every line bearing counters reaches one by
+   * following `parentUuid`, three hops in the median, which is how the reader resolves it.
+   *
+   * The run journal writes the same identifier on `step_start` (Claude Code hands its hooks
+   * `prompt_id`, stored there under the name `turn_id`). Matching the two joins a step to a
+   * record **exactly**, instead of inferring it from which interval each moment happens to
+   * fall in — the one route that stays true when two tasks advance at once, since two
+   * prompts remain two prompts however their moments overlap.
+   *
+   * Absent wherever a tool's files cannot say, which is every host but Claude Code today. */
+  readonly prompt_id?: string;
   /** How `step` came to be known. Never optional, for the same reason `provenance` is not:
    * an absent field would be read as "no step ran", which is exactly the assertion nothing
    * on a transcript or a journal can support. See `domain/models/step-attribution.ts`. */

--- a/cli/src/domain/ports/run-journal-reader.ts
+++ b/cli/src/domain/ports/run-journal-reader.ts
@@ -7,6 +7,15 @@ export interface RunJournalStepStart {
   readonly type: "step_start";
   readonly at: string;
   readonly skill: string;
+  /** The host's own identifier for the prompt this step opened under, where it hands one to
+   * a hook — Claude Code's `prompt_id`. Named `turn_id` on the line because that is what
+   * `buildStepStartLine` has always written; it is a prompt, not a turn, and three steps
+   * opened under one prompt share it.
+   *
+   * Matched against a record's `prompt_id`, it attributes a step **exactly** rather than by
+   * asking which interval a moment fell in — the only reading that survives two tasks
+   * advancing at once. Absent for every host that hands its hooks no such identifier. */
+  readonly turn_id?: string;
 }
 
 /** One `turn_end` line: closes whatever step was open, even where no further step opens

--- a/cli/src/infrastructure/adapters/run-journal-reader-adapter.ts
+++ b/cli/src/infrastructure/adapters/run-journal-reader-adapter.ts
@@ -44,6 +44,7 @@ interface RawJournalLine {
   readonly type?: unknown;
   readonly at?: unknown;
   readonly skill?: unknown;
+  readonly turn_id?: unknown;
   readonly run_id?: unknown;
   readonly tool?: unknown;
   readonly vendor_id?: unknown;
@@ -73,7 +74,9 @@ function parseBoundary(parsed: RawJournalLine): RunJournalBoundary | null {
   if (at === undefined) return null;
   if (parsed.type === "turn_end") return { type: "turn_end", at };
   const skill = parsed.type === "step_start" ? asString(parsed.skill) : undefined;
-  return skill !== undefined ? { type: "step_start", at, skill } : null;
+  if (skill === undefined) return null;
+  const turnId = asString(parsed.turn_id);
+  return { type: "step_start", at, skill, ...(turnId === undefined ? {} : { turn_id: turnId }) };
 }
 
 /** The worktree a session ran in, where the line names one. A plain checkout writes

--- a/cli/src/infrastructure/adapters/run-journal-reader-adapter.ts
+++ b/cli/src/infrastructure/adapters/run-journal-reader-adapter.ts
@@ -10,6 +10,7 @@ import type {
   RunJournalTaskDeclared,
 } from "../../domain/ports/run-journal-reader.js";
 import { isBareFileName } from "../confined-file-name.js";
+import { repositoryRootAbove } from "../repository-root.js";
 
 const ULID_LENGTH = 26; // encodeTime(10) + encodeRandom(16), matching record.cjs's own ULID_LENGTH.
 const RUN_FILE_EXTENSION = ".jsonl";
@@ -191,7 +192,8 @@ export class RunJournalReaderAdapter implements RunJournalStore {
   readonly runsDir: string;
 
   constructor(projectRoot: string) {
-    this.runsDir = process.env.AIDD_RUNS_DIR || join(projectRoot, DOCS_DIR, RUNS_SUBDIR);
+    this.runsDir =
+      process.env.AIDD_RUNS_DIR || join(repositoryRootAbove(projectRoot), DOCS_DIR, RUNS_SUBDIR);
   }
 
   async read(sessionId: string): Promise<RunJournal | null> {

--- a/cli/src/infrastructure/adapters/task-backlog-adapter.ts
+++ b/cli/src/infrastructure/adapters/task-backlog-adapter.ts
@@ -6,6 +6,7 @@ import type {
 } from "../../domain/models/task-backlog-link.js";
 import type { TaskBacklogReader } from "../../domain/ports/task-backlog-reader.js";
 import { asPlainObject, isErrnoException } from "../json-file.js";
+import { repositoryRootAbove } from "../repository-root.js";
 
 /** The one file a task folder writes to declare its backlog item — see
  * `domain/models/task-backlog-link.ts` for why this is not `metadata.json`. */
@@ -39,10 +40,18 @@ function parseLink(raw: string): TaskBacklogLink | null {
  * checkout someone else owns without ever risking the work it is describing.
  */
 export class TaskBacklogAdapter implements TaskBacklogReader {
-  constructor(private readonly projectRoot: string) {}
+  private readonly repositoryRoot: string;
+
+  // Resolved once, at construction, for the same reason `RunJournalReaderAdapter` freezes
+  // its own directory there: a relocation after construction can never change what this
+  // instance answers. A task folder path arrives repository-relative, because the journal
+  // line it came from was written that way.
+  constructor(projectRoot: string) {
+    this.repositoryRoot = repositoryRootAbove(projectRoot);
+  }
 
   async read(taskFolderPath: string): Promise<TaskBacklogDeclaration> {
-    const filePath = join(this.projectRoot, taskFolderPath, TASK_BACKLOG_LINK_FILENAME);
+    const filePath = join(this.repositoryRoot, taskFolderPath, TASK_BACKLOG_LINK_FILENAME);
     let raw: string;
     try {
       raw = await readFile(filePath, "utf8");

--- a/cli/src/infrastructure/repository-root.ts
+++ b/cli/src/infrastructure/repository-root.ts
@@ -1,0 +1,42 @@
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+/**
+ * The checkout `start` sits in, or `start` itself when it sits in none.
+ *
+ * Everything the run journal records is written relative to a repository root: the hook
+ * that writes it anchors at `git rev-parse --show-toplevel`
+ * (`plugins/aidd-telemetry/hooks/lib/repo.cjs`), so a session started anywhere inside a
+ * checkout writes one journal at its root, and every path inside that journal - a written
+ * file, a declared task folder - is relative to that same root. Every reader of those paths
+ * must therefore resolve them against the root too, not against the directory the command
+ * happened to be run from.
+ *
+ * Anchoring a reader at the process working directory instead made the report answer
+ * differently depending on where it ran. Measured on 2026-09-04: from a subdirectory the
+ * journal directory was never found, and `by_task` reported `"no-declaration"` - a claim
+ * about the work - for a period whose journals sat one directory up. Anchoring only *one*
+ * reader is the same fault wearing a better disguise: with the journal reader moved and the
+ * backlog reader left behind, `by_task` named the task correctly while `by_backlog` said
+ * that task declared no backlog item, which reads as a fact about the task rather than a
+ * path that missed.
+ *
+ * Walked rather than shelled out to `git`, because this runs on every report and a
+ * subprocess buys nothing here: `.git` is accepted as a directory (a main checkout) or as a
+ * file (a linked worktree's `gitdir:` pointer), which is the same root `--show-toplevel`
+ * prints for both. It is not the answer git would give in every case - a bare repository,
+ * or `GIT_DIR` pointed elsewhere - and it does not need to be: every caller here has its
+ * own override, and both agree with git for every layout a session is actually run in.
+ *
+ * Terminates at the filesystem root, where `dirname` reaches a fixed point, and answers
+ * `start` unchanged from there: never climbs past it to read a stranger's journal.
+ */
+export function repositoryRootAbove(start: string): string {
+  let current = start;
+  for (;;) {
+    if (existsSync(join(current, ".git"))) return current;
+    const parent = dirname(current);
+    if (parent === current) return start;
+    current = parent;
+  }
+}

--- a/cli/tests/application/display/cost-report-display.unit.test.ts
+++ b/cli/tests/application/display/cost-report-display.unit.test.ts
@@ -4,7 +4,7 @@ import "../../../src/domain/tools/ai/codex.js";
 import "../../../src/domain/tools/ai/copilot.js";
 import "../../../src/domain/tools/ai/cursor.js";
 import "../../../src/domain/tools/ai/opencode.js";
-import { printCostReport } from "../../../src/application/display/cost-report-display.js";
+import { padTo, printCostReport } from "../../../src/application/display/cost-report-display.js";
 import { CLIOutput } from "../../../src/application/output.js";
 import { buildCostReport, type CostReportInput } from "../../../src/domain/models/cost-report.js";
 import type { TelemetrySinkRecord } from "../../../src/domain/models/telemetry-sink-record.js";
@@ -380,6 +380,37 @@ describe("printCostReport", () => {
 
     expect(models).toContain("opus");
     expect(models).toContain("no known model");
+  });
+});
+
+describe("printCostReport — a label wider than its column", () => {
+  // Measured on a real report: a project id is the repository's own remote, and
+  // `git@github.com:ai-driven-dev/framework.git` is 41 characters against a 26-wide column.
+  // `padEnd` returns a longer string unchanged, so the share ran straight into the label and
+  // printed `…framework.git100%`. No fixture had ever carried an identifier that long.
+  it("keeps a separator between an overlong label and its share", () => {
+    const long = "git@github.com:ai-driven-dev/framework.git";
+
+    const out = printed({ records: [record({ cost_usd: 1, project_id: long })] });
+    const row = out.split("\n").find((line) => line.includes(long));
+
+    expect(row).toBeDefined();
+    expect(row).not.toContain(`${long}100%`);
+    expect(row).toMatch(new RegExp(`${long.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&")}\\s`, "u"));
+  });
+
+  it("still separates a label exactly as wide as its column from what follows it", () => {
+    // 26 is `LABEL_WIDTH`, private to this module - the one length where `padTo`'s own
+    // branches diverge. Shorter, `padEnd` alone already reserves the gap; longer, both the
+    // `padEnd` branch and the "at least as wide" branch agree on a single trailing space.
+    // Exactly 26 is the only length where `>=` and `>` decide something different, and
+    // nothing above ever exercised it - the 41-character label is already past it, never
+    // sitting on the boundary itself.
+    const exact = "a".repeat(26);
+
+    const padded = padTo(exact, 26);
+
+    expect(padded).toBe(`${exact} `);
   });
 });
 

--- a/cli/tests/application/use-cases/telemetry/report-cost-use-case.unit.test.ts
+++ b/cli/tests/application/use-cases/telemetry/report-cost-use-case.unit.test.ts
@@ -382,7 +382,176 @@ describe("a report that catches the sink up first", () => {
     expect(built.totals.requests).toBe(0);
   });
 
-  it("leaves a session already stored alone rather than reading it again", async () => {
+  // Was asserted the other way round — `expect(reads).toBe(0)`, "leaves a session already
+  // stored alone" — and that assertion is why the defect survived: it locked an
+  // optimisation that buys speed with correctness. Keyed on whether a session appears at
+  // all, one stored record froze a session that was still running. Measured on a live
+  // session: the sink held 285 records while the transcript had 541, and `report` added
+  // none of them. A plausible wrong figure, which is the one thing this layer refuses
+  // everywhere else.
+  //
+  // Re-reading is safe because the reader already dedupes per `turn_id`
+  // (`read-local-cost-use-case.ts`), so the session-level gate was a second filter at the
+  // wrong granularity. What bounds the cost is the period, not this.
+  // A judgement is derived, never trusted from disk. `step_attribution` is written into the
+  // record at read time, so a record stored before a rule was corrected keeps the answer
+  // that rule gave — measured on a live sink, which reported 91% `unattributed` while a
+  // fresh read of the same session reported 0%. `tool-stated` stays trusted: the tool naming
+  // a skill on the counters line is an observation, not a judgement.
+  // The other half of the same rule, and it had no test until a mutation went unnoticed:
+  // overwriting `tool-stated` too broke nothing. An observation outranks a derivation — the
+  // tool named that skill on the line carrying the counters, and no interval can improve on
+  // it. Asserted with the journal naming a *different* skill, so trusting the stored one is
+  // the only way to pass.
+  // A journal can disappear while its records stay: `aidd_docs/runs/` lives in the project
+  // and is git-ignored, so a clean checkout has the figures and none of the boundaries.
+  // Deriving there would answer `unattributed` for a session that once resolved a step,
+  // trading a stale reading for no reading — the one direction this whole change refuses.
+  it("keeps a stored step for a session the period's journals say nothing about", async () => {
+    await sink.appendRecord(
+      record({
+        vendor_id: "s-no-journal",
+        event_timestamp: "2026-08-18T10:00:00.000Z",
+        step_attribution: "journal-interval",
+        step: "aidd-dev:05-review",
+      }),
+      STORED_ON
+    );
+
+    const built = await reportWith().execute({ ...BASE_OPTIONS, period: PERIOD });
+
+    expect(built.bySteps).toContainEqual(
+      expect.objectContaining({ attribution: "journal-interval", step: "aidd-dev:05-review" })
+    );
+  });
+
+  it("leaves a tool-stated step alone, even where the journal's interval names another", async () => {
+    const journal = journalAt("2026-08-18T09:00:00Z");
+    journals.set(SESSION, {
+      ...journal,
+      boundaries: [
+        { type: "step_start", at: "2026-08-18T09:30:00Z", skill: "aidd-dev:02-implement" },
+      ],
+    });
+    await sink.appendRecord(
+      record({
+        vendor_id: SESSION,
+        event_timestamp: "2026-08-18T10:00:00.000Z",
+        step_attribution: "tool-stated",
+        step: "aidd-vcs:01-commit",
+      }),
+      STORED_ON
+    );
+
+    const built = await reportWith().execute({ ...BASE_OPTIONS, period: PERIOD });
+
+    expect(built.bySteps).toContainEqual(
+      expect.objectContaining({ attribution: "tool-stated", step: "aidd-vcs:01-commit" })
+    );
+  });
+
+  // The exact join, and the reason the whole prompt chain exists. The record's moment falls
+  // *outside* every interval, so an interval reading answers `unattributed` — only matching
+  // the prompt both sides name can attribute it. That is what survives two tasks advancing
+  // at once: two prompts stay two prompts however their moments overlap.
+  // Three steps really do open under one prompt: measured on a live session, where
+  // `aidd-orchestrator:01-sdlc`, `aidd-pm:04-spec` and `aidd-dev:01-plan` all carried
+  // `839ab4a8-…`. The prompt names the step its work began in; taking the last opener would
+  // answer "plan" for the reasoning that produced the spec — a different claim, and a wrong
+  // one.
+  it("names the step a shared prompt opened first, never the last to reuse it", async () => {
+    const journal = journalAt("2026-08-18T09:00:00Z");
+    journals.set(SESSION, {
+      ...journal,
+      boundaries: [
+        {
+          type: "step_start",
+          at: "2026-08-18T11:00:00Z",
+          skill: "aidd-pm:04-spec",
+          turn_id: "p-abc",
+        },
+        {
+          type: "step_start",
+          at: "2026-08-18T11:30:00Z",
+          skill: "aidd-dev:01-plan",
+          turn_id: "p-abc",
+        },
+      ],
+    });
+    await sink.appendRecord(
+      record({
+        vendor_id: SESSION,
+        event_timestamp: "2026-08-18T10:00:00.000Z",
+        prompt_id: "p-abc",
+      }),
+      STORED_ON
+    );
+
+    const built = await reportWith().execute({ ...BASE_OPTIONS, period: PERIOD });
+
+    expect(built.bySteps).toContainEqual(
+      expect.objectContaining({ attribution: "prompt-matched", step: "aidd-pm:04-spec" })
+    );
+  });
+
+  it("attributes on the prompt both sides name, where no interval covers the moment", async () => {
+    const journal = journalAt("2026-08-18T09:00:00Z");
+    journals.set(SESSION, {
+      ...journal,
+      boundaries: [
+        {
+          type: "step_start",
+          at: "2026-08-18T11:00:00Z",
+          skill: "aidd-dev:02-implement",
+          turn_id: "p-abc",
+        },
+      ],
+    });
+    await sink.appendRecord(
+      record({
+        vendor_id: SESSION,
+        // Before the step ever opened: no interval can reach it.
+        event_timestamp: "2026-08-18T10:00:00.000Z",
+        prompt_id: "p-abc",
+      }),
+      STORED_ON
+    );
+
+    const built = await reportWith().execute({ ...BASE_OPTIONS, period: PERIOD });
+
+    expect(built.bySteps).toContainEqual(
+      expect.objectContaining({ attribution: "prompt-matched", step: "aidd-dev:02-implement" })
+    );
+  });
+
+  it("derives a stored record's step from the journal rather than trusting the stored one", async () => {
+    const at = "2026-08-18T10:00:00.000Z";
+    const journal = journalAt("2026-08-18T09:00:00Z");
+    journals.set(SESSION, {
+      ...journal,
+      boundaries: [
+        { type: "step_start", at: "2026-08-18T09:30:00Z", skill: "aidd-dev:02-implement" },
+      ],
+    });
+    await sink.appendRecord(
+      record({ vendor_id: SESSION, event_timestamp: at, step_attribution: "unattributed" }),
+      STORED_ON
+    );
+
+    const built = await reportWith().execute({ ...BASE_OPTIONS, period: PERIOD });
+
+    expect(built.bySteps).toContainEqual(
+      expect.objectContaining({ attribution: "journal-interval", step: "aidd-dev:02-implement" })
+    );
+  });
+
+  // The limit of re-reading, found by the reference-week e2e going from 7 requests to 10.
+  // A re-read is matched against what is stored on `turn_id`, and `groupByTurnId` indexes
+  // nothing without one — so re-reading a session whose records carry none appends them a
+  // second time. Rare while only unseen sessions were read; systematic once every session
+  // in the period is. Claude Code writes a `requestId` on every line (0 of 810 records
+  // without one on a live sink), but a host that does not must not be silently doubled.
+  it("leaves a session alone when its stored records carry no turn id to match on", async () => {
     journals.set(SESSION, journalAt(AT));
     await sink.appendRecord(record({ vendor_id: SESSION, event_timestamp: AT }), STORED_ON);
     let reads = 0;
@@ -407,6 +576,38 @@ describe("a report that catches the sink up first", () => {
     await reportWith(counting).execute({ ...BASE_OPTIONS, period: PERIOD });
 
     expect(reads).toBe(0);
+  });
+
+  it("reads a stored session again, so a live session's later turns land", async () => {
+    journals.set(SESSION, journalAt(AT));
+    // A `turn_id` is what makes a re-read reconcilable rather than duplicating: the test
+    // below holds the other half of that rule.
+    await sink.appendRecord(
+      record({ vendor_id: SESSION, event_timestamp: AT, turn_id: "req_1" }),
+      STORED_ON
+    );
+    let reads = 0;
+    const counting = new ReadLocalCostUseCase(
+      sink,
+      new Map([
+        [
+          "claude",
+          {
+            read: async () => {
+              reads += 1;
+              return { records: [CANDIDATE], sessionFound: true };
+            },
+          },
+        ],
+      ]),
+      journals,
+      NULL_PERSON_IDENTITY_READER,
+      evidence
+    );
+
+    await reportWith(counting).execute({ ...BASE_OPTIONS, period: PERIOD });
+
+    expect(reads).toBe(1);
   });
 
   it("reaches a session journalled on the last day of the period, which runs to midnight", async () => {

--- a/cli/tests/application/use-cases/telemetry/report-cost-use-case.unit.test.ts
+++ b/cli/tests/application/use-cases/telemetry/report-cost-use-case.unit.test.ts
@@ -121,6 +121,51 @@ describe("ReportCostUseCase", () => {
     expect(built.totals.costMicroUsd).toBe(toMicroUsd(1));
   });
 
+  // The written-file route only fires inside the span the journal itself witnessed, and that
+  // span reaches the report from the journal's own lines - nowhere else. A record inside it
+  // that no declaration covers is named after the one task folder the session wrote into; a
+  // record from before the journal was ever open is not, however many files that session
+  // went on to write.
+  it("names a record inside the journal's span after the only task folder that session wrote into", async () => {
+    journals.set("s-inferred", {
+      boundaries: [],
+      session: {
+        type: "session_start",
+        at: "2026-08-18T09:00:00Z",
+        run_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        tool: "claude-code",
+        vendor_id: "s-inferred",
+      },
+      filesWritten: [
+        {
+          type: "file_written",
+          at: "2026-08-18T09:30:00Z",
+          path: `aidd_docs/tasks/${TASK}/plan.md`,
+        },
+      ],
+      taskDeclarations: [],
+    });
+    await store(
+      record({
+        vendor_id: "s-inferred",
+        cost_usd: 1,
+        event_timestamp: "2026-08-18T09:15:00Z",
+      }),
+      record({
+        vendor_id: "s-inferred",
+        cost_usd: 2,
+        event_timestamp: "2026-08-17T09:15:00Z",
+      })
+    );
+
+    const built = await useCase.execute({ ...BASE_OPTIONS, period: PERIOD });
+
+    const inferred = built.byTasks.find((row) => row.attribution === "inferred");
+    expect(inferred?.task).toBe(TASK);
+    expect(inferred?.totals.costMicroUsd).toBe(toMicroUsd(1));
+    expect(built.byTasks.some((row) => row.reason !== undefined)).toBe(true);
+  });
+
   it("gives every declared tool a row, with the reason an unreadable one cannot be read", async () => {
     await store(record({ cost_usd: 1 }));
 
@@ -221,6 +266,83 @@ describe("ReportCostUseCase", () => {
     await expect(useCase.execute({ ...BASE_OPTIONS, period: PERIOD })).rejects.toThrow(
       "some other failure entirely"
     );
+  });
+
+  // A task reached only by the written-file route still has a folder, and that folder can
+  // declare a backlog item. Resolving declarations from declared intervals alone would send
+  // every inferred record to the "this task declares no backlog item" row - a claim about
+  // the task, produced by a lookup that never happened.
+  // A journal moment is a second: `nowIso()` in the writing hook strips the milliseconds
+  // (`plugins/aidd-telemetry/hooks/lib/record.cjs`). A record carries them. Comparing the
+  // two as instants refuses a record that landed in the very second the journal last wrote,
+  // which is a rounding artefact of the source, not a fact about the work - measured, it
+  // cost one record of 1073 on a real session.
+  it("counts a record inside the last second its journal wrote as witnessed", async () => {
+    journals.set("s-same-second", {
+      boundaries: [],
+      session: {
+        type: "session_start",
+        at: "2026-08-18T09:00:00Z",
+        run_id: "01ARZ3NDEKTSV4RRFFQ69G5FB0",
+        tool: "claude-code",
+        vendor_id: "s-same-second",
+      },
+      filesWritten: [
+        {
+          type: "file_written",
+          at: "2026-08-18T09:30:00Z",
+          path: `aidd_docs/tasks/${TASK}/plan.md`,
+        },
+      ],
+      taskDeclarations: [],
+    });
+    await store(
+      record({
+        vendor_id: "s-same-second",
+        cost_usd: 5,
+        event_timestamp: "2026-08-18T09:30:00.351Z",
+      })
+    );
+
+    const built = await useCase.execute({ ...BASE_OPTIONS, period: PERIOD });
+
+    expect(built.byTasks.find((row) => row.attribution === "inferred")?.task).toBe(TASK);
+  });
+
+  it("resolves the backlog declaration of a task no interval ever declared", async () => {
+    journals.set("s-written-only", {
+      boundaries: [],
+      session: {
+        type: "session_start",
+        at: "2026-08-18T09:00:00Z",
+        run_id: "01ARZ3NDEKTSV4RRFFQ69G5FAX",
+        tool: "claude-code",
+        vendor_id: "s-written-only",
+      },
+      filesWritten: [
+        {
+          type: "file_written",
+          at: "2026-08-18T09:40:00Z",
+          path: `aidd_docs/tasks/${TASK}/plan.md`,
+        },
+      ],
+      taskDeclarations: [],
+    });
+    taskBacklog.set(taskFolderPathFromIdentity(TASK), {
+      kind: "declared",
+      link: { backlog: "acme/widgets#742", writtenAt: "2026-08-18T09:00:00Z", writtenBy: "x" },
+    });
+    await store(
+      record({
+        vendor_id: "s-written-only",
+        cost_usd: 3,
+        event_timestamp: "2026-08-18T09:20:00Z",
+      })
+    );
+
+    const built = await useCase.execute({ ...BASE_OPTIONS, period: PERIOD });
+
+    expect(built.byBacklog.map((row) => row.backlog)).toContain("acme/widgets#742");
   });
 
   it("resolves the declaration through TaskBacklogReader, keyed on the folder the task identity resolves to", async () => {

--- a/cli/tests/domain/formats/claude-code-transcript.unit.test.ts
+++ b/cli/tests/domain/formats/claude-code-transcript.unit.test.ts
@@ -19,6 +19,87 @@ function loadFixture(relativePath: string): string {
 const MAIN_PATH = `.claude/projects/fake-project/${SID}.jsonl`;
 const SUBAGENT_PATH = `.claude/projects/fake-project/${SID}/subagents/agent-aa81cdef3bb58820c.jsonl`;
 
+/** A billed call and the prompt that caused it never share a line.
+ *
+ * Measured on a real 810-record session: zero lines carry both `requestId` and `promptId`.
+ * Only `type: "user"` lines carry a `promptId` — 112 of them — and every one of the 209
+ * lines bearing counters reaches one by following `parentUuid`, three hops in the median.
+ *
+ * The journal already writes that same identifier on `step_start` (Claude Code's
+ * `prompt_id`), so resolving it here is what lets a step be joined to a record exactly,
+ * instead of inferred from the moment each happened to fall on. */
+function chain(lines: readonly Record<string, unknown>[]): string {
+  return lines.map((line) => JSON.stringify(line)).join("\n");
+}
+
+function assistantLine(overrides: Record<string, unknown>): Record<string, unknown> {
+  return {
+    type: "assistant",
+    sessionId: SID,
+    requestId: "req_1",
+    // All four counters or none: `readCounters` refuses a partial `usage` rather than
+    // reading a missing one as zero, so a fixture with two of them yields no record at all.
+    message: {
+      id: "msg_1",
+      model: "claude-opus-5",
+      usage: {
+        input_tokens: 10,
+        output_tokens: 5,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe("mapClaudeCodeTranscriptToSinkRecords — the prompt a billed call belongs to", () => {
+  it("follows parentUuid up to the user line that carries the prompt id", () => {
+    const content = chain([
+      { type: "user", uuid: "u1", promptId: "p-abc" },
+      { type: "assistant", uuid: "a1", parentUuid: "u1", sessionId: SID },
+      assistantLine({ uuid: "a2", parentUuid: "a1" }),
+    ]);
+
+    const [record] = mapClaudeCodeTranscriptToSinkRecords(content);
+
+    expect(record?.prompt_id).toBe("p-abc");
+  });
+
+  it("carries no prompt id when the chain reaches no line that names one", () => {
+    const content = chain([assistantLine({ uuid: "a1" })]);
+
+    const [record] = mapClaudeCodeTranscriptToSinkRecords(content);
+
+    expect(record?.prompt_id).toBeUndefined();
+  });
+
+  // A transcript is appended to by a live process and can be truncated mid-write; a parent
+  // pointing at a line that never arrived must end the walk, not search forever.
+  it("stops at a parent the transcript does not hold, rather than looping", () => {
+    const content = chain([assistantLine({ uuid: "a1", parentUuid: "missing" })]);
+
+    const [record] = mapClaudeCodeTranscriptToSinkRecords(content);
+
+    expect(record?.prompt_id).toBeUndefined();
+  });
+
+  // This one fails by *hanging*, not by going red: the walk is synchronous, so a cycle
+  // wedges the worker and no `--testTimeout` can cut it. Measured — removing the `seen`
+  // guard runs the suite past two minutes until it is killed. Worth stating, because a
+  // reader who saw only a green tick might take the guard for decoration.
+  it("terminates on a chain that points back at itself", () => {
+    const content = chain([
+      { type: "user", uuid: "u1", parentUuid: "a1", promptId: undefined },
+      assistantLine({ uuid: "a1", parentUuid: "u1" }),
+    ]);
+
+    const [record] = mapClaudeCodeTranscriptToSinkRecords(content);
+
+    expect(record?.prompt_id).toBeUndefined();
+  });
+});
+
 describe("mapClaudeCodeTranscriptToSinkRecords", () => {
   it("yields one record per real assistant turn, by value, under the stored field names", () => {
     const records = mapClaudeCodeTranscriptToSinkRecords(loadFixture(MAIN_PATH));

--- a/cli/tests/domain/models/cost-report-contract.unit.test.ts
+++ b/cli/tests/domain/models/cost-report-contract.unit.test.ts
@@ -1,0 +1,66 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { COST_REPORT_ENVELOPE_VERSION } from "../../../src/domain/models/cost-report-envelope.js";
+import { TASK_UNATTRIBUTED_REASONS } from "../../../src/domain/models/task-attribution.js";
+
+// The same honesty check `metrics-contract.unit.test.ts` runs over the record: never a
+// hand-maintained list on either side, only the code's own exported values and the
+// document's own prose, both read fresh off disk. A reason a consumer can receive and the
+// contract never names is a shape nobody can parse against.
+
+const CONTRACT_DOC_URL = new URL(
+  "../../../../aidd_docs/product/cost-report-contract.md",
+  import.meta.url
+);
+
+function contractText(): string {
+  return readFileSync(fileURLToPath(CONTRACT_DOC_URL), "utf8");
+}
+
+describe("the cost report contract document", () => {
+  it("names every reason a row with no task can carry", () => {
+    const document = contractText();
+
+    // Required as a table cell, not merely somewhere in the prose: a reason can be named in
+    // a version note and still be missing from the table a reader parses against, which is
+    // exactly what happened while this document was being edited - the `"no-journal"` row
+    // was clipped out of the table while three prose mentions kept a looser check green.
+    const undocumented = TASK_UNATTRIBUTED_REASONS.filter(
+      (reason) => !document.includes(`| \`"${reason}"\` |`)
+    );
+
+    expect(undocumented).toEqual([]);
+  });
+
+  // A journal file really can be read and still yield no session: `report-cost-use-case.ts`
+  // drops one whose `session_start` header is torn (`if (!journal.session) return null`),
+  // and the adapter's own "keeps a session's boundaries when its header line is torn" test
+  // proves that shape reaches it. Those records land on this reason, so a document claiming
+  // no journal was read "at all", or that nothing looked at what the session declared,
+  // states something false about a case the code produces. The word this hinges on is
+  // "usable".
+  it("never claims the unattributed reason means no journal existed", () => {
+    const document = contractText();
+
+    expect(document).not.toMatch(/no run journal was read for this record's session at all/i);
+    expect(document).toContain("no usable run journal");
+  });
+
+  it("states the envelope version the code actually emits", () => {
+    const stated = /Every object carries `cost_report_version`, currently `(\d+)`/.exec(
+      contractText()
+    );
+
+    expect(stated?.[1]).toBe(String(COST_REPORT_ENVELOPE_VERSION));
+  });
+
+  // The prose sentence above and the worked example below it drifted apart - the sentence
+  // said 10 while the example still showed 8, two versions behind. A reader parses against
+  // the example, so pinning only the sentence guards the half nobody copies.
+  it("shows that same version in its own worked example", () => {
+    const shown = /"cost_report_version": (\d+)/.exec(contractText());
+
+    expect(shown?.[1]).toBe(String(COST_REPORT_ENVELOPE_VERSION));
+  });
+});

--- a/cli/tests/domain/models/cost-report-envelope.unit.test.ts
+++ b/cli/tests/domain/models/cost-report-envelope.unit.test.ts
@@ -198,9 +198,10 @@ describe("toCostReportEnvelope", () => {
     expect(cursor?.reason).toBe("It writes no token count in any file it produces.");
   });
 
-  it("carries all three attribution strengths, strongest first, zeros included", () => {
+  it("carries all four attribution strengths, strongest first, zeros included", () => {
     expect(envelopeOf().attribution.map((row) => row.attribution)).toEqual([
       "tool-stated",
+      "prompt-matched",
       "journal-interval",
       "unattributed",
     ]);

--- a/cli/tests/domain/models/cost-report-task.unit.test.ts
+++ b/cli/tests/domain/models/cost-report-task.unit.test.ts
@@ -170,6 +170,157 @@ describe("buildCostReport — by_task groups by the declared interval a record f
     expect(sumOf(built.byTasks).requests).toBe(built.totals.requests);
   });
 
+  // Two absences a person acts on differently, and the report used to give them one name.
+  // A session whose journal was read and declared nothing is a fact about the work. A
+  // session with no journal at all is a fact about the read - the directory was missing,
+  // the machine that wrote it was another one, the project is not this one. Calling the
+  // second "no usable task declaration in this session" asserts something about work this
+  // layer never looked at, which is an unknown reported as a zero.
+  it("says no journal was read, rather than that the session declared nothing", () => {
+    const records: readonly TelemetrySinkRecord[] = [
+      request({ vendor_id: "s-unjournalled", event_timestamp: "2026-08-17T10:00:00Z" }),
+    ];
+
+    const built = report({ records, journals: [] });
+
+    expect(built.byTasks).toHaveLength(1);
+    expect(built.byTasks[0]?.task).toBeUndefined();
+    expect(built.byTasks[0]?.reason).toBe("no-journal");
+    expect(sumOf(built.byTasks).requests).toBe(built.totals.requests);
+  });
+
+  it("still says the session declared nothing when its journal was read and held no declaration", () => {
+    const journals: readonly CostReportSessionJournal[] = [
+      {
+        vendorId: "s-read-but-silent",
+        tool: "claude-code",
+        writtenPaths: [],
+        taskIntervals: [],
+        flowIntervals: [],
+      },
+    ];
+    const records: readonly TelemetrySinkRecord[] = [
+      request({ vendor_id: "s-read-but-silent", event_timestamp: "2026-08-17T10:00:00Z" }),
+    ];
+
+    const built = report({ records, journals });
+
+    expect(built.byTasks[0]?.reason).toBe("no-declaration");
+  });
+
+  // The backlog axis keys off `by_task`'s own row key, so an unread journal must not arrive
+  // there as a task that declared no backlog item either.
+  it("carries the unread journal through to the backlog axis unchanged", () => {
+    const records: readonly TelemetrySinkRecord[] = [
+      request({ vendor_id: "s-unjournalled", event_timestamp: "2026-08-17T10:00:00Z" }),
+    ];
+
+    const built = report({ records, journals: [] });
+
+    expect(built.byBacklog).toHaveLength(1);
+    expect(built.byBacklog[0]?.reason).toBe("no-journal");
+  });
+
+  // 27 of a real session's 1073 records sat between `session_start` and its first
+  // declaration - 38 minutes of work before the flow named its ticket. That session wrote
+  // into exactly one task folder for its whole life, so those records have an answer the
+  // breakdown was not reading. Marked `inferred`, never merged into the declared row: the
+  // same task holds 1045 records the journal declared and 27 it did not, and one row
+  // carrying the weaker attribution would state something false about the 1045.
+  it("names a record no declaration covers after the only task folder the session wrote into", () => {
+    const journals: readonly CostReportSessionJournal[] = [
+      {
+        vendorId: "s-one-folder",
+        tool: "claude-code",
+        writtenPaths: ["aidd_docs/tasks/2026_08/first-task/plan.md"],
+        taskIntervals: [
+          {
+            path: "aidd_docs/tasks/2026_08/first-task/plan.md",
+            startMs: Date.parse("2026-08-17T11:00:00Z"),
+            endMs: Date.parse("2026-08-17T12:00:00Z"),
+          },
+        ],
+        flowIntervals: [],
+        witnessed: {
+          fromMs: Date.parse("2026-08-17T09:00:00Z"),
+          toMs: Date.parse("2026-08-17T12:00:00Z"),
+        },
+      },
+    ];
+    const records: readonly TelemetrySinkRecord[] = [
+      request({ vendor_id: "s-one-folder", event_timestamp: "2026-08-17T10:00:00Z" }),
+      request({ vendor_id: "s-one-folder", event_timestamp: "2026-08-17T11:30:00Z" }),
+    ];
+
+    const built = report({ records, journals });
+
+    expect(built.byTasks).toEqual([
+      { task: FIRST_TASK, attribution: "declared", totals: expect.anything() },
+      { task: FIRST_TASK, attribution: "inferred", totals: expect.anything() },
+    ]);
+    expect(sumOf(built.byTasks).requests).toBe(built.totals.requests);
+  });
+
+  // Two candidates and no reason to choose between them. The objection that kept written
+  // paths out of this breakdown entirely - one session placed under two task rows at once -
+  // is answered by refusing, never by picking the first.
+  it("infers nothing for a session that wrote into two task folders", () => {
+    const journals: readonly CostReportSessionJournal[] = [
+      {
+        vendorId: "s-two-folders",
+        tool: "claude-code",
+        writtenPaths: [
+          "aidd_docs/tasks/2026_08/first-task/plan.md",
+          "aidd_docs/tasks/2026_08/second-task/plan.md",
+        ],
+        taskIntervals: [],
+        flowIntervals: [],
+        witnessed: {
+          fromMs: Date.parse("2026-08-17T09:00:00Z"),
+          toMs: Date.parse("2026-08-17T12:00:00Z"),
+        },
+      },
+    ];
+    const records: readonly TelemetrySinkRecord[] = [
+      request({ vendor_id: "s-two-folders", event_timestamp: "2026-08-17T10:00:00Z" }),
+    ];
+
+    const built = report({ records, journals });
+
+    expect(built.byTasks).toHaveLength(1);
+    expect(built.byTasks[0]?.task).toBeUndefined();
+    expect(built.byTasks[0]?.reason).toBe("no-declaration");
+  });
+
+  // The bound that stops this route from inventing history. A session whose journal was lost
+  // and recreated witnesses only the time since: its earlier records are in the sink, and
+  // attributing them to a folder that session touched today would be false by days. Measured
+  // on a live machine, where one session's journal began at 09:54 while its own records ran
+  // back a week.
+  it("infers nothing for a record outside the span its journal actually witnessed", () => {
+    const journals: readonly CostReportSessionJournal[] = [
+      {
+        vendorId: "s-short-journal",
+        tool: "claude-code",
+        writtenPaths: ["aidd_docs/tasks/2026_08/first-task/plan.md"],
+        taskIntervals: [],
+        flowIntervals: [],
+        witnessed: {
+          fromMs: Date.parse("2026-08-21T09:00:00Z"),
+          toMs: Date.parse("2026-08-21T12:00:00Z"),
+        },
+      },
+    ];
+    const records: readonly TelemetrySinkRecord[] = [
+      request({ vendor_id: "s-short-journal", event_timestamp: "2026-08-17T10:00:00Z" }),
+    ];
+
+    const built = report({ records, journals });
+
+    expect(built.byTasks).toHaveLength(1);
+    expect(built.byTasks[0]?.task).toBeUndefined();
+  });
+
   it("never lets the whole-session written-path inference the --task filter uses leak into this breakdown", () => {
     // A session that wrote into a task folder, but never declared - the --task filter's
     // own "inferred" route would attribute the whole session to it; this breakdown does

--- a/cli/tests/domain/models/cost-report.unit.test.ts
+++ b/cli/tests/domain/models/cost-report.unit.test.ts
@@ -555,10 +555,11 @@ describe("buildCostReport — every breakdown reconciles", () => {
     }
   });
 
-  it("splits the total three ways by how strongly each part was attributed", () => {
+  it("splits the total four ways by how strongly each part was attributed", () => {
     const built = report({ records: RECORDS });
     expect(built.attributionMix.map((row) => [row.attribution, row.totals.requests])).toEqual([
       ["tool-stated", 2],
+      ["prompt-matched", 0],
       ["journal-interval", 1],
       ["unattributed", 1],
     ]);
@@ -1212,10 +1213,11 @@ describe("buildCostReport — what it says about itself", () => {
     expect(built.totals).toEqual({ requests: 0 });
     expect(built.bySteps).toEqual([]);
     expect(built.byModels).toEqual([]);
-    // Three rows even here: the total is known to be nothing, and none of it came from
+    // Four rows even here: the total is known to be nothing, and none of it came from
     // any source. That is a measurement, not an absence.
     expect(built.attributionMix.map((row) => [row.attribution, row.totals.requests])).toEqual([
       ["tool-stated", 0],
+      ["prompt-matched", 0],
       ["journal-interval", 0],
       ["unattributed", 0],
     ]);

--- a/cli/tests/domain/models/cost-report.unit.test.ts
+++ b/cli/tests/domain/models/cost-report.unit.test.ts
@@ -555,6 +555,40 @@ describe("buildCostReport — every breakdown reconciles", () => {
     }
   });
 
+  // 93% of a real session's tokens are a subagent's: measured on a live transcript, 432M of
+  // 466M, across ten subagent files. Every one of those lines names its agent
+  // (`attributionAgent`, 100% of subagent tokens) and almost never its skill (2.7%), which is
+  // why `by_step` reads 3.7% while the spend is elsewhere. The record already carried
+  // `agent_name` — 924 of 1018 stored records hold one — and nothing exposed it.
+  it("breaks the period down by the agent that ran, main thread included as its own row", () => {
+    const built = report({
+      records: [
+        request({ agent_name: "aidd-dev:executor", input_tokens: 100 }),
+        request({ agent_name: "aidd-dev:executor", input_tokens: 50 }),
+        request({ agent_name: "Explore", input_tokens: 10 }),
+        request({ input_tokens: 1 }),
+      ],
+    });
+
+    expect(built.byAgents.map((row) => [row.agent, row.totals.requests])).toEqual([
+      ["aidd-dev:executor", 2],
+      ["Explore", 1],
+      [undefined, 1],
+    ]);
+  });
+
+  it("reconciles the agent breakdown to the same total as every other axis", () => {
+    const built = report({
+      records: [
+        request({ agent_name: "aidd-dev:checker", input_tokens: 7 }),
+        request({ input_tokens: 3 }),
+      ],
+    });
+
+    const summed = built.byAgents.reduce((total, row) => total + (row.totals.inputTokens ?? 0), 0);
+    expect(summed).toBe(built.totals.inputTokens);
+  });
+
   it("splits the total four ways by how strongly each part was attributed", () => {
     const built = report({ records: RECORDS });
     expect(built.attributionMix.map((row) => [row.attribution, row.totals.requests])).toEqual([

--- a/cli/tests/domain/models/task-attribution.unit.test.ts
+++ b/cli/tests/domain/models/task-attribution.unit.test.ts
@@ -37,6 +37,27 @@ describe("task-attribution — pure: journal lines -> bounded intervals", () => 
     ]);
   });
 
+  // The live case, and the reason `turn_end` stopped closing a declaration on 2026-09-04.
+  // A `turn_end` is a pause, not a change of subject: the session declared
+  // `telemetry-screen` at 05:59, paused at 06:02, and worked on that same task for three
+  // more hours. Closed at the pause, 78% of the session read "before the next task this
+  // session declares" while only 1.8% of its tokens truly preceded any declaration.
+  //
+  // `turn_end` stays a *witness*, so an interval with nothing after it still ends there —
+  // the same moment, for the honest reason. What changes is an interval with work after it.
+  it("keeps a declaration open across a turn_end, ending at the work that followed", () => {
+    const wrote = {
+      type: "file_written",
+      at: "2026-08-17T10:20:00Z",
+      path: "aidd_docs/tasks/2026_08/wanted/phase-1.md",
+    } as const;
+    const intervals = buildTaskIntervals(journalOf([WANTED], [TURN_END], [wrote]));
+
+    expect(intervals).toEqual([
+      { path: WANTED.path, startMs: Date.parse(WANTED.at), endMs: Date.parse(wrote.at) },
+    ]);
+  });
+
   it("closes a declaration at a later declaration, never at the turn's own end past it", () => {
     const intervals = buildTaskIntervals(journalOf([WANTED, OTHER], [TURN_END]));
 
@@ -234,20 +255,12 @@ describe("taskUnattributedReason — which of three distinct facts applies", () 
     expect(taskUnattributedReason(intervals, "2026-08-17T09:00:00Z")).toBe("precedes-declaration");
   });
 
-  it("names precedes-declaration for a record in the gap a turn_end leaves before the next declaration - never journal-silent, since the journal keeps going right through it", () => {
-    // WANTED closes at TURN_END (10:15); a further declaration follows once the journal is
-    // alive again, at 11:00, leaving a real gap in between that no interval covers.
-    const laterDeclaration = {
-      type: "task_declared",
-      at: "2026-08-17T11:00:00Z",
-      path: "aidd_docs/tasks/2026_08/later/spec.md",
-    } as const;
-    const intervals = buildTaskIntervals(journalOf([WANTED, laterDeclaration], [TURN_END]));
-
-    // 10:30 falls after WANTED's own interval closed at TURN_END (10:15) and before
-    // laterDeclaration opens at 11:00 - a real gap the journal is not silent through.
-    expect(taskUnattributedReason(intervals, "2026-08-17T10:30:00Z")).toBe("precedes-declaration");
-  });
+  // Deleted on 2026-09-04, not moved: it asserted a reason for a moment that is now
+  // attributed, so it passed while proving nothing. It described a gap a `turn_end` left
+  // between two declarations — and a `turn_end` no longer closes one, so intervals run
+  // contiguously from each declaration to the next and no such gap can arise.
+  // `precedes-declaration` stays reachable only before a session's first declaration,
+  // which the test above covers.
 
   it("names journal-silent for a record after the last declared interval's own end", () => {
     const intervals = buildTaskIntervals(journalOf([WANTED], [TURN_END]));

--- a/cli/tests/e2e/telemetry-lifecycle.e2e.test.ts
+++ b/cli/tests/e2e/telemetry-lifecycle.e2e.test.ts
@@ -260,6 +260,6 @@ describe("measurement, from nothing to off and back", () => {
     const { measurement_enabled: _before, ...historicalFigures } = envelope;
     const { measurement_enabled: _after, ...historicalFiguresAfterOff } = afterOff;
     expect(historicalFiguresAfterOff).toEqual(historicalFigures);
-    expect(envelope.cost_report_version).toBe(9);
+    expect(envelope.cost_report_version).toBe(10);
   }, 60_000);
 });

--- a/cli/tests/e2e/telemetry-lifecycle.e2e.test.ts
+++ b/cli/tests/e2e/telemetry-lifecycle.e2e.test.ts
@@ -260,6 +260,6 @@ describe("measurement, from nothing to off and back", () => {
     const { measurement_enabled: _before, ...historicalFigures } = envelope;
     const { measurement_enabled: _after, ...historicalFiguresAfterOff } = afterOff;
     expect(historicalFiguresAfterOff).toEqual(historicalFigures);
-    expect(envelope.cost_report_version).toBe(10);
+    expect(envelope.cost_report_version).toBe(12);
   }, 60_000);
 });

--- a/cli/tests/e2e/telemetry-lifecycle.e2e.test.ts
+++ b/cli/tests/e2e/telemetry-lifecycle.e2e.test.ts
@@ -260,6 +260,6 @@ describe("measurement, from nothing to off and back", () => {
     const { measurement_enabled: _before, ...historicalFigures } = envelope;
     const { measurement_enabled: _after, ...historicalFiguresAfterOff } = afterOff;
     expect(historicalFiguresAfterOff).toEqual(historicalFigures);
-    expect(envelope.cost_report_version).toBe(8);
+    expect(envelope.cost_report_version).toBe(9);
   }, 60_000);
 });

--- a/cli/tests/e2e/telemetry-multi-tool.e2e.test.ts
+++ b/cli/tests/e2e/telemetry-multi-tool.e2e.test.ts
@@ -444,7 +444,7 @@ describe("the flow a person can actually follow", () => {
     expect(first.exitCode, first.stderr).toBe(0);
     expect(second.stdout).toBe(first.stdout);
     const parsed = JSON.parse(first.stdout);
-    expect(parsed.cost_report_version).toBe(9);
+    expect(parsed.cost_report_version).toBe(10);
     expect(parsed.period).toEqual({ from_day: "2026-07-01", to_day: "2026-07-31" });
     expect(parsed.attribution.map((row: { attribution: string }) => row.attribution)).toEqual([
       "tool-stated",

--- a/cli/tests/e2e/telemetry-multi-tool.e2e.test.ts
+++ b/cli/tests/e2e/telemetry-multi-tool.e2e.test.ts
@@ -444,10 +444,11 @@ describe("the flow a person can actually follow", () => {
     expect(first.exitCode, first.stderr).toBe(0);
     expect(second.stdout).toBe(first.stdout);
     const parsed = JSON.parse(first.stdout);
-    expect(parsed.cost_report_version).toBe(8);
+    expect(parsed.cost_report_version).toBe(9);
     expect(parsed.period).toEqual({ from_day: "2026-07-01", to_day: "2026-07-31" });
     expect(parsed.attribution.map((row: { attribution: string }) => row.attribution)).toEqual([
       "tool-stated",
+      "prompt-matched",
       "journal-interval",
       "unattributed",
     ]);

--- a/cli/tests/e2e/telemetry-multi-tool.e2e.test.ts
+++ b/cli/tests/e2e/telemetry-multi-tool.e2e.test.ts
@@ -444,7 +444,7 @@ describe("the flow a person can actually follow", () => {
     expect(first.exitCode, first.stderr).toBe(0);
     expect(second.stdout).toBe(first.stdout);
     const parsed = JSON.parse(first.stdout);
-    expect(parsed.cost_report_version).toBe(10);
+    expect(parsed.cost_report_version).toBe(12);
     expect(parsed.period).toEqual({ from_day: "2026-07-01", to_day: "2026-07-31" });
     expect(parsed.attribution.map((row: { attribution: string }) => row.attribution)).toEqual([
       "tool-stated",

--- a/cli/tests/e2e/telemetry-reference-week.e2e.test.ts
+++ b/cli/tests/e2e/telemetry-reference-week.e2e.test.ts
@@ -167,13 +167,20 @@ describe("the reference week", () => {
   });
 
   it("breaks the week down by task, and by the backlog item a task declared", () => {
-    const tasks = envelope.by_task.map((row) => row.task).filter(Boolean);
+    // Distinct, because one task can hold two rows since `cost_report_version` 12 - one for
+    // what a declaration covered, one for what only a written file names, the same
+    // `(name x attribution)` shape `by_step` has always had. What this asserts is which
+    // tasks the week names, never how many routes named each.
+    const tasks = [...new Set(envelope.by_task.map((row) => row.task).filter(Boolean))];
     expect(tasks.sort()).toEqual([...built.expected.tasks].sort());
 
     const declared = envelope.by_backlog.filter((row) => row.backlog !== undefined);
     expect(declared.map((row) => row.backlog)).toEqual([built.expected.backlogItem]);
-    // The task with a backlog link and the task without must not merge into one row.
-    expect(declared[0]?.totals.requests).toBe(2);
+    // The task with a backlog link and the task without must not merge into one row. Three
+    // requests since version 12, not two: that session's 08:07 record precedes its own
+    // declaration at 08:12 by five minutes, its journal witnessed it, and it wrote into that
+    // one task folder and no other - so the written-file route names it too.
+    expect(declared[0]?.totals.requests).toBe(3);
     expect(sumRequests(envelope.by_backlog)).toBe(envelope.totals.requests);
   });
 

--- a/cli/tests/e2e/telemetry-task-midsession.e2e.test.ts
+++ b/cli/tests/e2e/telemetry-task-midsession.e2e.test.ts
@@ -19,6 +19,8 @@ const RUN_ID = "01ARZ3NDEKTSV4RRFFQ69G5FAX";
 const ALPHA_VENDOR_ID = "33333333-3333-4333-8333-333333333333";
 const SILENT_RUN_ID = "01ARZ3NDEKTSV4RRFFQ69G5FAY";
 const SILENT_VENDOR_ID = "44444444-4444-4444-8444-444444444444";
+const AMBIGUOUS_RUN_ID = "01ARZ3NDEKTSV4RRFFQ69G5FAZ";
+const AMBIGUOUS_VENDOR_ID = "55555555-5555-4555-8555-555555555555";
 const PROJECT_ID = "acme/widgets";
 const ALPHA_TASK = "2026_02/2026_02_10_alpha";
 const PERIOD = ["--from", "2026-02-01", "--to", "2026-02-28"];
@@ -65,6 +67,36 @@ const SILENT_JOURNAL_LINES = [
   },
 ];
 
+/** A third session that declares a task and writes into TWO task folders. Two candidates
+ * and no reason to choose, so the written-file route infers nothing here - which is what
+ * keeps a record before this session's own declaration reading `precedes-declaration`, and
+ * proves the refusal bound end to end rather than only in a unit test. */
+const AMBIGUOUS_JOURNAL_LINES = [
+  {
+    type: "session_start",
+    at: "2026-02-10T14:00:00Z",
+    run_id: AMBIGUOUS_RUN_ID,
+    tool: "codex",
+    vendor_id: AMBIGUOUS_VENDOR_ID,
+    project_id: PROJECT_ID,
+  },
+  {
+    type: "file_written",
+    at: "2026-02-10T14:10:00Z",
+    path: `aidd_docs/tasks/${ALPHA_TASK}/plan.md`,
+  },
+  {
+    type: "file_written",
+    at: "2026-02-10T14:12:00Z",
+    path: "aidd_docs/tasks/2026_02/2026_02_10_beta/plan.md",
+  },
+  {
+    type: "task_declared",
+    at: "2026-02-10T14:30:00Z",
+    path: `aidd_docs/tasks/${ALPHA_TASK}/spec.md`,
+  },
+];
+
 function record(overrides: Record<string, unknown>): Record<string, unknown> {
   return {
     kind: "request",
@@ -101,6 +133,14 @@ const AFTER_LAST_WITNESS = record({
   event_timestamp: "2026-02-10T10:30:00Z",
   cost_usd: 4,
 });
+// Before the ambiguous session's own declaration, and its two written folders refuse the
+// inferred route - precedes-declaration.
+const PRECEDES_IN_AMBIGUOUS = record({
+  vendor_id: AMBIGUOUS_VENDOR_ID,
+  turn_id: "ambiguous",
+  event_timestamp: "2026-02-10T14:05:00Z",
+  cost_usd: 16,
+});
 // A session whose journal never declared a task at all - no-declaration.
 const NEVER_DECLARED = record({
   vendor_id: SILENT_VENDOR_ID,
@@ -109,10 +149,17 @@ const NEVER_DECLARED = record({
   cost_usd: 8,
 });
 
-const RECORDS = [BEFORE_DECLARATION, DURING_ALPHA_NO_TURN_END, AFTER_LAST_WITNESS, NEVER_DECLARED];
+const RECORDS = [
+  BEFORE_DECLARATION,
+  DURING_ALPHA_NO_TURN_END,
+  AFTER_LAST_WITNESS,
+  PRECEDES_IN_AMBIGUOUS,
+  NEVER_DECLARED,
+];
 
 interface TaskRow {
   readonly task?: string;
+  readonly attribution?: string;
   readonly reason?: string;
   readonly totals: { readonly requests: number; readonly cost_micro_usd?: number };
 }
@@ -152,6 +199,11 @@ describe("aidd telemetry report — a task declared while the work is still goin
     await writeFile(
       join(runsDir, `${SILENT_RUN_ID}__${SILENT_VENDOR_ID}.jsonl`),
       `${SILENT_JOURNAL_LINES.map((line) => JSON.stringify(line)).join("\n")}\n`,
+      "utf-8"
+    );
+    await writeFile(
+      join(runsDir, `${AMBIGUOUS_RUN_ID}__${AMBIGUOUS_VENDOR_ID}.jsonl`),
+      `${AMBIGUOUS_JOURNAL_LINES.map((line) => JSON.stringify(line)).join("\n")}\n`,
       "utf-8"
     );
     const sinkDir = join(env.fakeHome, ".config", "aidd", "telemetry");
@@ -198,14 +250,20 @@ describe("aidd telemetry report — a task declared while the work is still goin
     expect(taskRowOfCost(afterClose, 2)?.task).toBe(ALPHA_TASK);
   });
 
-  it("names each of the three unattributed reasons distinctly, never collapsing two into one", async () => {
+  // The record at 09:05 precedes its session's declaration, but that session wrote into one
+  // task folder and nothing else, and its journal witnessed 09:05 - so the written-file
+  // route names it, marked `inferred`. `precedes-declaration` is proven on the ambiguous
+  // session instead, where two written folders refuse that route.
+  it("names each unattributed reason distinctly, never collapsing two into one", async () => {
     const { projectDir, fakeHome } = await seed();
 
     const result = await runCli(["telemetry", "report", ...PERIOD, "--json"], projectDir, fakeHome);
     expect(result.exitCode).toBe(0);
     const envelope = JSON.parse(result.stdout) as Envelope;
 
-    expect(taskRowOfCost(envelope, 1)?.reason).toBe("precedes-declaration");
+    expect(taskRowOfCost(envelope, 1)?.attribution).toBe("inferred");
+    expect(taskRowOfCost(envelope, 1)?.task).toBe(ALPHA_TASK);
+    expect(taskRowOfCost(envelope, 16)?.reason).toBe("precedes-declaration");
     expect(taskRowOfCost(envelope, 4)?.reason).toBe("journal-silent");
     expect(taskRowOfCost(envelope, 8)?.reason).toBe("no-declaration");
 
@@ -213,7 +271,7 @@ describe("aidd telemetry report — a task declared while the work is still goin
     expect(new Set(reasonRows.map((row) => row.reason)).size).toBe(reasonRows.length);
   });
 
-  it("prints each reason in the text rendering too, never one label for all three", async () => {
+  it("prints each reason in the text rendering too, never one label for all of them", async () => {
     const { projectDir, fakeHome } = await seed();
 
     const result = await runCli(["telemetry", "report", ...PERIOD], projectDir, fakeHome);

--- a/cli/tests/fixtures/cli-owns-read/expected-envelope.json
+++ b/cli/tests/fixtures/cli-owns-read/expected-envelope.json
@@ -1,5 +1,5 @@
 {
-  "cost_report_version": 8,
+  "cost_report_version": 9,
   "period": {
     "from_day": "2026-01-01",
     "to_day": "2026-01-31"
@@ -443,6 +443,12 @@
         "output_tokens": 500,
         "cache_read_tokens": 12000,
         "cache_creation_tokens": 1000
+      }
+    },
+    {
+      "attribution": "prompt-matched",
+      "totals": {
+        "requests": 0
       }
     },
     {

--- a/cli/tests/fixtures/cli-owns-read/expected-envelope.json
+++ b/cli/tests/fixtures/cli-owns-read/expected-envelope.json
@@ -1,5 +1,5 @@
 {
-  "cost_report_version": 10,
+  "cost_report_version": 12,
   "period": {
     "from_day": "2026-01-01",
     "to_day": "2026-01-31"
@@ -226,7 +226,7 @@
   ],
   "by_task": [
     {
-      "reason": "no-declaration",
+      "reason": "no-journal",
       "totals": {
         "requests": 4,
         "input_tokens": 935,
@@ -490,7 +490,7 @@
   },
   "by_backlog": [
     {
-      "reason": "no-declaration",
+      "reason": "no-journal",
       "totals": {
         "requests": 4,
         "input_tokens": 935,

--- a/cli/tests/fixtures/cli-owns-read/expected-envelope.json
+++ b/cli/tests/fixtures/cli-owns-read/expected-envelope.json
@@ -1,5 +1,5 @@
 {
-  "cost_report_version": 9,
+  "cost_report_version": 10,
   "period": {
     "from_day": "2026-01-01",
     "to_day": "2026-01-31"
@@ -59,6 +59,17 @@
     }
   ],
   "by_flow": [
+    {
+      "totals": {
+        "requests": 4,
+        "input_tokens": 935,
+        "output_tokens": 590,
+        "cache_read_tokens": 14100,
+        "cache_creation_tokens": 1000
+      }
+    }
+  ],
+  "by_agent": [
     {
       "totals": {
         "requests": 4,

--- a/cli/tests/infrastructure/adapters/run-journal-reader-adapter.integration.test.ts
+++ b/cli/tests/infrastructure/adapters/run-journal-reader-adapter.integration.test.ts
@@ -89,6 +89,66 @@ describe("RunJournalReaderAdapter", () => {
     ]);
   });
 
+  // The hook that writes a journal anchors at `git rev-parse --show-toplevel`
+  // (plugins/aidd-telemetry/hooks/lib/repo.cjs), so a session started anywhere inside a
+  // checkout writes into ONE directory at its root. A reader anchored at the process
+  // working directory instead finds that directory only when the command happens to be run
+  // from the root - and answers "this session declared no task" when it is not, which is a
+  // claim about the work rather than about the read.
+  it("anchors at the repository root, so a subdirectory finds the journal the hook wrote", async () => {
+    await mkdir(join(projectRoot, ".git"), { recursive: true });
+    await writeFile(
+      join(runsDir, `${RUN_ID}__${SESSION_ID}.jsonl`),
+      runFileLines({ type: "step_start", at: "2026-08-20T10:00:00Z", skill: "from-the-root" })
+    );
+    const subdirectory = join(projectRoot, "cli", "nested");
+    await mkdir(subdirectory, { recursive: true });
+
+    const journal = await new RunJournalReaderAdapter(subdirectory).read(SESSION_ID);
+
+    expect(journal?.boundaries).toEqual([
+      { type: "step_start", at: "2026-08-20T10:00:00Z", skill: "from-the-root" },
+    ]);
+  });
+
+  // A linked worktree's `.git` is a FILE holding `gitdir: …`, not a directory. Accepting
+  // only a directory would leave every worktree anchored at the process working directory -
+  // and this repository is developed in worktrees, so the case is the common one, not a
+  // corner.
+  it("accepts a linked worktree, whose .git is a file rather than a directory", async () => {
+    await writeFile(join(projectRoot, ".git"), "gitdir: /elsewhere/.git/worktrees/w\n");
+    await writeFile(
+      join(runsDir, `${RUN_ID}__${SESSION_ID}.jsonl`),
+      runFileLines({ type: "step_start", at: "2026-08-20T10:00:00Z", skill: "from-the-worktree" })
+    );
+    const subdirectory = join(projectRoot, "cli");
+    await mkdir(subdirectory, { recursive: true });
+
+    const journal = await new RunJournalReaderAdapter(subdirectory).read(SESSION_ID);
+
+    expect(journal?.boundaries).toEqual([
+      { type: "step_start", at: "2026-08-20T10:00:00Z", skill: "from-the-worktree" },
+    ]);
+  });
+
+  // Outside any checkout there is no root to walk up to. The reader keeps the directory it
+  // was handed rather than climbing to the filesystem root and reading a stranger's journal.
+  it("keeps the directory it was given when no repository root is above it", async () => {
+    const outside = await mkdtemp(join(tmpdir(), "aidd-run-journal-outside-"));
+    await mkdir(join(outside, "aidd_docs", "runs"), { recursive: true });
+    await writeFile(
+      join(outside, "aidd_docs", "runs", `${RUN_ID}__${SESSION_ID}.jsonl`),
+      runFileLines({ type: "step_start", at: "2026-08-20T10:00:00Z", skill: "from-outside" })
+    );
+
+    const journal = await new RunJournalReaderAdapter(outside).read(SESSION_ID);
+
+    expect(journal?.boundaries).toEqual([
+      { type: "step_start", at: "2026-08-20T10:00:00Z", skill: "from-outside" },
+    ]);
+    await rm(outside, { recursive: true, force: true });
+  });
+
   it("honors AIDD_RUNS_DIR over <projectRoot>/aidd_docs/runs, matching the writing hook", async () => {
     const overrideDir = await mkdtemp(join(tmpdir(), "aidd-run-journal-override-"));
     process.env.AIDD_RUNS_DIR = overrideDir;

--- a/cli/tests/infrastructure/adapters/task-backlog-adapter.integration.test.ts
+++ b/cli/tests/infrastructure/adapters/task-backlog-adapter.integration.test.ts
@@ -95,6 +95,31 @@ describe("TaskBacklogAdapter — reads a declaration without ever writing one", 
     );
   });
 
+  // The task folder path this reader is handed is repository-relative, because the journal
+  // line it came from was written relative to the repository root. Joining it to the
+  // process working directory instead finds nothing from a subdirectory - and "nothing" is
+  // spelled `{ kind: "none" }`, "this task declares no backlog item", which is a claim about
+  // the task rather than about the read. Introduced the moment the journal reader started
+  // anchoring at the root: `by_task` names the task, `by_backlog` says it declares nothing.
+  it("anchors at the repository root, so a subdirectory reads the same declaration", async () => {
+    const root = await freshProject();
+    await mkdir(join(root, ".git"), { recursive: true });
+    await writeLink(
+      root,
+      JSON.stringify({
+        backlog: "acme/widgets#661",
+        written_at: "2026-08-21T10:00:00Z",
+        written_by: "aidd-vcs:01-commit",
+      })
+    );
+    const subdirectory = join(root, "cli", "nested");
+    await mkdir(subdirectory, { recursive: true });
+
+    const declaration = await new TaskBacklogAdapter(subdirectory).read(TASK_FOLDER);
+
+    expect(declaration.kind).toBe("declared");
+  });
+
   it("answers none for a folder that declares nothing — a normal state, not an error", async () => {
     const root = await freshProject();
     await mkdir(join(root, TASK_FOLDER), { recursive: true });

--- a/plugins/aidd-telemetry/skills/01-cost/actions/03-report.md
+++ b/plugins/aidd-telemetry/skills/01-cost/actions/03-report.md
@@ -65,7 +65,7 @@ else.
 
 | Task | Share | Tokens | Attribution |
 | --- | --- | --- | --- |
-| <task, or the reason it fell in none: "no usable task declaration in this session" \| "before the next task this session declares" \| "the journal falls silent before this record"> | <n>% | <tokens> | <declared by the flow \| —> |
+| <task, or the reason it fell in none: "no usable run journal for this session" \| "no usable task declaration in this session" \| "before the next task this session declares" \| "the journal falls silent before this record"> | <n>% | <tokens> | <declared by the flow \| inferred from a written file \| —> |
 
 **By backlog item**
 
@@ -93,9 +93,18 @@ A breakdown the object leaves empty is a section left out, never a table of zero
    - One axis: `aidd telemetry report --axis <axis> --from 2026-08-01 --to 2026-08-31`.
    - Everything: `aidd telemetry report --from 2026-08-01 --to 2026-08-31 --json`, reading the shape from [cost-report-contract.md](../../../../../aidd_docs/product/cost-report-contract.md).
    - The figure will be kept or compared: give `--from` and `--to`, since `--days` resolves against today and two identical calls on two days cover two different periods.
-3. **Refuse an unknown shape.** `cost_report_version` is `8` today, read from the `--json`
+3. **Refuse an unknown shape.** `cost_report_version` is `12` today, read from the `--json`
    path - the `--axis` path prints text the script already built from that same object, so
-   there is no separate version to check there. The bump from `7` to `8` added `by_flow`
+   there is no separate version to check there. The bump from `11` to `12` did not add a
+   breakdown either: `by_task`'s `attribution` stopped being always `declared`, so one task
+   can now hold two rows - one for what a declaration covered, one for what only a written
+   file names. The bump from `10` to `11` did not add a
+   breakdown: the reasons a `by_task` or `by_backlog` row can carry for a record in no task
+   gained a fourth, `"no-journal"`, which says no usable run journal reached that record's
+   session - a fact about the read, never the claim that the session declared no task. The
+   bump from `9` to `10` added `by_agent` to the top-level breakdowns: which agent ran,
+   which on Claude Code is where most of the spend is. The bump from `8` to `9` added a
+   fourth value to `attribution`, `prompt-matched`. The bump from `7` to `8` added `by_flow`
    to the top-level breakdowns: which orchestrated run the journal's own step sequence
    already names (see [cost-report-contract.md](../../../../../aidd_docs/product/cost-report-contract.md)),
    nothing newly captured for it. The bump from `6` to `7` added `by_backlog`
@@ -103,9 +112,8 @@ A breakdown the object leaves empty is a section left out, never a table of zero
    declares (see [cost-report-contract.md](../../../../../aidd_docs/product/cost-report-contract.md)),
    never a second notion of which task a record belongs to. The bump from `5` to `6` did
    not add a breakdown: what `by_task` gives for a record that fell in no declared
-   interval can now be up to three rows instead of always one, each carrying `reason` -
-   naming which of three distinct facts applies, so two different gaps are never read as
-   one. The bump from `4` added `by_task` to the top-level breakdowns, grouped by the same
+   interval can now be more than one row, each carrying `reason` - naming which distinct
+   fact applies, so two different gaps are never read as one. The bump from `4` added `by_task` to the top-level breakdowns, grouped by the same
    declared intervals `--task` already filters on - never by a written file, which could
    place one session under two task rows at once. The bump from `3` to `4` added
    `by_person` to the top-level breakdowns and `identity_unusable` to `read`.

--- a/scripts/__tests__/aidd-telemetry-cost-skill.test.js
+++ b/scripts/__tests__/aidd-telemetry-cost-skill.test.js
@@ -154,7 +154,11 @@ test("every field the cost skill names by name resolves on the object the script
   // `by_task`'s rows by what each task's own folder declares. 16 -> 17 when 03-report.md
   // named `by_flow`, the flow-and-versions top-level breakdown grouping by the orchestrated
   // run the journal's own step sequence already names, nothing newly captured for it.
-  assert.equal(claims.size, 17, "expected exactly seventeen field references in the cost skill");
+  // 17 -> 18 when 03-report.md named `by_agent`, the breakdown by the agent that ran, added
+  // while bringing the skill's own version paragraph up from `8` to `11` - it had gone three
+  // bumps stale, so the paragraph named neither `by_agent` nor `prompt-matched` nor the
+  // fourth no-task reason a row can now carry.
+  assert.equal(claims.size, 18, "expected exactly eighteen field references in the cost skill");
 
   // Fields the envelope carries only under some condition, so a fixture cannot show them all
   // at once: the first five appear only under a selection, and `cost_micro_usd` only once a

--- a/scripts/lib/telemetry-reference-week.cjs
+++ b/scripts/lib/telemetry-reference-week.cjs
@@ -333,10 +333,11 @@ function seedAdaFlow({ projectDir, home, runsDir }) {
   });
   // Not redundant with the write, and the difference is why both are here: a write is
   // recorded as `file_written` and `task-declared.cjs` stands down for it, but
-  // `buildTaskIntervals` opens intervals on `task_declared` alone. A session that only
-  // writes into a task folder gets no `--axis task` row, while `--task <folder>` still
-  // finds it through the inferred route. The axis and the filter disagree; this session
-  // carries both lines so the week shows each.
+  // `buildTaskIntervals` opens intervals on `task_declared` alone. Since
+  // `cost_report_version` 12 the axis reads written files too, bounded to a session that
+  // wrote into exactly one task folder and to the span its journal witnessed - so a record
+  // before this session's own declaration lands on the task, marked `inferred` rather than
+  // `declared`. This session carries both lines so the week shows each route on one task.
   toolUsed("2026-03-02T08:12:00Z", {
     tool_name: "Read",
     tool_input: { file_path: `aidd_docs/tasks/${TASK_WITH_BACKLOG}/plan.md` },


### PR DESCRIPTION
## What this fixes

`aidd telemetry report` answered differently depending on the directory it ran from. From
`cli/`, one row: `"no-declaration"`, 100% of the period. From the repository root, four
named tasks. Same machine, same sink, same journals.

The hook that writes a run journal anchors at `git rev-parse --show-toplevel`; the reader
joined `aidd_docs/runs` to the process working directory. From a subdirectory it found no
journal at all — and then reported that the work had declared no task. An unknown reported
as a zero, on the project's own rule.

## Three changes

**Both readers of repository-relative journal paths anchor at the repository root.**
Anchoring only the journal reader turned out worse than the original fault: `by_task` named
the task while `by_backlog` said that task declared no backlog item, with nothing left to
signal the answer was wrong. Found by an independent check, reproduced as a failing test
before being fixed.

**A record whose session has no usable run journal carries its own reason,** `"no-journal"`,
distinct from a session whose journal was read and declared nothing. "Usable" is
load-bearing: a journal whose `session_start` header is torn is read and then dropped, so
its records reach this reason too — claiming "no journal was read at all" would have
replaced one false statement with another.

**`by_task` now reads the second signal the journal already holds.** A record no declaration
covers, in a session that wrote into exactly one task folder, inside the span its own
journal witnessed, is named after that folder and marked `"inferred"`. Nothing is asked of a
skill or of the model: `file_written` is already written by the hook at turn end.

## Measured

On the one session in a real sink with a complete journal, 1073 requests:

```
before:  1045 declared                        = 1045 / 1073   (97.4%)
after:   1045 declared + 28 inferred          = 1073 / 1073  (100.0%)
```

Both bounds on the inferred route fired on real data. A session that wrote into two task
folders infers nothing. A record outside the span its journal witnessed infers nothing
either — which keeps 28,079 records, from the seven days before one session's journal was
lost and recreated, off a folder that session touched today.

A journal moment is a second (the writing hook strips the milliseconds) while a record
carries them, so a record landing inside the very second the journal last wrote was refused
by a rounding artefact. Exactly one record of 1073 — the difference between 99.9% and 100%.

## Contract

`cost_report_version` 10 → 12. Every consumer updated: the contract document and its worked
example, three e2e expectations, the pinned envelope fixture, and the cost skill's report
template, whose version paragraph had gone three bumps stale.

Two new guards cover what slipped while writing this: the contract's worked example is
pinned to the emitted version (it had drifted to `8` while the prose said `10`), and each
reason must appear as a **table row** rather than as a mention anywhere in the prose — added
after an edit here silently clipped one row out of that table.

## How it was checked

- Test first throughout; every guard shipped with the mutation that proves it, and each
  mutation killed the test named for it and no other.
- An independent checker reviewed the first half and returned six findings, all reproduced
  and closed. One of them was that `npx vitest run` does not build, so the e2e tier had been
  running against a stale binary — the gate is `pnpm test`, and every run since is that.
- `pnpm test`: 311 files, 3450 tests. `tsc --noEmit`: clean. biome, knip, jscpd: clean.
- End to end on the built binary, in a sandboxed `HOME`: root, subdirectory and outside a
  checkout, with `by_task` and `by_backlog` agreeing where they must and refusing where they
  must.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWNxk63AGKkqE8HRqHLjGp
