### PR TITLE
feat(telemetry): a skill says when it is done, because nothing else can

### DIFF
--- a/aidd_docs/product/metrics-contract.md
+++ b/aidd_docs/product/metrics-contract.md
@@ -391,6 +391,23 @@ plugin alongside the step name; a journal interval never carries a plugin at
 all, so `step_plugin` is absent whenever `step_attribution` is
 `"journal-interval"`, even though `step` itself is present there.
 
+**A journal interval ends where the journal says, and only a skill can say it.** The
+interval runs from the `step_start` a skill's invocation wrote to the first of: a `step_end`
+line naming that same skill, another `step_start`, or a `turn_end`. Only the first of those
+is the end itself; the other two stand in for it. That matters because a `turn_end` is a
+**pause** — a skill working across three prompts is credited with its first turn and nothing
+after — and nothing any host emits says when a skill's work finished. Measured: a `Skill`
+tool call's own `tool_result` returns about a tenth of a second after the call, which is the
+dispatch, not the completion. So a skill declares its own end through a tool call it makes,
+carrying `aidd:step-end <skill>` in that call's arguments, and the hook writes the line. An
+end naming a skill the session never started closes nothing, and an end never closes a step
+other than the one it names — a skill invoking another must not end it.
+
+A step whose interval was closed by a stated `step_end` still reads `"journal-interval"`, not
+a stronger value: the record was still placed by its moment falling inside a span, which is
+the inference that value names. What the end changes is the span, never how the record met
+it.
+
 **`step_attribution: "unattributed"` does not mean "this request ran outside any
 step."** Claude Code's own attribution field is omitted from its transcript both
 when no skill was running and when the running Claude Code version predates the

--- a/aidd_docs/runs/README.md
+++ b/aidd_docs/runs/README.md
@@ -16,12 +16,31 @@ Every line carries `at` (ISO 8601, UTC, second precision) and `type`:
 | `turn_end` | `prompt_id` when the host provides one, omitted otherwise | Stop |
 | `file_written` | `path`, repository-relative and `/`-separated, plus `source` (`"tool-stated"` \| `"observed"`) | PostToolUse, for a write that lands inside a task folder |
 | `task_declared` | `path`, repository-relative and `/`-separated | PostToolUse, for a call whose own arguments name a file under a task folder |
-| `step_start` | `skill` (sanitised as a value, never as a path segment), plus `turn_id` when the host provides one | PostToolUse, for a call that names a skill being run — a start only, since no tool exposes when a skill's work finishes |
+| `step_start` | `skill` (sanitised as a value, never as a path segment), plus `turn_id` when the host provides one | PostToolUse, for a call that names a skill being run |
+| `step_end` | `skill`, sanitised the same way | PostToolUse, for a call whose own arguments carry `aidd:step-end <skill>` — the skill saying its own work is over, since no host emits that |
 | `scan_truncated` | `cap`, `scanned` | Stop, when the sweep for files a task folder gained since the turn began hit its budget before finishing — so a reader can tell "nothing else changed" from "the walk gave up before it could tell" |
 
 `step_start` is the line that names which skill was running, and the one this table most
 recently caught up on documenting: complete coverage of what the journal writes is the
 whole reason a report can attribute a token to a step at all.
+
+`step_end` is its counterpart, and it exists because nothing else can supply it. A `Skill`
+tool call's own `tool_result` comes back about a tenth of a second later — that is the
+dispatch, not the completion — so no hook can observe when a skill finished. Without a stated
+end a reader must close a step at the next `step_start` or `turn_end`, and a `turn_end` is a
+pause: a skill working across three prompts is credited with its first turn and nothing
+after. So the skill declares its own end through a tool call it makes, carrying
+`aidd:step-end <skill>` in that call's arguments, and the hook — which alone holds the
+session id and the working directory — writes the line. It is read out of free-form arguments
+exactly as `task_declared` is, so every host that forwards tool arguments is covered rather
+than one.
+
+The line names its skill, never only a moment. An end closes only the interval its own skill
+opened: closing "whatever is open" would close the wrong one the moment a skill invokes
+another, and an end naming a skill the session never started closes nothing at all rather
+than truncating whatever was running. Like `task_declared`, it restores the run file's mtime
+after appending, so it can never push the write watermark past a file the turn should still
+observe.
 
 `plugin_version` is this plugin's own version, from `.claude-plugin/plugin.json` — read
 once per process by `lib/plugin-version.cjs`, never per line, and stamped only on

