### PR TITLE
feat(telemetry): a prompt is an axis, and the only one complete by construction

### DIFF
--- a/aidd_docs/product/cost-report-contract.md
+++ b/aidd_docs/product/cost-report-contract.md
@@ -61,12 +61,14 @@ up, by what each task's folder declares. `by_flow` is a ninth, also with no filt
 own — see **`by_flow`** below — grouping by which orchestrated run the journal's own step
 sequence names, never a second capture. `by_agent` is a tenth, also with no filter of its
 own — see **`by_agent`** below — grouping by which agent ran, the main thread carrying its
-own row rather than an absence. `aidd telemetry report` also takes
-`--axis <name>` (`total`, `day`, `step`, `model`, `agent`, `task`, `backlog`, `flow`,
-`tool`, `project` or `person`), which picks one of those arrays and renders it alone as a small
+own row rather than an absence. `by_prompt` is an eleventh, also with no filter of its own —
+see **`by_prompt`** below — grouping by the prompt that caused the work, the one breakdown
+no host limit can leave empty. `aidd telemetry report` also takes
+`--axis <name>` (`total`, `day`, `step`, `model`, `agent`, `prompt`, `task`, `backlog`,
+`flow`, `tool`, `project` or `person`), which picks one of those arrays and renders it alone as a small
 pasteable artefact instead of the whole object — a convenience for copying one figure out,
 not a second way to group. Every figure `--axis` can show is already in the plain `--json`
-object; only the one-artefact-at-a-time rendering is what it adds. A name outside the ten
+object; only the one-artefact-at-a-time rendering is what it adds. A name outside the twelve
 is a usage error naming the valid list (`Error: Unknown axis 'bogus'. Expected one of:
 total, day, step, model, task, backlog, flow, tool, project, person.`, exit `1`), not a
 silently empty artefact. Given both flags at once, `--json` wins and `--axis` is ignored, never the
@@ -129,7 +131,7 @@ real count is the ordinary case of reporting from a project whose switch never c
 work, never a contradiction (see "Attributing records to a task" for the same scope split
 elsewhere in this object).
 
-Every object carries `cost_report_version`, currently `12`.
+Every object carries `cost_report_version`, currently `13`.
 
 Bumped from `11` when **`by_task`'s `attribution` stopped being always `"declared"`**. A
 record no declaration covers is now named after the one task folder its session wrote into,
@@ -156,6 +158,20 @@ this reason covers what the anchor cannot reach: a project whose journals are on
 machine, a period read outside any checkout, a session whose journal was removed. A
 consumer that switched exhaustively on the three previous reasons must add this one; every
 row's `totals` still reconciles to the period total exactly as before.
+
+Bumped from `12` when **`by_prompt`** joined the top-level breakdowns. It is the only
+breakdown complete by construction: every other one depends on a capture that may not have
+happened — a run journal, an identity file, a task declaration, a host that names the skill
+it is running — while this one depends on a field the transcript reader already resolves for
+every usage line by walking `parentUuid` back to the turn that caused it. Measured 2026-09-04
+on the built binary against one real session: 1073 of 1073 records carried a `prompt_id`, its
+972 subagent records included, across 12 distinct prompts. Nothing new is captured for it.
+A row carries `started_at`, the earliest moment in that prompt, because a prompt id alone is
+opaque — it is what a person greps for in their own transcript. The row for records that
+named no prompt carries neither `prompt` nor `started_at`, is placed last rather than ranked
+among the prompts, and holds the whole period on every tool but Claude Code, which is the
+truth for a route whose files cannot say which turn caused what. A consumer summing every
+breakdown's `requests` against `totals.requests` has one more to include.
 
 Bumped from `9` when **`by_agent`** joined the top-level breakdowns. It exists because that
 is where the spend is: measured on a live session, ten subagent transcripts held 432M of its