--- a/aidd_docs/tasks/2026_09/2026_09_04_a-skill-says-when-it-is-done/plan.md
+++ b/aidd_docs/tasks/2026_09/2026_09_04_a-skill-says-when-it-is-done/plan.md
@@ -1,0 +1,113 @@
+---
+status: done
+---
+
+# A skill says when it is done, because nothing else can
+
+## Frame
+
+### The measured gap
+
+A step interval opens on `step_start` and closes on whichever boundary comes next — another
+`step_start`, or a `turn_end`. `turn_end` is a **pause**, not the end of a skill's work, so a
+skill that spans several prompts is credited only with its first turn.
+
+Measured on the one session with a complete journal: four `Skill` invocations between
+05:23 and 06:02, and the step axis names **6.4%** of that session's 1073 records. The
+session went on working for three and a half more hours.
+
+The same fix that worked for tasks — stop letting `turn_end` close an interval — was tried
+here and reverted: it gave `aidd-dev:01-plan` 93% of a period, attributing 130M tokens of
+implementation to a planning skill. Leaving the interval open is worse still.
+
+### Why no hook can close it
+
+Checked, not assumed. The `tool_result` for both `Skill` and `Agent` comes back in about a
+tenth of a second:
+
+```
+Skill  05:23:51.590 -> 05:23:51.668   0s
+Agent  06:01:12.684 -> 06:01:12.820   0s
+```
+
+That is the dispatch, not the completion. `step-starts.cjs` says the same in its own header:
+*"no tool measured so far exposes when a skill's work finishes"*. So the end is not something
+any host emits and no hook can observe it.
+
+The only party that knows a skill's work is over is the skill.
+
+### What this does not buy
+
+**It does not raise the number of steps.** 86 `Skill` invocations across 180 transcripts of
+this project, against 31,435 prompts. Work that ran under no skill still has no step, and
+nothing here changes that. What it buys is the *span* of the steps that do exist: a skill
+that ran for two hours currently reads as one turn.
+
+### Decisions
+
+**The hook stays the writer.** A script invoked by a skill has no payload, therefore no
+session id and no cwd, and cannot find the run file to append to. The precedent is already in
+the plugin: `task-declared.cjs` reads a task path out of a tool call's own free-form
+arguments, because "naming the file you are about to read is what calling the tool already
+requires". A step end is declared the same way — the skill's own last tool call carries a
+marker, `PostToolUse` fires with a full payload, and the hook writes the line. Nothing new is
+invoked, no second writer of the journal exists, and every host that forwards tool arguments
+is covered rather than Claude Code alone.
+
+**The marker names its skill.** Closing "whatever step is open" would close the wrong one
+when a skill invokes another. A marker naming a skill with no open interval is ignored.
+
+**A step closed by a stated end is a different strength from one closed by a pause**, and
+`StepAttributionSource` already exists to say so. Whether that earns a fifth value is settled
+in phase 3, against the same rule that governs every axis here: an attribution says its own
+strength.
+
+**One skill emits it in this change.** A mechanism nothing uses is unearned surface, and this
+repository deletes those. One skill proves the path end to end; the rest follow only once the
+route has run against real work.
+
+## Phases
+
+| # | Phase | Proves |
+| --- | --- | --- |
+| 1 | The hook writes `step_end` from a marker in a tool call | the line appears, for the named skill, on every declared host |
+| 2 | The reader closes an interval on it | a step spanning three turns is one interval, not one turn |
+| 3 | The contract says how strong that is | the envelope and the document name the difference |
+| 4 | One skill declares its own end | the path runs end to end, measured |
+
+Test first at every phase; each guard ships with the mutation that proves it.
+
+## Result
+
+Measured end to end on the built binary, one journal, two records, the only difference being
+whether the skill declared its end:
+
+```
+avec step_end     aidd-dev:01-plan  journal-interval  2
+sans step_end     [aucune]          unattributed      1
+                  aidd-dev:01-plan  journal-interval  1
+```
+
+The record made after two `turn_end` lines is the one at stake. Without a stated end the
+interval closes at the first pause and that record is unattributed; with one it belongs to
+the step that was actually running.
+
+Nine guards, each with the mutation that proves it: no mtime restore (the turn loses a write
+it should have observed), a marker that need not name a skill, the hook not dispatching, an
+end closing whatever is open rather than its own skill, an end acting as a generic closer,
+and a skill whose marker names another skill.
+
+The last of those is the drift guard that matters most: it sweeps every `SKILL.md` under
+`plugins/`, and for each one carrying a marker asserts the hook reads back exactly that
+skill's own name. A second skill opting in is covered without the test being told, and a
+marker that drifts from the pattern fails here rather than silently closing nothing for a
+whole release.
+
+`pnpm test` 311 files / 3453 tests; repo-level `node --test scripts/__tests__` 364 pass, the
+single failure naming only another session's untracked files.
+
+## What it does not do
+
+It does not raise the number of steps. 86 `Skill` invocations across 180 transcripts of this
+project against 31,435 prompts: work that ran under no skill still has no step. What changed
+is the span of the steps that exist, and only for skills that opt in — one does today.

--- a/cli/src/domain/models/step-attribution.ts
+++ b/cli/src/domain/models/step-attribution.ts
@@ -79,14 +79,34 @@ function parseableBoundaries(boundaries: readonly RunJournalBoundary[]): readonl
  * (A, then B, then A) yield three intervals and two names, exactly as the boundaries
  * dictate; nothing here decides which record falls into which, that is `attributeMoment`'s
  * job, kept separate so an interval list can be built once per session and reused. */
+/** Where a step that opened at `from` ends.
+ *
+ * A `step_end` naming this very skill wins over everything between, however many pauses that
+ * is: it is the only line in the journal that states the end rather than standing in for it,
+ * and a skill spanning three prompts is exactly the case a `turn_end` used to cut short.
+ *
+ * With no such line, the rule is the one this reader always had - the next `step_start` or
+ * `turn_end`, or nothing. A `step_end` naming a *different* skill is never a closer here: it
+ * would truncate a step it has no claim on, which is the fault naming the skill exists to
+ * prevent. */
+function stepEndsAt(timed: readonly TimedBoundary[], from: number, skill: string): number {
+  for (let i = from + 1; i < timed.length; i++) {
+    const { boundary } = timed[i];
+    if (boundary.type === "step_end" && boundary.skill === skill) return timed[i].atMs;
+  }
+  for (let i = from + 1; i < timed.length; i++) {
+    if (timed[i].boundary.type !== "step_end") return timed[i].atMs;
+  }
+  return Number.POSITIVE_INFINITY;
+}
+
 export function buildStepIntervals(journal: RunJournal): readonly StepInterval[] {
   const timed = parseableBoundaries(journal.boundaries);
   const intervals: StepInterval[] = [];
   for (let i = 0; i < timed.length; i++) {
     const { atMs: startMs, boundary } = timed[i];
     if (boundary.type !== "step_start") continue;
-    const endMs = timed[i + 1]?.atMs ?? Number.POSITIVE_INFINITY;
-    intervals.push({ skill: boundary.skill, startMs, endMs });
+    intervals.push({ skill: boundary.skill, startMs, endMs: stepEndsAt(timed, i, boundary.skill) });
   }
   return intervals;
 }

--- a/cli/src/domain/ports/run-journal-reader.ts
+++ b/cli/src/domain/ports/run-journal-reader.ts
@@ -25,7 +25,21 @@ export interface RunJournalTurnEnd {
   readonly at: string;
 }
 
-export type RunJournalBoundary = RunJournalStepStart | RunJournalTurnEnd;
+/** One `step_end` line: the moment a skill said its own work was over, and the skill it
+ * says it for. Mirrors `plugins/aidd-telemetry/hooks/lib/record.cjs`'s `buildStepEndLine`.
+ *
+ * The one thing about a step no host emits, which is why the skill declares it and the hook
+ * writes it (`plugins/aidd-telemetry/hooks/lib/step-ends.cjs`). Carries its skill, and closes only that skill's own
+ * open interval: closing "whatever is open" would close the wrong one the moment a skill
+ * invokes another, and an end naming a skill this session never started closes nothing at
+ * all rather than truncating whatever was running. */
+export interface RunJournalStepEnd {
+  readonly type: "step_end";
+  readonly at: string;
+  readonly skill: string;
+}
+
+export type RunJournalBoundary = RunJournalStepStart | RunJournalTurnEnd | RunJournalStepEnd;
 
 /** The `session_start` line: the one line naming what a session was. `tool` holds the
  * journal hook's own host identifier ("claude-code", "codex", "copilot", "cursor"), which

--- a/cli/src/infrastructure/adapters/run-journal-reader-adapter.ts
+++ b/cli/src/infrastructure/adapters/run-journal-reader-adapter.ts
@@ -67,15 +67,19 @@ function parseLine(line: string): RawJournalLine | null {
   }
 }
 
-/** One `step_start` or `turn_end` line, or `null` for every other line type and every line
+/** One `step_start`, `turn_end` or `step_end` line, or `null` for every other line type and every line
  * this file cannot parse — a torn final line from a session still in progress reads as
  * nothing, not as a boundary at the wrong moment. */
 function parseBoundary(parsed: RawJournalLine): RunJournalBoundary | null {
   const at = asString(parsed.at);
   if (at === undefined) return null;
   if (parsed.type === "turn_end") return { type: "turn_end", at };
-  const skill = parsed.type === "step_start" ? asString(parsed.skill) : undefined;
+  const skill = asString(parsed.skill);
   if (skill === undefined) return null;
+  // An end with no skill is dropped rather than read as a bare boundary: it would close a
+  // step it cannot name, which is the one thing `RunJournalStepEnd` exists to prevent.
+  if (parsed.type === "step_end") return { type: "step_end", at, skill };
+  if (parsed.type !== "step_start") return null;
   const turnId = asString(parsed.turn_id);
   return { type: "step_start", at, skill, ...(turnId === undefined ? {} : { turn_id: turnId }) };
 }