@@ -214,7 +230,7 @@ one. Adding a field you may ignore is not a bump; changing what an existing fiel
 
 ```jsonc
 {
-  "cost_report_version": 12,
+  "cost_report_version": 13,
   "period": { "from_day": "2026-07-01", "to_day": "2026-07-31" },
   "measurement_enabled": true,                  // this project's own switch, right now — see Versioning
   "task": "2026_08/2026_08_21_cost-reporter",   // absent unless --task was given
@@ -225,6 +241,8 @@ one. Adding a field you may ignore is not a bump; changing what an existing fiel
   "active_time_s": 2820,                        // absent when no record carried it
   "by_step":    [{ "step": "aidd-dev:02-implement", "attribution": "journal-interval", "totals": {} }],
   "by_model":   [{ "model": "gpt-5.6-sol", "totals": {} }],  // a row with no "model" names none known
+  "by_agent":   [{ "agent": "aidd-dev:executor", "totals": {} }, { "totals": {} }],  // a row with no "agent" is the main thread's own, never "no agent"
+  "by_prompt":  [{ "prompt": "a-prompt-id", "started_at": "2026-07-01T09:00:00Z", "totals": {} }, { "totals": {} }],  // one row per prompt, largest first; the last row, undated, is every record that named none
   "by_tool":    [{ "tool": "codex", "coverage": "covered", "reason": "…", "capability": {}, "totals": {}, "session_totals": {} }],  // session_totals absent unless the tool has one (Copilot, today)
   "by_project": [{ "project": "acme/widgets", "totals": {} }],   // a row with no `project` names none known
   "by_task":    [{ "task": "2026_08/2026_08_21_cost-reporter", "attribution": "declared", "totals": {} }, { "reason": "precedes-declaration", "totals": {} }],  // a row with no `task` carries `reason` instead, naming which of four facts applies; up to four such rows
@@ -411,6 +429,25 @@ it.
 
 `by_flow` sums to `totals.requests` exactly like every other breakdown, and carries no
 filter of its own — grouping only, the same as `by_person`.
+
+### `by_prompt` — the axis no host limit can empty
+
+Every other breakdown can read low for a reason that is about the capture, not the work: a
+skill the host never named, a journal that was never written, an identity nobody declared.
+This one groups on `prompt_id`, which the transcript reader resolves for every usage line it
+stores — subagent lines included, by walking each file's own `parentUuid` chain back to the
+turn that caused the work.
+
+| Row | Means |
+| --- | --- |
+| `prompt` and `started_at` | one prompt, and the earliest moment measured inside it |
+| neither field | every record whose tool cannot say which prompt caused it |
+
+Ordered largest first, like every breakdown but `by_day`; the remainder row is placed last
+rather than ranked, because a bucket drawn from many turns has no size comparable to a single
+turn's. The text rendering prints the ten largest and then says how many it withheld — one
+row per turn is unbounded where every other axis has a small vocabulary — while this object
+always carries them all.
 
 ### `by_person` — three outcomes, never a merge
 

--- a/aidd_docs/tasks/2026_09/2026_09_04_a-prompt-is-an-axis/plan.md
+++ b/aidd_docs/tasks/2026_09/2026_09_04_a-prompt-is-an-axis/plan.md
@@ -1,0 +1,109 @@
+---
+status: done
+---
+
+# A prompt is an axis
+
+## Why
+
+The report has ten breakdowns. Every one of them can read low, and each for its own honest
+reason: a step axis reads a few percent because the host names a skill on the main thread
+alone; a task axis needs a journal; a person axis needs an identity file; a backlog axis
+needs a declaration. Each is a capture that may or may not have happened.
+
+One field is on every record already. Measured today, on the built binary, against a
+sandboxed copy of one real session (1073 records ingested from a main transcript plus its
+20 subagent files):
+
+```
+requests 1073
+with prompt_id 1073 (100.0%)   distinct prompts 12
+with agent_name 972 (90.6%)
+subagent records with prompt_id 972 / 972
+```
+
+That is not a capture to build. `resolvePromptId` in
+`cli/src/domain/formats/claude-code-transcript.ts` already walks `parentUuid` inside each
+file and resolves every usage line, subagent files included. The axis is grouping and
+rendering over a field that is already there.
+
+So `by_prompt` is offered as the axis that is complete by construction, not as a way to
+raise another axis. It answers "how did this period's spend distribute across the turns
+that caused it", and its id is greppable in the person's own transcript.
+
+## Two earlier claims this plan corrects
+
+Both were measured against a sink written by an older build, and both were wrong:
+
+- **"`prompt_id` is missing on most records."** It is on 1073/1073, subagents included.
+  Nothing to build. Item 3 of the ranked list is closed by measurement, not by work.
+- **"`prompt-matched` never fires."** It fires: 9 requests on that session
+  (`aidd-refine:01-brainstorm` 8, `aidd-orchestrator:01-sdlc` 1).
+
+## The honest ceiling this does not move
+
+On that same session, 973 of 1073 records are `unattributed` on the step axis, because the
+prompts they belong to carried no `step_start`. `by_prompt` names those 973 by the prompt
+that caused them. It does not name a skill for them, and this plan does not claim it does.
+
+## Decisions
+
+| Decision | Choice | Why |
+| --- | --- | --- |
+| Row shape | `{ prompt?, startedAt?, totals }` | `prompt` absent is the row for records that carried none — every non-Claude tool today. Same shape as `by_agent`'s main-thread row and `by_model`'s unknown-model row: an absent key is a named row, never a merge. |
+| Absent key | a `Symbol`, not a reserved string | a prompt id is opaque; no string is safe to reserve. Same reasoning as `NO_AGENT` and `NO_KNOWN_MODEL`. |
+| `startedAt` | earliest `event_timestamp` in the prompt, to the second | an opaque id alone is unreadable. The moment orders the rows and locates the turn in the person's own transcript. Derived from a field already on every record — no new capture. |
+| Order | largest first, like every axis but `by_day` | the question is which turn cost the most. `by_day` is chronological because a series read out of order is not a series; a ranking has no such property. |
+| Printed rows | top `MAX_PRINTED_PROMPTS`, then a count and `--json` | this is the first axis whose cardinality is unbounded: one row per turn, 12 on a session and 31,435 over the measured history. `by_day` suppresses every row above its cap because a partial series is a lie about continuity; a partial ranking is not — it is a top N, and it says so. The envelope still carries every row. |
+| Envelope version | 12 → 13 | a new top-level breakdown. A consumer summing every breakdown's `requests` against `totals.requests` has one more to include. |
+
+## Out of scope, named
+
+- **Deduplicating on content instead of on `turn_id`.** 474 duplicates exist in the live
+  sink. That fix touches the write path and gets its own task; the claim that the current
+  key is `turn_id` must be re-read from the adapter before that plan is written, not
+  carried over from a summary.
+- Attributing a step by prompt range rather than by time range.
+- `aidd telemetry identity` (`by_person`), `backlog-link.json` (`by_backlog`).
+
+## Phases
+
+| # | Phase | Done when |
+| --- | --- | --- |
+| 1 | The domain groups by prompt | `byPrompts` reconciles to `totals.requests`, an absent `prompt_id` is its own row, rows are largest first, `startedAt` is the earliest moment in the group |
+| 2 | The envelope carries it | `by_prompt` present, version 13, the fixture regenerated, every consumer of the version enumerated |
+| 3 | A person can read it | the text report prints the axis under its cap and says what it withheld above it; `--axis prompt` returns its artefact |
+| 4 | Proven end to end | the built binary reports the axis on the sandboxed real session, reconciling to the same total as every other breakdown |
+
+Every guard ships with the mutation that proves it.
+
+## Measured, end to end on the built binary
+
+Sandboxed copy of one real session (`HOME` and `AIDD_TELEMETRY_DIR` both under the
+scratchpad), `aidd telemetry report --from 2026-09-04 --to 2026-09-04`:
+
+```
+by_prompt  rows  12  requests 1073   named 12, dated 12, remainder rows 0
+by_agent   rows   4  requests 1073
+by_step    rows   7  requests 1073   (96% of tokens unattributed)
+totals.requests 1073                 cost_report_version 13
+```
+
+The axis reconciles to the same total as every other breakdown and leaves nothing in a
+remainder, on the same session where the step axis cannot name 96% of the tokens.
+
+## Two gaps this closed on the way
+
+- The skill's `--axis` enumeration and its question table both omitted `agent`, which had
+  shipped two versions earlier. A person asking "which subagent spent this" was told the
+  question had no axis while the binary had been answering it. Both now name every axis, and
+  a guard reads `ARTEFACT_AXES` from the module itself and asserts the two lists are equal -
+  in both directions, since the e2e that runs every command the skill names expands that
+  enumeration to its first alternative alone.
+- That e2e's placeholder expansion held its own copy of the axis list, so a skill could not
+  name a new axis without the regex being edited in the same breath. It now expands any
+  `<a|b|c>` by its shape.
+
+## Cost
+
+Bundle 588.4 -> 590.6 KB, budget raised 590 -> 593 with the measurement recorded beside it.

--- a/cli/package.json
+++ b/cli/package.json
@@ -44,7 +44,7 @@
       "qs": ">=6.15.2"
     }
   },
-  "bundleBudgetKB": 590,
+  "bundleBudgetKB": 593,
   "scripts": {
     "build": "tsup && node scripts/check-bundle-size.mjs",
     "build:check-size": "node scripts/check-bundle-size.mjs",

--- a/cli/scripts/check-bundle-size.mjs
+++ b/cli/scripts/check-bundle-size.mjs
@@ -11,6 +11,8 @@ const pkg = JSON.parse(readFileSync(resolve(root, "package.json"), "utf8"));
 // 590 was set when resolving one person across tools and machines (#661) took
 // the bundle to 567.7 KB - tighter headroom than the 560 raise left, on
 // purpose, rather than padding past what was actually measured.
+// 593 was set when `by_prompt` joined the breakdowns: measured 588.4 -> 590.6 KB,
+// +2.2 KB for the axis that is complete by construction. Same tight headroom.
 const budgetKB = pkg.bundleBudgetKB ?? 500;
 const budgetBytes = budgetKB * 1024;
 

--- a/cli/src/application/display/cost-report-artefact.ts
+++ b/cli/src/application/display/cost-report-artefact.ts
@@ -36,6 +36,7 @@ export const ARTEFACT_AXES = [
   "step",
   "model",
   "agent",
+  "prompt",
   "task",
   "backlog",
   "flow",
@@ -46,6 +47,7 @@ export const ARTEFACT_AXES = [
 
 export type ArtefactAxis = (typeof ARTEFACT_AXES)[number];
 
+const NO_PROMPT_LABEL = "no prompt named";
 const UNKNOWN_AMOUNT = "amount unknown";
 const NOTHING_MEASURED = "nothing in this period";
 const NOTHING_IN_SELECTION = "nothing in this selection";
@@ -339,6 +341,24 @@ function agentArtefact(envelope: CostReportEnvelope): string {
   );
 }
 
+/** An id and the moment its turn began: the id alone is opaque, and the moment is what a
+ * person greps for in their own transcript. `—` where a row carries none, which is the row
+ * for records that named no prompt - never a moment borrowed from another turn. */
+function promptArtefact(envelope: CostReportEnvelope): string {
+  const rows = envelope.by_prompt.map(
+    (row) =>
+      `| ${row.prompt ?? NO_PROMPT_LABEL} | ${row.started_at ?? "—"} | ${figure(row.totals, envelope)} |`
+  );
+  return [
+    header(envelope, "by prompt"),
+    "",
+    "| Prompt | Started at | Total |",
+    "| --- | --- | --- |",
+    ...rows,
+    ...caveats(envelope),
+  ].join("\n");
+}
+
 function modelArtefact(envelope: CostReportEnvelope): string {
   return table(
     envelope,
@@ -416,6 +436,7 @@ const BUILDERS: Record<ArtefactAxis, (envelope: CostReportEnvelope) => string> =
   step: stepArtefact,
   model: modelArtefact,
   agent: agentArtefact,
+  prompt: promptArtefact,
   task: taskArtefact,
   backlog: backlogArtefact,
   flow: flowArtefact,

--- a/cli/src/application/display/cost-report-display.ts
+++ b/cli/src/application/display/cost-report-display.ts
@@ -88,6 +88,16 @@ const NO_KNOWN_MODEL = "no known model";
 // Not "no agent": the main thread is where a session starts, not an absence.
 const MAIN_THREAD = "the main thread";
 
+// A prompt id is a uuid, wider than `LABEL_WIDTH`, and `padTo` never truncates - so the
+// column is its own width rather than colliding with the one every named label shares.
+const PROMPT_WIDTH = 38;
+const NO_PROMPT = "no prompt named";
+// One row per turn, unbounded where every other axis has a small vocabulary: 12 on one
+// session, 31,435 over the measured history. Truncated rather than suppressed the way
+// `printDays` suppresses - a partial series is a lie about continuity, a top N of a ranking
+// is not, and the line below says how many it withheld. The envelope still carries them all.
+const MAX_PRINTED_PROMPTS = 10;
+
 // A year asked for by day is 365 rows - the envelope always carries every one of them, but
 // a terminal is not the place to read that many. Above this, the text rendering names the
 // count and points at --json rather than printing a screen nobody can scan. Must match
@@ -386,6 +396,24 @@ function printAgents(output: CLIOutput, report: CostReport, basis: Basis): void 
   }
 }
 
+/** The one axis no host limit can empty: every record the transcript reader resolves carries
+ * a `prompt_id`, where a skill name, an identity and a declaration each may be missing. */
+function printPrompts(output: CLIOutput, report: CostReport, basis: Basis): void {
+  if (report.byPrompts.length === 0) return;
+  output.print("");
+  output.print(`  by prompt   ${basis.label}`);
+  for (const row of report.byPrompts.slice(0, MAX_PRINTED_PROMPTS)) {
+    const share = shareOf(row.totals, basis.of, basis.useCost);
+    output.print(
+      `    ${padTo(row.prompt ?? NO_PROMPT, PROMPT_WIDTH)}${padTo(row.startedAt ?? "", 22)}${share}   ${figureFor(row.totals, basis.useCost)}`
+    );
+  }
+  const withheld = report.byPrompts.length - MAX_PRINTED_PROMPTS;
+  if (withheld > 0) {
+    output.print(`    ${formatCount(withheld)} more prompts — see --json for all of them`);
+  }
+}
+
 function printModels(output: CLIOutput, report: CostReport, basis: Basis): void {
   if (report.byModels.length === 0) return;
   output.print("");
@@ -537,6 +565,7 @@ function printBreakdowns(output: CLIOutput, report: CostReport): void {
   printTaskAttribution(output, report, basis);
   printStepsAndAttribution(output, report, basis);
   printAgents(output, report, basis);
+  printPrompts(output, report, basis);
   printModels(output, report, basis);
   printProjects(output, report.byProjects, basis);
   printTasks(output, report.byTasks, basis);

--- a/cli/src/domain/models/cost-report-envelope.ts
+++ b/cli/src/domain/models/cost-report-envelope.ts
@@ -18,6 +18,14 @@ import type { AiToolId } from "./tool-ids.js";
  * `sink_schema_version` exists on a stored line. Adding a field a consumer may ignore is
  * not a bump; changing what an existing field means is.
  *
+ * Bumped to 13: `by_prompt` is a new top-level breakdown, and a consumer summing every
+ * breakdown's `requests` against `totals.requests` to check nothing was dropped now has one
+ * more to include. It is the only breakdown complete by construction: every other depends on
+ * a capture that may not have happened, this one on a field the transcript reader already
+ * resolves for every usage line. Measured 2026-09-04 on the built binary - 1073 of 1073
+ * records of one real session carried a `prompt_id`, its 972 subagent records included,
+ * across 12 distinct prompts.
+ *
  * Bumped to 12: `by_task`'s `attribution` stops being always `"declared"`. A record no
  * declaration covers, in a session whose journal witnessed it and that wrote into exactly
  * one task folder, is now named after that folder and marked `"inferred"` - so one task can
@@ -94,7 +102,7 @@ import type { AiToolId } from "./tool-ids.js";
  * `by_project`'s `project` to optional back when that row was added.
  *
  * Bumped to 2: `by_project` and `by_day` are new top-level breakdowns. */
-export const COST_REPORT_ENVELOPE_VERSION = 12;
+export const COST_REPORT_ENVELOPE_VERSION = 13;
 
 /** Money as whole micro-dollars, the way the report carries it: an integer, so a consumer
  * summing several reports gets the same answer this one did. Divide by 1,000,000 for
@@ -204,6 +212,15 @@ export interface CostReportEnvelopeAgentRow {
   readonly totals: CostReportEnvelopeTotals;
 }
 
+/** `started_at` is the earliest moment in the prompt, and only a named prompt carries one:
+ * the row for records that named no prompt is drawn from many turns, so a start moment there
+ * would assert a unit that never existed. */
+export interface CostReportEnvelopePromptRow {
+  readonly prompt?: string;
+  readonly started_at?: string;
+  readonly totals: CostReportEnvelopeTotals;
+}
+
 export interface CostReportEnvelopeFlowRow {
   readonly flow?: string;
   readonly started_at?: string;
@@ -282,6 +299,9 @@ export interface CostReportEnvelope {
   readonly by_flow: readonly CostReportEnvelopeFlowRow[];
   /** One row per agent that ran, `agent` absent on the main thread's own row. */
   readonly by_agent: readonly CostReportEnvelopeAgentRow[];
+  /** One row per prompt that caused work, largest first, plus the row for records that
+   * named none. The one breakdown no host limit can empty. */
+  readonly by_prompt: readonly CostReportEnvelopePromptRow[];
   /** Every day the period spans, always — a long period stays readable by how the text
    * rendering chooses to show it, never by what this envelope omits. */
   readonly by_day: readonly CostReportEnvelopeDayRow[];
@@ -383,6 +403,14 @@ function agentRow(row: CostReport["byAgents"][number]): CostReportEnvelopeAgentR
   return { ...(row.agent === undefined ? {} : { agent: row.agent }), totals: totals(row.totals) };
 }
 
+function promptRow(row: CostReport["byPrompts"][number]): CostReportEnvelopePromptRow {
+  return {
+    ...(row.prompt === undefined ? {} : { prompt: row.prompt }),
+    ...(row.startedAt === undefined ? {} : { started_at: row.startedAt }),
+    totals: totals(row.totals),
+  };
+}
+
 function flowRow(row: CostReport["byFlows"][number]): CostReportEnvelopeFlowRow {
   return {
     ...(row.flow === undefined ? {} : { flow: row.flow }),
@@ -455,6 +483,7 @@ function breakdownFields(
   | "by_backlog"
   | "by_flow"
   | "by_agent"
+  | "by_prompt"
   | "by_day"
   | "by_person"
 > {
@@ -467,6 +496,7 @@ function breakdownFields(
     by_backlog: report.byBacklog.map(backlogRow),
     by_flow: report.byFlows.map(flowRow),
     by_agent: report.byAgents.map(agentRow),
+    by_prompt: report.byPrompts.map(promptRow),
     by_day: report.byDays.map((row) => ({ day: row.day, totals: totals(row.totals) })),
     by_person: report.byPeople.map(personRow),
   };

--- a/cli/src/domain/models/cost-report.ts
+++ b/cli/src/domain/models/cost-report.ts
@@ -88,6 +88,25 @@ export interface CostReportAgentRow {
   readonly totals: CostTotals;
 }
 
+/** One prompt's own share of a period, `prompt` absent on the row for records that named
+ * none.
+ *
+ * The one breakdown that is complete by construction. Every other depends on a capture that
+ * may not have happened — a journal, an identity file, a declaration, a host that names a
+ * skill. This one depends on a field the transcript reader already resolves for every usage
+ * line by walking `parentUuid`: measured 2026-09-04 on the built binary, 1073 of 1073
+ * records of one real session carried a `prompt_id`, its 972 subagent records included,
+ * across 12 distinct prompts.
+ *
+ * `startedAt` is the earliest moment in the group, and only a named prompt gets one: the
+ * row for records that named no prompt is a bucket drawn from many turns, so a start moment
+ * there would assert a unit that never existed. */
+export interface CostReportPromptRow {
+  readonly prompt?: string;
+  readonly startedAt?: string;
+  readonly totals: CostTotals;
+}
+
 /** Why a tool contributes nothing, when it contributes nothing. `covered` with no records
  * is a tool that could have been read and did nothing in this period; `not-covered` is a
  * tool nothing here can read at all. A consumer prints the second as its reason, never as
@@ -397,6 +416,9 @@ export interface CostReport {
   readonly bySteps: readonly CostReportStepRow[];
   readonly byModels: readonly CostReportModelRow[];
   readonly byAgents: readonly CostReportAgentRow[];
+  /** One row per prompt that caused work, largest first, plus the row for records that
+   * named none — see `CostReportPromptRow`. */
+  readonly byPrompts: readonly CostReportPromptRow[];
   readonly byTools: readonly CostReportToolRow[];
   readonly byProjects: readonly CostReportProjectRow[];
   readonly byTasks: readonly CostReportTaskRow[];
@@ -608,6 +630,15 @@ type AgentKey = string | typeof NO_AGENT;
 
 function agentKeyOf(record: TelemetrySinkRecord): AgentKey {
   return record.agent_name === undefined ? NO_AGENT : record.agent_name;
+}
+
+// The row for what named no prompt. A symbol for the same reason `NO_AGENT` is one: a prompt
+// id is opaque and host-assigned, so no string is safe to reserve against it.
+const NO_PROMPT = Symbol("no prompt named");
+type PromptKey = string | typeof NO_PROMPT;
+
+function promptKeyOf(record: TelemetrySinkRecord): PromptKey {
+  return record.prompt_id === undefined ? NO_PROMPT : record.prompt_id;
 }
 
 function modelKeyOf(record: TelemetrySinkRecord): ModelKey {
@@ -896,6 +927,26 @@ function addToPersonGroup(
   groups.set(key, created);
 }
 
+/** A prompt's running totals plus the earliest moment seen in it. The moment is tracked
+ * here rather than read back off the records because the pass over them happens once, and
+ * because a sink is append-ordered by when it was read, never by when a turn began. */
+interface PromptGroup {
+  readonly totals: TotalsAccumulator;
+  earliestMs?: number;
+}
+
+function addToPromptGroup(groups: Map<PromptKey, PromptGroup>, record: TelemetrySinkRecord): void {
+  const key = promptKeyOf(record);
+  const group = groups.get(key) ?? { totals: new TotalsAccumulator() };
+  group.totals.add(record);
+  const atMs =
+    record.event_timestamp === undefined ? Number.NaN : Date.parse(record.event_timestamp);
+  if (!Number.isNaN(atMs) && (group.earliestMs === undefined || atMs < group.earliestMs)) {
+    group.earliestMs = atMs;
+  }
+  groups.set(key, group);
+}
+
 /** Every UTC day from `fromDay` to `toDay`, inclusive — the full period, whether or not a
  * record ever lands on a given day. A day with nothing is still a row: a gap in a series
  * reads as continuity, so the row has to exist to be a zero. */
@@ -1147,6 +1198,7 @@ interface Groups {
   readonly steps: Map<string, StepGroup>;
   readonly models: Map<ModelKey, TotalsAccumulator>;
   readonly agents: Map<AgentKey, TotalsAccumulator>;
+  readonly prompts: Map<PromptKey, PromptGroup>;
   readonly tools: Map<AiToolId, TotalsAccumulator>;
   readonly toolSessionTotals: Map<AiToolId, TotalsAccumulator>;
   readonly attributions: Map<StepAttributionSource, TotalsAccumulator>;
@@ -1168,6 +1220,7 @@ function emptyGroups(fromDay: string, toDay: string): Groups {
     steps: new Map(),
     models: new Map(),
     agents: new Map(),
+    prompts: new Map(),
     tools: new Map(),
     toolSessionTotals: new Map(),
     attributions: new Map(),
@@ -1224,6 +1277,7 @@ function accumulateRequestRecord(
   accumulateInto(groups.tools, record.tool, record);
   accumulateInto(groups.models, modelKeyOf(record), record);
   accumulateInto(groups.agents, agentKeyOf(record), record);
+  addToPromptGroup(groups.prompts, record);
   accumulateInto(groups.projects, projectKeyOf(record), record);
   const taskRow = taskRowOf(record, taskIntervalsByVendorId, journalsByVendorId);
   addToTaskGroup(groups.tasks, taskRow, record);
@@ -1477,6 +1531,34 @@ function agentRows(
   );
 }
 
+/** Every prompt that caused work, largest first, plus one row for what named none.
+ * Largest first and not chronological: unlike `by_day` this is a ranking, and a ranking has
+ * no continuity to break by reordering. The row for what named none is placed last rather
+ * than ranked among them - it is a remainder drawn from many turns, not a turn, so its size
+ * is not comparable to theirs. `by_flow` places its own remainder the same way. */
+function promptRows(prompts: ReadonlyMap<PromptKey, PromptGroup>): readonly CostReportPromptRow[] {
+  const named: CostReportPromptRow[] = [];
+  let namedNone: CostReportPromptRow | undefined;
+  for (const [key, group] of prompts) {
+    const totals = group.totals.build();
+    if (key === NO_PROMPT) {
+      namedNone = { totals };
+      continue;
+    }
+    named.push({
+      prompt: key,
+      ...(group.earliestMs === undefined ? {} : { startedAt: isoSecondsFromMs(group.earliestMs) }),
+      totals,
+    });
+  }
+  const sorted = bySize(
+    named,
+    (row) => row.totals,
+    (row) => row.prompt ?? ""
+  );
+  return namedNone === undefined ? sorted : [...sorted, namedNone];
+}
+
 /** Every model a record named, largest first, plus one row for what named none. */
 function modelRows(
   models: ReadonlyMap<ModelKey, TotalsAccumulator>
@@ -1592,6 +1674,7 @@ function breakdownFields(
   | "bySteps"
   | "byModels"
   | "byAgents"
+  | "byPrompts"
   | "byTools"
   | "byProjects"
   | "byTasks"
@@ -1604,6 +1687,7 @@ function breakdownFields(
     bySteps: stepRows(groups.steps),
     byModels: modelRows(groups.models),
     byAgents: agentRows(groups.agents),
+    byPrompts: promptRows(groups.prompts),
     byTools: toolRowsInScope(input, groups),
     byProjects: projectRows(groups.projects),
     byTasks: taskRows(groups.tasks),

--- a/cli/tests/application/display/cost-report-artefact.unit.test.ts
+++ b/cli/tests/application/display/cost-report-artefact.unit.test.ts
@@ -70,6 +70,30 @@ describe("buildCostReportArtefact", () => {
     expect(isArtefactAxis("person")).toBe(true);
   });
 
+  it("answers the prompt axis with one dated row per prompt, and the remainder last", () => {
+    const artefact = buildCostReportArtefact(
+      envelopeOf({
+        records: [
+          request({
+            turn_id: "a",
+            prompt_id: "p-1",
+            cost_usd: 2,
+            event_timestamp: "2026-08-18T09:00:00Z",
+          }),
+          request({ turn_id: "b", cost_usd: 1, event_timestamp: "2026-08-18T10:00:00Z" }),
+        ],
+      }),
+      "prompt"
+    );
+
+    expect(artefact).toContain("| Prompt | Started at | Total |");
+    const lines = artefact
+      .split("\n")
+      .filter((line) => line.startsWith("| p-1") || line.includes("no prompt named"));
+    expect(lines[0]).toContain("| p-1 | 2026-08-18T09:00:00Z |");
+    expect(lines[1]).toContain("| no prompt named | — |");
+  });
+
   it("refuses an unknown axis by name, listing the ones that exist", () => {
     expect(() => buildCostReportArtefact(envelopeOf(), "bogus")).toThrow(
       /Unknown axis 'bogus'.*person/su

--- a/cli/tests/application/display/cost-report-display.unit.test.ts
+++ b/cli/tests/application/display/cost-report-display.unit.test.ts
@@ -356,6 +356,46 @@ describe("printCostReport", () => {
     expect(out).not.toContain("2026-01-15");
   });
 
+  it("prints the prompt that caused the work, dated, largest first", () => {
+    const out = printed({
+      records: [
+        record({
+          turn_id: "a",
+          prompt_id: "p-1",
+          cost_usd: 2,
+          event_timestamp: "2026-08-18T09:00:00Z",
+        }),
+        record({
+          turn_id: "b",
+          prompt_id: "p-2",
+          cost_usd: 1,
+          event_timestamp: "2026-08-18T10:00:00Z",
+        }),
+      ],
+    });
+
+    expect(out).toContain("by prompt");
+    const prompts = out.split("\n").filter((line) => line.includes("p-1") || line.includes("p-2"));
+    expect(prompts[0]).toContain("p-1");
+    expect(prompts[0]).toContain("2026-08-18T09:00:00Z");
+  });
+
+  // The first axis whose cardinality is unbounded: one row per turn, 12 on a session and
+  // 31,435 over the measured history. Unlike `by day` this truncates rather than suppressing
+  // every row - a partial series is a lie about continuity, a top N of a ranking is not, and
+  // it says how many it withheld.
+  it("names how many prompts a long period carries beyond the ones it prints", () => {
+    const records = Array.from({ length: 30 }, (_, i) =>
+      record({ turn_id: `t-${i}`, prompt_id: `p-${i}`, cost_usd: 30 - i })
+    );
+    const out = printed({ records });
+
+    expect(out).toContain("p-0");
+    expect(out).not.toContain("p-29");
+    expect(out).toContain("20 more prompts");
+    expect(out).toContain("--json");
+  });
+
   it("gives a record with no project its own row, named as unknown", () => {
     const out = printed({
       records: [

--- a/cli/tests/domain/models/cost-report-envelope.unit.test.ts
+++ b/cli/tests/domain/models/cost-report-envelope.unit.test.ts
@@ -220,6 +220,26 @@ describe("toCostReportEnvelope", () => {
     expect(unknown?.totals.requests).toBe(1);
   });
 
+  // snake_case on the wire like every other row, and `started_at` beside the id because an
+  // opaque prompt id alone is not something a person can look up. The row for records that
+  // named no prompt carries neither field - see `CostReportPromptRow`.
+  it("carries one row per prompt, dated, and one undated row for records that named none", () => {
+    const envelope = envelopeOf({
+      records: [
+        record({ turn_id: "a", prompt_id: "p-1", event_timestamp: "2026-08-18T09:00:00.000Z" }),
+        record({ turn_id: "b", prompt_id: "p-1", event_timestamp: "2026-08-18T09:05:00.000Z" }),
+        record({ turn_id: "c", event_timestamp: "2026-08-18T10:00:00.000Z" }),
+      ],
+    });
+
+    expect(
+      envelope.by_prompt.map((row) => [row.prompt, row.started_at, row.totals.requests])
+    ).toEqual([
+      ["p-1", "2026-08-18T09:00:00Z", 2],
+      [undefined, undefined, 1],
+    ]);
+  });
+
   it("carries every day the period spans, a gap included, never sorted by size", () => {
     const envelope = envelopeOf({
       records: [

--- a/cli/tests/domain/models/cost-report.unit.test.ts
+++ b/cli/tests/domain/models/cost-report.unit.test.ts
@@ -589,6 +589,106 @@ describe("buildCostReport — every breakdown reconciles", () => {
     expect(summed).toBe(built.totals.inputTokens);
   });
 
+  // The one axis that is complete by construction. Measured 2026-09-04 on the built binary
+  // against a sandboxed copy of one real session: 1073 of 1073 records carried a
+  // `prompt_id`, its 972 subagent records included, across 12 distinct prompts. Every other
+  // breakdown depends on a capture that may not have happened; this one depends on a field
+  // the reader already resolves for every usage line by walking `parentUuid`.
+  it("breaks the period down by the prompt that caused the work, largest first", () => {
+    const built = report({
+      records: [
+        request({ prompt_id: "p-1", input_tokens: 100 }),
+        request({ prompt_id: "p-1", input_tokens: 50 }),
+        request({ prompt_id: "p-2", input_tokens: 10 }),
+        request({ input_tokens: 1 }),
+      ],
+    });
+
+    expect(built.byPrompts.map((row) => [row.prompt, row.totals.requests])).toEqual([
+      ["p-1", 2],
+      ["p-2", 1],
+      [undefined, 1],
+    ]);
+  });
+
+  // An opaque id alone is unreadable, so the row carries the earliest moment in its group -
+  // the one a person greps for in their own transcript. Earliest, never the first seen: the
+  // sink is append-ordered by read, not by turn.
+  it("dates each prompt row by the earliest moment in that prompt, not the first record read", () => {
+    const built = report({
+      records: [
+        request({ prompt_id: "p-1", event_timestamp: "2026-08-18T09:30:00.500Z" }),
+        request({ prompt_id: "p-1", event_timestamp: "2026-08-18T09:00:00.000Z" }),
+      ],
+    });
+
+    expect(built.byPrompts.map((row) => row.startedAt)).toEqual(["2026-08-18T09:00:00Z"]);
+  });
+
+  // A record whose tool cannot say which prompt caused it is its own row, never merged into
+  // one that named a prompt - the same rule `by_agent` and `by_model` follow for an absent
+  // key. Every host but Claude Code is in that row today.
+  it("leaves records that named no prompt undated rather than dating them from another prompt", () => {
+    const built = report({
+      records: [
+        request({ prompt_id: "p-1", event_timestamp: "2026-08-18T09:00:00.000Z" }),
+        request({ event_timestamp: "2026-08-18T10:00:00.000Z" }),
+      ],
+    });
+    const noPrompt = built.byPrompts.filter((row) => row.prompt === undefined);
+
+    expect(noPrompt.map((row) => row.startedAt)).toEqual([undefined]);
+  });
+
+  // A remainder, not a prompt: sorting it among the prompts by size would rank a bucket
+  // drawn from many turns against single turns. `by_flow` places its own remainder the same
+  // way, and for the same reason.
+  it("keeps the row for records that named no prompt last, even when it is the largest", () => {
+    const built = report({
+      records: [request({ input_tokens: 900 }), request({ prompt_id: "p-1", input_tokens: 10 })],
+    });
+
+    expect(built.byPrompts.map((row) => row.prompt)).toEqual(["p-1", undefined]);
+  });
+
+  // Every counter, not only the one this session happens to look at: 99% of a real session's
+  // tokens are cache, so a guard summing `input_tokens` alone would pass while the counter
+  // carrying the money went missing. `requests` too, which is what a session-kind record
+  // leaking into a prompt group would break.
+  it("reconciles the prompt breakdown to the same total as every other axis", () => {
+    const built = report({
+      records: [
+        request({ prompt_id: "p-1", input_tokens: 7, output_tokens: 5, cache_read_tokens: 4000 }),
+        request({ input_tokens: 3, output_tokens: 2, cache_creation_tokens: 900 }),
+      ],
+    });
+
+    const summed = built.byPrompts.reduce(
+      (total, row) => ({
+        requests: total.requests + row.totals.requests,
+        inputTokens: total.inputTokens + (row.totals.inputTokens ?? 0),
+        outputTokens: total.outputTokens + (row.totals.outputTokens ?? 0),
+        cacheReadTokens: total.cacheReadTokens + (row.totals.cacheReadTokens ?? 0),
+        cacheCreationTokens: total.cacheCreationTokens + (row.totals.cacheCreationTokens ?? 0),
+      }),
+      {
+        requests: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+      }
+    );
+
+    expect(summed).toEqual({
+      requests: built.totals.requests,
+      inputTokens: built.totals.inputTokens,
+      outputTokens: built.totals.outputTokens,
+      cacheReadTokens: built.totals.cacheReadTokens,
+      cacheCreationTokens: built.totals.cacheCreationTokens,
+    });
+  });
+
   it("splits the total four ways by how strongly each part was attributed", () => {
     const built = report({ records: RECORDS });
     expect(built.attributionMix.map((row) => [row.attribution, row.totals.requests])).toEqual([

--- a/cli/tests/e2e/telemetry-cost-skill-commands.e2e.test.ts
+++ b/cli/tests/e2e/telemetry-cost-skill-commands.e2e.test.ts
@@ -46,10 +46,13 @@ function commandsNamedBySkill(): string[] {
 }
 
 /** `<axis>` and friends stand for a choice the agent makes; a placeholder is expanded to its
- * first alternative so the command can actually be run, rather than skipped. */
+ * first alternative so the command can actually be run, rather than skipped. Any `<a|b|c>`
+ * is expanded by its own shape rather than by a copy of one skill's list: pinning the list
+ * here meant the skill could not name a new axis without this regex being edited in the same
+ * breath, and the failure it produced named the placeholder, not the drift. */
 function runnable(command: string): string[] {
   return command
-    .replace(/<total\|day\|step\|model\|task\|backlog\|flow\|tool\|project\|person>/gu, "step")
+    .replace(/<([^<>|]+)(?:\|[^<>]+)>/gu, "$1")
     .replace(/<axis>/gu, "step")
     .replace(/<day>/gu, "2026-01-01")
     .split(/\s+/u)

--- a/cli/tests/e2e/telemetry-lifecycle.e2e.test.ts
+++ b/cli/tests/e2e/telemetry-lifecycle.e2e.test.ts
@@ -260,6 +260,6 @@ describe("measurement, from nothing to off and back", () => {
     const { measurement_enabled: _before, ...historicalFigures } = envelope;
     const { measurement_enabled: _after, ...historicalFiguresAfterOff } = afterOff;
     expect(historicalFiguresAfterOff).toEqual(historicalFigures);
-    expect(envelope.cost_report_version).toBe(12);
+    expect(envelope.cost_report_version).toBe(13);
   }, 60_000);
 });

--- a/cli/tests/e2e/telemetry-multi-tool.e2e.test.ts
+++ b/cli/tests/e2e/telemetry-multi-tool.e2e.test.ts
@@ -444,7 +444,7 @@ describe("the flow a person can actually follow", () => {
     expect(first.exitCode, first.stderr).toBe(0);
     expect(second.stdout).toBe(first.stdout);
     const parsed = JSON.parse(first.stdout);
-    expect(parsed.cost_report_version).toBe(12);
+    expect(parsed.cost_report_version).toBe(13);
     expect(parsed.period).toEqual({ from_day: "2026-07-01", to_day: "2026-07-31" });
     expect(parsed.attribution.map((row: { attribution: string }) => row.attribution)).toEqual([
       "tool-stated",

--- a/cli/tests/fixtures/cli-owns-read/expected-envelope.json
+++ b/cli/tests/fixtures/cli-owns-read/expected-envelope.json
@@ -1,5 +1,5 @@
 {
-  "cost_report_version": 12,
+  "cost_report_version": 13,
   "period": {
     "from_day": "2026-01-01",
     "to_day": "2026-01-31"
@@ -70,6 +70,17 @@
     }
   ],
   "by_agent": [
+    {
+      "totals": {
+        "requests": 4,
+        "input_tokens": 935,
+        "output_tokens": 590,
+        "cache_read_tokens": 14100,
+        "cache_creation_tokens": 1000
+      }
+    }
+  ],
+  "by_prompt": [
     {
       "totals": {
         "requests": 4,

--- a/plugins/aidd-telemetry/skills/01-cost/SKILL.md
+++ b/plugins/aidd-telemetry/skills/01-cost/SKILL.md
@@ -38,6 +38,8 @@ menu and ask them to pick.
 | which framework task | task | one row per task declared in the period, plus the remainder with no task declared |
 | per backlog item, per ticket, what did issue X cost | backlog | one row per backlog item a task declared, plus tasks that named none, plus the remainder with no task at all |
 | per orchestrated run, per flow, what did that pipeline cost | flow | one row per orchestrated run the journal's own sequence names, plus the remainder that ran outside any flow |
+| which subagent, what did delegation cost | agent | one row per agent that ran, plus the main thread's own row |
+| which prompt, which turn, what did one request cost | prompt | one row per prompt that caused work, dated, plus the row for records naming none |
 | for a report, to paste, to send, to keep | any of the above | the same artefact, written to a file |
 | per person, who spent, which teammate | person | one row per resolved person plus every unresolved identity, each with the raw identities behind it |
 

--- a/plugins/aidd-telemetry/skills/01-cost/actions/03-report.md
+++ b/plugins/aidd-telemetry/skills/01-cost/actions/03-report.md
@@ -10,7 +10,7 @@ The path to `aidd telemetry`, and the question the user asked, in their own word
 ## Output
 
 **One axis, asked for by name.** Run
-`aidd telemetry report --axis <total|day|step|model|task|backlog|flow|tool|project|person> --from <day> --to <day>`,
+`aidd telemetry report --axis <total|day|step|model|agent|prompt|task|backlog|flow|tool|project|person> --from <day> --to <day>`,
 never alongside `--json` - the axis flag already picks the one rendering that answers the
 question, printed exactly as the script wrote it:
 
@@ -93,9 +93,12 @@ A breakdown the object leaves empty is a section left out, never a table of zero
    - One axis: `aidd telemetry report --axis <axis> --from 2026-08-01 --to 2026-08-31`.
    - Everything: `aidd telemetry report --from 2026-08-01 --to 2026-08-31 --json`, reading the shape from [cost-report-contract.md](../../../../../aidd_docs/product/cost-report-contract.md).
    - The figure will be kept or compared: give `--from` and `--to`, since `--days` resolves against today and two identical calls on two days cover two different periods.
-3. **Refuse an unknown shape.** `cost_report_version` is `12` today, read from the `--json`
+3. **Refuse an unknown shape.** `cost_report_version` is `13` today, read from the `--json`
    path - the `--axis` path prints text the script already built from that same object, so
-   there is no separate version to check there. The bump from `11` to `12` did not add a
+   there is no separate version to check there. The bump from `12` to `13` added `by_prompt`
+   to the top-level breakdowns: the prompt that caused the work, the one breakdown no host
+   limit can leave empty, since every record the reader stores already carries the turn it
+   came from. The bump from `11` to `12` did not add a
    breakdown either: `by_task`'s `attribution` stopped being always `declared`, so one task
    can now hold two rows - one for what a declaration covered, one for what only a written
    file names. The bump from `10` to `11` did not add a

--- a/scripts/__tests__/aidd-telemetry-cost-skill.test.js
+++ b/scripts/__tests__/aidd-telemetry-cost-skill.test.js
@@ -157,8 +157,10 @@ test("every field the cost skill names by name resolves on the object the script
   // 17 -> 18 when 03-report.md named `by_agent`, the breakdown by the agent that ran, added
   // while bringing the skill's own version paragraph up from `8` to `11` - it had gone three
   // bumps stale, so the paragraph named neither `by_agent` nor `prompt-matched` nor the
-  // fourth no-task reason a row can now carry.
-  assert.equal(claims.size, 18, "expected exactly eighteen field references in the cost skill");
+  // fourth no-task reason a row can now carry. 18 -> 19 when 03-report.md named `by_prompt`,
+  // the breakdown by the prompt that caused the work - the one axis complete by construction,
+  // since every record the reader stores already carries the turn it came from.
+  assert.equal(claims.size, 19, "expected exactly nineteen field references in the cost skill");
 
   // Fields the envelope carries only under some condition, so a fixture cannot show them all
   // at once: the first five appear only under a selection, and `cost_micro_usd` only once a
@@ -320,6 +322,35 @@ test("the cost skill offers its axes in the language of a question", () => {
     assert.ok(everything.includes(question), `must speak in the language of "${question}"`);
   }
   assert.ok(everything.includes("--axis"), "must derive the flag itself, from the question");
+});
+
+// The skill's own axis list drifted twice while the CLI grew one: `agent` shipped and was
+// named in neither the `--axis` enumeration nor the question table, so a person asking "which
+// subagent spent this" was told the question had no axis while the binary had answered it for
+// two releases. Read the axes the binary actually accepts, rather than restating them here,
+// so the next one cannot ship unoffered.
+test("the cost skill offers every axis the binary accepts, in both places it names them", () => {
+  const artefactSource = fs.readFileSync(
+    path.resolve(__dirname, "../../cli/src/application/display/cost-report-artefact.ts"),
+    "utf8",
+  );
+  const declared = /export const ARTEFACT_AXES = \[([^\]]+)\]/u.exec(artefactSource)?.[1] ?? "";
+  const axes = [...declared.matchAll(/"([a-z]+)"/gu)].map((match) => match[1]);
+  assert.ok(axes.length > 1, "must have read the axis list from the artefact module itself");
+
+  const axisFlagEnum = /--axis <([^>]+)>/u.exec(everything)?.[1].split("|") ?? [];
+  const questionTable = /\| The question sounds like \| Axis \| Artefact \|[\s\S]*?\n\n/u.exec(skill)?.[0] ?? "";
+  // Both directions: an axis the binary accepts must be offered, and one the skill offers
+  // must exist - the second is not covered elsewhere, since the e2e that runs every command
+  // the skill names expands this enumeration to its first alternative alone.
+  assert.deepEqual(axisFlagEnum, axes, "the --axis choices must be exactly the axes that exist");
+  for (const axis of axes) {
+    assert.ok(axisFlagEnum.includes(axis), `must list "${axis}" among the --axis choices`);
+    assert.ok(
+      new RegExp(`\\|[^|\\n]*\\b${axis}\\b[^|\\n]*\\|`, "u").test(questionTable),
+      `must map a question to the "${axis}" axis in SKILL.md's own table`,
+    );
+  }
 });
 
 // Per person used to be the one axis nothing could answer, back when no record carried an

--- a/scripts/__tests__/aidd-telemetry-cost-skill.test.js
+++ b/scripts/__tests__/aidd-telemetry-cost-skill.test.js
@@ -1,5 +1,6 @@
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
+const os = require("node:os");
 const path = require("node:path");
 const test = require("node:test");
 
@@ -7,12 +8,17 @@ const pluginDir = path.resolve(__dirname, "../../plugins/aidd-telemetry");
 const skillDir = path.join(pluginDir, "skills/01-cost");
 // Real source, not a re-description of it: closure tests below check the skill's own text
 // against what these two modules actually accept and actually emit.
-const skill = fs.readFileSync(path.join(skillDir, "SKILL.md"), "utf8");
+// Normalized, because these tests match multi-line shapes against the file's own text and
+// git hands a Windows checkout the same content with CRLF endings - where `\n\n` matches
+// nothing. Measured: the axis table regex below returns true on the POSIX checkout and false
+// on the identical file with CRLF, which is how a green suite failed on Windows alone.
+const read = (file) => fs.readFileSync(file, "utf8").replace(/\r\n/gu, "\n");
+const skill = read(path.join(skillDir, "SKILL.md"));
 // A router skill's rules live in its actions; reading only the router would test a
 // table of contents.
 const actions = fs
   .readdirSync(path.join(skillDir, "actions"))