--- a/cli/tests/domain/models/step-attribution.unit.test.ts
+++ b/cli/tests/domain/models/step-attribution.unit.test.ts
@@ -37,6 +37,61 @@ describe("step-attribution — pure: journal lines + records -> intervals", () =
     expect(attribution).toEqual({ source: "journal-interval", step: "aidd-dev:02-implement" });
   });
 
+  // A `turn_end` is a pause: a skill that spans three prompts is credited with its first
+  // turn and nothing after. Nothing any host emits says when a skill's work finished -
+  // measured, a `Skill` call's own `tool_result` returns in about a tenth of a second, which
+  // is the dispatch - so the skill declares its own end and the hook writes it. Stated, the
+  // end wins over every pause between it and the start.
+  it("runs a step past every pause, to the end its own skill declared", () => {
+    const intervals = buildStepIntervals(
+      journalOf(
+        A_START,
+        TURN_END,
+        { type: "turn_end", at: "2026-08-20T10:20:00Z" },
+        { type: "step_end", at: "2026-08-20T10:30:00Z", skill: "aidd-dev:02-implement" }
+      )
+    );
+
+    const attribution = attributeMoment(intervals, "2026-08-20T10:25:00Z");
+
+    expect(attribution).toEqual({ source: "journal-interval", step: "aidd-dev:02-implement" });
+  });
+
+  // An end names its skill so that closing one never closes another. A skill invoking a
+  // second one leaves two open intervals; an end for the inner skill must leave the outer
+  // one running.
+  it("closes only the step its own skill names", () => {
+    const intervals = buildStepIntervals(
+      journalOf(A_START, B_START, {
+        type: "step_end",
+        at: "2026-08-20T10:07:00Z",
+        skill: "aidd-dev:06-test",
+      })
+    );
+
+    const outer = intervals.find((interval) => interval.skill === "aidd-dev:02-implement");
+    const inner = intervals.find((interval) => interval.skill === "aidd-dev:06-test");
+    expect(inner?.endMs).toBe(Date.parse("2026-08-20T10:07:00Z"));
+    expect(outer?.endMs).toBe(Date.parse("2026-08-20T10:05:00Z"));
+  });
+
+  // An end for a skill that never started names nothing to close. Read as a boundary all the
+  // same it would truncate whatever interval was running, which is a step it has no claim on.
+  it("ignores an end for a skill this session never started", () => {
+    const intervals = buildStepIntervals(
+      journalOf(A_START, {
+        type: "step_end",
+        at: "2026-08-20T10:02:00Z",
+        skill: "some-other:skill",
+      })
+    );
+
+    expect(attributeMoment(intervals, "2026-08-20T10:03:00Z")).toEqual({
+      source: "journal-interval",
+      step: "aidd-dev:02-implement",
+    });
+  });
+
   it("closes an interval at the next step_start, not at the turn's end past it", () => {
     const intervals = buildStepIntervals(journalOf(A_START, B_START, TURN_END));
 

--- a/plugins/aidd-dev/skills/01-plan/SKILL.md
+++ b/plugins/aidd-dev/skills/01-plan/SKILL.md
@@ -20,6 +20,18 @@ Turn a gathered source into an implementation plan and its phase files. Never wr
 Run them in order, `01 → 04`. The plan is the culmination. Skip `03` when there is no UI.
 Before running an action, read its file in `actions/`, not only the table or assets.
 
+Once the plan and its phase files are written, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-dev:01-plan"
+```
+
+This is the one thing about a step nothing else can supply. No host reports when a skill's
+work finished — a skill call's own result comes back in a tenth of a second, which is the
+dispatch, not the completion — so a measurement that never hears this ends the step at the
+next pause and credits planning with one turn out of however many it took. See
+[`aidd_docs/runs/README.md`](../../../../aidd_docs/runs/README.md).
+
 ## References
 
 - `references/wireframe-conventions.md`: how to draw the ASCII wireframe a screen needs.

--- a/plugins/aidd-telemetry/hooks/journal.cjs
+++ b/plugins/aidd-telemetry/hooks/journal.cjs
@@ -9,6 +9,7 @@ const repo = require("./lib/repo.cjs");
 const record = require("./lib/record.cjs");
 const fileWrites = require("./lib/file-writes.cjs");
 const stepStarts = require("./lib/step-starts.cjs");
+const stepEnds = require("./lib/step-ends.cjs");
 const taskDeclared = require("./lib/task-declared.cjs");
 
 function readStdin() {
@@ -76,6 +77,7 @@ function processPayload(payload, event) {
     // declaration reads the call's own arguments rather than a named field.
     fileWrites.handleFileWritten(payload, host, sessionId);
     stepStarts.handleStepStart(payload, host, sessionId);
+    stepEnds.handleStepEnd(payload, host, sessionId);
     taskDeclared.handleTaskDeclared(payload, host, sessionId);
   }
 }

--- a/plugins/aidd-telemetry/hooks/lib/record.cjs
+++ b/plugins/aidd-telemetry/hooks/lib/record.cjs
@@ -194,6 +194,13 @@ function buildStepStartLine({ at, skill, turnId }) {
   return line;
 }
 
+// The end of the step `skill` names, told rather than inferred - see step-ends.cjs for why no
+// hook can observe it. Carries the skill, never only the moment: a bare end would have to
+// close whatever step is open, which closes the wrong one the moment a skill invokes another.
+function buildStepEndLine({ at, skill }) {
+  return { type: "step_end", at, skill: sanitizeSkillName(skill) };
+}
+
 // A start, told rather than inferred, the same way step_start is: a tool call named a task
 // path, so this session is on that task from here. No end on this line either, and for the
 // same reason step_start carries none - closing is the reader's derivation, from whichever
@@ -314,6 +321,7 @@ module.exports = {
   buildTurnEndLine,
   buildFileWrittenLine,
   buildStepStartLine,
+  buildStepEndLine,
   buildTaskDeclaredLine,
   sanitizeSkillName,
   PRIVATE_FILE_MODE,

--- a/plugins/aidd-telemetry/hooks/lib/step-ends.cjs
+++ b/plugins/aidd-telemetry/hooks/lib/step-ends.cjs
@@ -1,0 +1,92 @@
+// When a skill's work finished, told rather than inferred - the one thing about a step that
+// no host emits. Measured: the `tool_result` for a `Skill` call comes back about a tenth of a
+// second after the call, which is the dispatch and not the completion, so `PostToolUse` never
+// sees an end. `step-starts.cjs` says the same in its own header. The only party that knows
+// the work is over is the skill, and the only channel it has is a tool call it makes.
+//
+// Read out of the call's own free-form arguments, exactly as `task-declared.cjs` reads a task
+// path, and for the same reason: it asks nothing of the host, so every host that forwards
+// tool arguments is covered rather than one. The hook stays the writer - a script a skill
+// invoked directly would carry no payload, therefore no session id and no cwd, and could not
+// find the run file to append to.
+
+const fs = require("node:fs");
+
+const { normalizeSeparators, stringsWithin } = require("./host.cjs");
+const { resolveRunsDir } = require("./repo.cjs");
+const { readCwd } = require("./tools/index.cjs");
+const { findRunFileByVendorId, appendLine, buildStepEndLine, nowIso } = require("./record.cjs");
+
+// The marker, then the skill it closes. Naming the skill is not decoration: closing "whatever
+// step is open" closes the wrong one the moment a skill invokes another.
+//
+// The name must begin with a letter, which is what refuses a path fragment - `../../etc/passwd`
+// offers `.` at the first position and matches nothing. `[\w.-]` after that covers every skill
+// name this repository ships (`artifact-design`) and the plugin-qualified form
+// (`aidd-dev:01-plan`), and nothing else: no slash, no space, no shell metacharacter, so a
+// later reader never has to defend against one.
+const STEP_END_PATTERN = /aidd:step-end[ \t]+([A-Za-z][\w.-]*(?::[\w.-]+)?)/u;
+
+// A tool call that merely *mentions* the marker - reading this file, grepping for it - closes
+// a step it never ran. The same false positive `task-declared.cjs` accepts for a task path
+// mentioned in passing, and bounded the same way: a step end can only ever close an interval
+// its own session already opened for that exact skill, so a mention in another session, or of
+// a skill that never started, writes a line the reader ignores.
+function firstStepEndIn(value) {
+  for (const candidate of stringsWithin(value)) {
+    const match = STEP_END_PATTERN.exec(normalizeSeparators(candidate));
+    if (match) return match[1];
+  }
+  return null;
+}
+
+// tool_input is every declared host's own shape for a tool call's arguments; only Copilot's
+// canonical builder spells them toolArgs, as a JSON string - which a plain string scan reads
+// exactly as well as a parsed object would, so it is read the same way rather than parsed
+// first. Identical to `declaredTaskPath`'s own two-field read, deliberately.
+function declaredStepEnd(payload) {
+  return firstStepEndIn(payload.tool_input) ?? firstStepEndIn(payload.toolArgs);
+}
+
+// The same watermark `task-declared.cjs` protects, for the same reason: file-writes.cjs reads
+// the run file's own mtime as "the moment this session last wrote a line" to know what changed
+// since, and an end landing between a shell write and the turn end that observes it would push
+// that mark past the write, silently dropping it. Restoring the mtime leaves the line itself
+// the only trace on disk.
+function mtimeOf(filePath) {
+  try {
+    return fs.statSync(filePath).mtime;
+  } catch {
+    return null;
+  }
+}
+
+function restoreMtime(filePath, mtime) {
+  try {
+    fs.utimesSync(filePath, mtime, mtime);
+  } catch {
+    // A run file that vanished between the append and this restore costs the watermark, not
+    // the line - the same tolerance every other write in this directory takes.
+  }
+}
+
+function handleStepEnd(payload, host, sessionId) {
+  const skill = declaredStepEnd(payload);
+  if (!skill) return;
+
+  const target = resolveRunsDir(readCwd(host, payload));
+  if (!target) return;
+
+  const filePath = findRunFileByVendorId(target.dir, sessionId);
+  if (!filePath) return;
+
+  const before = mtimeOf(filePath);
+  appendLine(filePath, buildStepEndLine({ at: nowIso(), skill }));
+  if (before) restoreMtime(filePath, before);
+}
+
+module.exports = {
+  STEP_END_PATTERN,
+  declaredStepEnd,
+  handleStepEnd,
+};

--- a/scripts/__tests__/aidd-telemetry-journal.test.js
+++ b/scripts/__tests__/aidd-telemetry-journal.test.js
@@ -2975,6 +2975,67 @@ function sessionStartPayload(host, { cwd, sessionId }) {
   return payload;
 }
 
+// Built from the same captured Claude Code payload the step_start tests replay, with only
+// the tool call swapped for the shell command a skill runs to declare its end - so the shape
+// under test is one that host really sends, never one hand-written to pass.
+function endPayload(cwd, sessionId, skill) {
+  const payload = loadFixture(STEP_FIXTURE_BY_HOST["claude-code"]);
+  payload.session_id = sessionId;
+  payload.cwd = cwd;
+  payload.tool_name = "Bash";
+  payload.tool_input = { command: `echo "aidd:step-end ${skill}"` };
+  return payload;
+}
+
+// A skill's end is the one thing about a step no host emits - measured, a `Skill` call's own
+// `tool_result` returns in about a tenth of a second, which is the dispatch and not the
+// completion. So the skill declares it, through a tool call it makes, and the hook - which
+// alone holds the session id and the working directory - writes the line.
+test("a skill declaring its own end leaves a step_end naming it", () => {
+  const repo = makeTempRepo({ remote: "git@github.com:acme/step-end.git" });
+  try {
+    const sessionId = "00000000-0000-4000-8000-00000000e0de";
+    replayIn(sessionStartPayload("claude-code", { cwd: repo, sessionId }), "session-start");
+    const result = replayIn(endPayload(repo, sessionId, "aidd-dev:01-plan"), "tool-used");
+    assert.equal(result.status, 0);
+
+    const ends = readRunFiles(runsDirOf(repo))
+      .flatMap((file) => readLines(file))
+      .filter((line) => line.type === "step_end");
+    assert.equal(ends.length, 1);
+    assert.equal(ends[0].skill, "aidd-dev:01-plan");
+    assert.ok(typeof ends[0].at === "string" && ends[0].at.length > 0);
+  } finally {
+    cleanup(repo);
+  }
+});
+
+// The same watermark `task-declared.cjs` protects, and for the same reason: file-writes.cjs
+// reads the run file's own mtime as "the moment this session last wrote a line" to know what
+// changed since. A step end landing between a shell write and the turn end that observes it
+// would push that mark past the write, silently dropping it.
+test("a step end never costs the turn a write it should have observed", () => {
+  const repo = makeTempRepo({ remote: "git@github.com:acme/step-end-mtime.git" });
+  const sessionId = "00000000-0000-4000-8000-00000000e0df";
+  try {
+    replayIn(makePayload({ cwd: repo, sessionId, event: "SessionStart" }));
+    writeIntoTaskFolder(repo, "2026_08_21_ended");
+    // Between the write and the turn end that observes it - the exact placement that costs
+    // the write if this line moves the watermark past it.
+    replayIn(endPayload(repo, sessionId, "aidd-dev:01-plan"), "tool-used");
+    replayIn({ ...makePayload({ cwd: repo, sessionId }), hook_event_name: "Stop" }, "turn-end");
+
+    const lines = readLines(readRunFiles(runsDirOf(repo))[0]);
+    assert.equal(lines.filter((line) => line.type === "step_end").length, 1);
+    assert.deepEqual(
+      lines.filter((line) => line.type === "file_written").map((line) => line.source),
+      ["observed"]
+    );
+  } finally {
+    cleanup(repo);
+  }
+});
+
 function stepLinesIn(repo) {
   const written = readRunFiles(runsDirOf(repo));
   if (written.length === 0) return [];

--- a/scripts/__tests__/aidd-telemetry-step-end.test.js
+++ b/scripts/__tests__/aidd-telemetry-step-end.test.js
@@ -1,0 +1,93 @@
+// A skill's own end, declared the way a task already is: read out of a tool call's own
+// free-form arguments, never from a field a host populates. Nothing any host emits says when
+// a skill's work finishes - measured, the `tool_result` for a `Skill` call comes back in
+// about a tenth of a second, which is the dispatch and not the completion - so the only party
+// that can say it is the skill itself, and the only channel it has is a tool call it makes.
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const { declaredStepEnd } = require("../../plugins/aidd-telemetry/hooks/lib/step-ends.cjs");
+
+const pluginsDir = path.join(__dirname, "..", "..", "plugins");
+
+test("reads the skill named by an end marker in a tool call's own arguments", () => {
+  const payload = {
+    tool_name: "Bash",
+    tool_input: { command: 'echo "aidd:step-end aidd-dev:01-plan"' },
+  };
+
+  assert.equal(declaredStepEnd(payload), "aidd-dev:01-plan");
+});
+
+test("reads it out of Copilot's toolArgs, which carries a JSON string rather than an object", () => {
+  const payload = {
+    toolName: "bash",
+    toolArgs: JSON.stringify({ command: "echo aidd:step-end aidd-context:04-skill-generate" }),
+  };
+
+  assert.equal(declaredStepEnd(payload), "aidd-context:04-skill-generate");
+});
+
+test("answers null for a tool call that names no end at all", () => {
+  const payload = { tool_name: "Bash", tool_input: { command: "pnpm test" } };
+
+  assert.equal(declaredStepEnd(payload), null);
+});
+
+// The marker must name its skill. A bare marker would have to close "whatever step is open",
+// which closes the wrong one the moment a skill invokes another.
+test("answers null for a marker that names no skill", () => {
+  const payload = { tool_name: "Bash", tool_input: { command: "echo aidd:step-end" } };
+
+  assert.equal(declaredStepEnd(payload), null);
+});
+
+// The same guard `sanitizeSkillName` gives `step_start`: a name is a name, never a path
+// fragment or a shell fragment that a later reader would have to defend against.
+test("refuses a skill name carrying anything but a skill name", () => {
+  const payload = {
+    tool_name: "Bash",
+    tool_input: { command: "echo aidd:step-end ../../etc/passwd" },
+  };
+
+  assert.equal(declaredStepEnd(payload), null);
+});
+
+// Every skill that declares its own end must do it in a form the hook actually reads, naming
+// the skill it actually is. Written as a sweep rather than a list, so a second skill opting
+// in is covered without this file being told - and so a marker that drifts from the pattern,
+// or names another skill, fails here rather than silently closing nothing for the life of
+// the release.
+function skillFilesDeclaringAnEnd() {
+  const found = [];
+  const walk = (dir) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+        continue;
+      }
+      if (entry.name !== "SKILL.md") continue;
+      const text = fs.readFileSync(full, "utf8");
+      if (text.includes("aidd:step-end")) found.push({ full, text });
+    }
+  };
+  walk(pluginsDir);
+  return found;
+}
+
+test("every skill declaring its own end declares it in the form the hook reads", () => {
+  const declaring = skillFilesDeclaringAnEnd();
+  assert.ok(declaring.length > 0, "no skill declares an end - the mechanism has no user");
+
+  for (const { full, text } of declaring) {
+    const relative = path.relative(pluginsDir, full);
+    const [plugin, , skillDir] = relative.split(path.sep);
+    const expected = `${plugin}:${skillDir}`;
+
+    const read = declaredStepEnd({ tool_input: { command: text } });
+    assert.equal(read, expected, `${relative} declares an end the hook reads as ${read}`);
+  }
+});


### PR DESCRIPTION
## The gap

A step interval opens on `step_start` and closes on whichever boundary comes next — another
`step_start`, or a `turn_end`. A `turn_end` is a **pause**, so a skill working across three
prompts is credited with its first turn and nothing after.

Measured on a real session: four `Skill` invocations between 05:23 and 06:02, a step axis
naming 6.4% of that session's 1073 records, and three and a half more hours of work after
the last of them.

## Why no hook can close it

Checked rather than assumed — both `Skill` and `Agent` return their `tool_result` in about a
tenth of a second:

```
Skill  05:23:51.590 -> 05:23:51.668   0s
Agent  06:01:12.684 -> 06:01:12.820   0s
```

That is the dispatch, not the completion. `step-starts.cjs` already said as much in its own
header. The only party that knows a skill's work is over is the skill.

## The shape

The skill declares its end through a tool call it makes, carrying `aidd:step-end <skill>` in
that call's arguments; `PostToolUse` fires with a full payload, and the hook writes the line.
This is the move `task-declared.cjs` already makes for a task path — read out of free-form
arguments, so every host that forwards tool arguments is covered rather than Claude Code
alone.

A script invoked by the skill directly could not do it: no payload, therefore no session id
and no working directory, and no way to find the run file to append to. The hook stays the
only writer of the journal.

An end names its skill. It closes only that skill's interval — closing "whatever is open"
closes the wrong one the moment a skill invokes another — and an end naming a skill the
session never started closes nothing rather than truncating whatever was running. Like a task
declaration, it restores the run file's mtime, so it can never push the write watermark past
a file the same turn should still observe.

## Measured end to end

Built binary, one journal, two records, the only difference being whether the end was
declared:

```
with a step_end     aidd-dev:01-plan  journal-interval  2
without one         (none)            unattributed      1
                    aidd-dev:01-plan  journal-interval  1
```

The record made after two `turn_end` lines is the one at stake.

## What this does not do

**It does not raise the number of steps.** 86 `Skill` invocations across 180 transcripts of
this project against 31,435 prompts. Work that ran under no skill still has no step, and
nothing here changes that. What changed is the *span* of the steps that exist, and only for
skills that opt in — one does today.

## No envelope bump

A step closed by a stated end still reads `journal-interval`. The record was still placed by
its moment falling inside a span, which is the inference that value names; what the end
changes is the span, never how the record met it. A fifth attribution value would name a
distinction no consumer could act on differently.

## How it was checked

Test first throughout, and each guard shipped with the mutation that proves it: no mtime
restore (the turn loses a write it should have observed), a marker that need not name a
skill, the hook not dispatching, an end closing whatever is open rather than its own skill,
an end acting as a generic closer, and a skill whose marker names another skill.

The last is the drift guard that matters most — a sweep over every `SKILL.md` under
`plugins/` asserting the hook reads back exactly that skill's own name. A second skill opting
in is covered without the test being told, and a marker that drifts from the pattern fails
there rather than silently closing nothing for a whole release.

`pnpm test`: 311 files, 3453 tests. Repo-level `node --test scripts/__tests__`: 364 pass.
`tsc --noEmit`, biome, knip, jscpd: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWNxk63AGKkqE8HRqHLjGp