-  .map((name) => fs.readFileSync(path.join(skillDir, "actions", name), "utf8"))
+  .map((name) => read(path.join(skillDir, "actions", name)))
   .join("\n");
 const everything = `${skill}\n${actions}`;
 
@@ -330,9 +336,8 @@ test("the cost skill offers its axes in the language of a question", () => {
 // two releases. Read the axes the binary actually accepts, rather than restating them here,
 // so the next one cannot ship unoffered.
 test("the cost skill offers every axis the binary accepts, in both places it names them", () => {
-  const artefactSource = fs.readFileSync(
+  const artefactSource = read(
     path.resolve(__dirname, "../../cli/src/application/display/cost-report-artefact.ts"),
-    "utf8",
   );
   const declared = /export const ARTEFACT_AXES = \[([^\]]+)\]/u.exec(artefactSource)?.[1] ?? "";
   const axes = [...declared.matchAll(/"([a-z]+)"/gu)].map((match) => match[1]);
@@ -350,6 +355,25 @@ test("the cost skill offers every axis the binary accepts, in both places it nam
       new RegExp(`\\|[^|\\n]*\\b${axis}\\b[^|\\n]*\\|`, "u").test(questionTable),
       `must map a question to the "${axis}" axis in SKILL.md's own table`,
     );
+  }
+});
+
+// The reader itself, against a file on disk with the endings git hands a Windows checkout -
+// not a string normalized inside the assertion, which would pass however the reader behaves.
+test("reads a Windows checkout the same way it reads a POSIX one", () => {
+  const scratch = fs.mkdtempSync(path.join(os.tmpdir(), "aidd-crlf-"));
+  const file = path.join(scratch, "SKILL.md");
+  fs.writeFileSync(file, skill.replace(/\n/gu, "\r\n"));
+  try {
+    const asRead = read(file);
+
+    assert.equal(asRead, skill, "must hand back the same text a POSIX checkout would");
+    assert.ok(
+      /\| The question sounds like \| Axis \| Artefact \|[\s\S]*?\n\n/u.test(asRead),
+      "the axis table must still be found in a file checked out with CRLF endings",
+    );
+  } finally {
+    fs.rmSync(scratch, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
## What

Adds `by_prompt` to the cost report: one row per prompt that caused work, dated by the earliest moment measured inside it, plus one row for records that named none.

## Why this one

Every other breakdown can read low for a reason about the capture rather than about the work — a skill the host never named, a run journal that was never written, an identity nobody declared. This one groups on `prompt_id`, which the transcript reader already resolves for every usage line it stores by walking each file's own `parentUuid` chain back to the turn that caused the work. Nothing new is captured for it.

## Measured, on the built binary

Sandboxed copy of one real session (`HOME` and `AIDD_TELEMETRY_DIR` both under a scratch directory):

```
by_prompt  rows  12  requests 1073   named 12, dated 12, remainder rows 0
by_agent   rows   4  requests 1073
by_step    rows   7  requests 1073   (96% of tokens unattributed)
totals.requests 1073                 cost_report_version 13
```

1073 of 1073 records carry a `prompt_id`, its 972 subagent records included, across 12 distinct prompts. The axis reconciles to the same total as every other breakdown with nothing in a remainder — on the same session where the step axis cannot name 96% of the tokens.

## Decisions

| Decision | Choice | Why |
| --- | --- | --- |
| Absent key | its own row, keyed on a `Symbol` | a prompt id is opaque, so no string is safe to reserve. Same reasoning as `NO_AGENT` and `NO_KNOWN_MODEL` |
| `started_at` | earliest moment in the prompt | an id alone is unreadable; the moment is what a person greps for in their own transcript |
| The remainder row | last, never ranked | a bucket drawn from many turns has no size comparable to a single turn's. `by_flow` places its own remainder the same way |
| Printed rows | top 10, then a count and `--json` | the first axis whose cardinality is unbounded. `by_day` suppresses every row above its cap because a partial series is a lie about continuity; a partial ranking is not, and it says how many it withheld. The envelope carries them all |

## Envelope 12 → 13

A new top-level breakdown, so a consumer summing every breakdown's `requests` against `totals.requests` has one more to include. Every consumer updated in this commit: the contract document, the cost skill's own pinned version and axis lists, the envelope fixture, and the two e2e version pins.

## Two gaps closed on the way

- The skill's `--axis` enumeration and its question table both omitted `agent`, which had shipped two versions earlier — a person asking which subagent spent the tokens was told the question had no axis while the binary had been answering it. A guard now reads `ARTEFACT_AXES` from the module itself and asserts the two lists are equal, in both directions.
- The e2e that runs every command the skill names held its own copy of the axis list in a placeholder regex, so a skill could not name a new axis without that regex being edited in the same breath. It now expands any `<a|b|c>` by its shape.

## Cost

Bundle 588.4 → 590.6 KB. Budget raised 590 → 593, with the measurement recorded beside the previous raises.

## Gates

- `cd cli && pnpm test` — 305 files, 3396 tests, green (build included)
- `node --test "scripts/__tests__/**/*.test.js"` — 366 pass
- `pnpm knip:production`, `pnpm jscpd`, `npx biome ci`, `npx tsc --noEmit` — green
- every pre-commit check run directly (json, skill frontmatter, argument hints, markdown links, cli layering); the three generators rewrite nothing
- every guard ships with a mutation that fails it, and only it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWNxk63AGKkqE8HRqHLjGp