### PR TITLE
fix(telemetry): a re-read stores nothing the same batch already wrote

### DIFF
--- a/aidd_docs/tasks/2026_09/2026_09_04_a-re-read-stores-nothing-twice/plan.md
+++ b/aidd_docs/tasks/2026_09/2026_09_04_a-re-read-stores-nothing-twice/plan.md
@@ -1,0 +1,80 @@
+---
+status: done
+---
+
+# A re-read stores nothing twice
+
+## The defect
+
+`storeNewCandidates` reads the index of what the sink already holds once, before its loop,
+and never updates it as it appends. Two candidates for the same turn inside one batch are
+therefore both stored: the second is matched only against what an earlier invocation left
+behind, never against the line this batch just wrote.
+
+## Why a batch holds the same turn twice
+
+Measured on this project's own transcripts: 53,425 usage lines carry a request id, 28,687
+of them distinct, and **350 of those ids appear in more than one file**. One read of one
+session hands both copies over as two candidates of the same batch.
+
+## What it actually cost, measured before deciding anything
+
+The sink held 29,699 lines: 339 groups of byte-identical records, 474 extra lines, every one
+of them a subagent record.
+
+**No reported figure was ever wrong.** `collapseBilledRequests` groups on
+`tool + vendor_id + billed_request_id`, which is exactly what those 339 groups share, so the
+report has always merged them:
+
+```
+29,699 stored lines  ->  29,207 reported requests
+```
+
+So this is storage hygiene, not a correction. The earlier framing of it as figures being
+wrong was mine and it was wrong.
+
+## The fix
+
+Make the index live: add each appended record to it. Three lines and a helper.
+
+Rejected: a content-key dedup beside the turn-id one. Measured, 491 extra lines share a
+`billed_request_id` against 474 sharing full content — the 17 in between are legitimate
+corrections, a re-read of the same billed call with larger counters. A content key stores
+those correctly, but it would be a second key answering the one question `turn_id` already
+answers, which is the second source of truth this repository refuses elsewhere.
+
+Also rejected: rewriting the 474 lines already in a person's sink. They cost nothing in any
+figure, and an append-only sink is not something to rewrite for that.
+
+## Proven end to end
+
+Same real transcripts, same command, two builds:
+
+| Build | Stored lines | Exact-duplicate extra lines |
+| --- | --- | --- |
+| `origin/next` | 29,171 | 474 |
+| this branch | 28,695 | 0 |
+
+The two sinks report the **identical envelope**, byte for byte. Of the 476 lines the fix does
+not write, 474 are the duplicates and 2 are smaller readings of a turn whose larger reading is
+still stored — the report already discarded those, which is why nothing moved:
+
+```
+one turn     base weights [520362, 522612]   fixed [522612]
+another      base weights [283285, 283851, 283851]   fixed [283851]
+```
+
+## Noted, not changed
+
+`pruneOldDayFiles` keeps the newest 90 **day files**, not 90 calendar days
+(`decideTelemetrySinkRetention`). A session re-read after more day files than that would no
+longer find its own priors and would store them again. Bounded and deliberate; named here so
+the next person reading this file does not have to re-derive it.
+
+## Guards
+
+| Guard | Mutation that kills it |
+| --- | --- |
+| one line stored when a batch hands the same turn twice | leave the index frozen |
+| a larger reading in the same batch still lands as a correction | treat every same-turn candidate as a drop |
+| every keyless candidate of one batch is appended | key the keyless records together, on both sides |

--- a/cli/src/application/use-cases/telemetry/read-local-cost-use-case.ts
+++ b/cli/src/application/use-cases/telemetry/read-local-cost-use-case.ts
@@ -135,10 +135,14 @@ function isPresent(value: string | undefined): value is string {
 }
 
 /** Every already-stored record for this session, keyed on its own `turn_id` — a record
- * with none is not indexed, the same as it is never matched by a re-read. */
+ * with none is not indexed, the same as it is never matched by a re-read.
+ *
+ * Mutable on purpose: `storeNewCandidates` adds each record it appends, so a second
+ * candidate for the same turn in the same batch is matched against the first. Read once
+ * and left frozen, it could only ever answer for what an earlier invocation stored. */
 function groupByTurnId(
   records: readonly TelemetrySinkRecord[]
-): ReadonlyMap<string, readonly TelemetrySinkRecord[]> {
+): Map<string, TelemetrySinkRecord[]> {
   const groups = new Map<string, TelemetrySinkRecord[]>();
   for (const record of records) {
     if (record.turn_id === undefined) continue;
@@ -147,6 +151,16 @@ function groupByTurnId(
     else groups.set(record.turn_id, [record]);
   }
   return groups;
+}
+
+function indexStoredRecord(
+  groups: Map<string, TelemetrySinkRecord[]>,
+  record: TelemetrySinkRecord
+): void {
+  if (record.turn_id === undefined) return;
+  const bucket = groups.get(record.turn_id);
+  if (bucket) bucket.push(record);
+  else groups.set(record.turn_id, [record]);
 }
 
 const LOCAL_READ_TURN_COUNTER_KEYS = [
@@ -492,6 +506,14 @@ export class ReadLocalCostUseCase {
    * as the same record is read again. A candidate with no `turn_id` cannot be matched and
    * is always appended: the reader's contract forbids inventing a key for it.
    *
+   * The index grows as this appends, so two candidates for one turn in a single batch match
+   * each other and not only what an earlier invocation left behind. Measured on a live sink:
+   * 339 groups of byte-identical records, 474 extra lines, every one a subagent record —
+   * of that project's 29,741 distinct request ids, 350 appear in more than one transcript
+   * file, and one read hands both copies over as two candidates of the same batch. No
+   * reported figure ever moved, since `collapseBilledRequests` already merges them at
+   * report time; what this stops is the sink storing an observation it already holds.
+   *
    * A candidate whose `turn_id` *is* already stored is dropped — unless it is a
    * `kind: "request"` local-read record correcting an earlier, still-open reading of the
    * same turn (`isLocalReadTurnCorrection`), the one case this match used to refuse
@@ -511,7 +533,9 @@ export class ReadLocalCostUseCase {
     for (const candidate of candidates) {
       const prior = candidate.turn_id === undefined ? undefined : byTurnId.get(candidate.turn_id);
       if (prior && !this.isLocalReadTurnCorrection(candidate, prior)) continue;
-      await this.sink.appendRecord(this.stampProvenanceAndTool(tool, candidate, attribution), at);
+      const record = this.stampProvenanceAndTool(tool, candidate, attribution);
+      await this.sink.appendRecord(record, at);
+      indexStoredRecord(byTurnId, record);
       stored++;
     }
     return stored;

--- a/cli/tests/application/use-cases/telemetry/read-local-cost-use-case.unit.test.ts
+++ b/cli/tests/application/use-cases/telemetry/read-local-cost-use-case.unit.test.ts
@@ -488,6 +488,73 @@ describe("ReadLocalCostUseCase", () => {
     expect([...sink.files.values()].flat()).toHaveLength(1);
   });
 
+  // Measured 2026-09-04 on a live sink: 339 groups of byte-identical records, 474 extra
+  // lines, every one of them a subagent record. The source explains it - of 29,741 distinct
+  // requestIds in that project's transcripts, 350 appear in more than one file, and one read
+  // of the session hands both copies to this method as two candidates of the same batch. The
+  // index of what is already stored was read once, before the loop, so the first copy was
+  // appended without the second ever being matched against it.
+  it("stores one line when a single read hands it the same turn twice", async () => {
+    declareClaudeReadable();
+    const sink = new InMemoryTelemetrySink();
+    const useCase = new ReadLocalCostUseCase(
+      sink,
+      new Map([["claude", stubReader([CANDIDATE, { ...CANDIDATE }])]]),
+      NULL_RUN_JOURNAL_READER,
+      NULL_PERSON_IDENTITY_READER,
+      TELEMETRY_EVIDENCE_READER
+    );
+
+    const result = await useCase.execute({
+      projectRoot: PROJECT_ROOT,
+      env: {},
+      sessionId: SESSION_ID,
+    });
+
+    expect([...sink.files.values()].flat()).toHaveLength(1);
+    expect(result.toolReports.find((r) => r.tool === "claude")?.recordsStored).toBe(1);
+  });
+
+  // The correction route still works inside one batch: a second candidate for the same turn
+  // that strictly improves on the first is what `isLocalReadTurnCorrection` exists for, and
+  // making the index live must not turn it into a drop.
+  it("still lands a correction when the larger reading arrives in the same read", async () => {
+    declareClaudeReadable();
+    const sink = new InMemoryTelemetrySink();
+    const larger: LocalCostCandidateRecord = { ...CANDIDATE, output_tokens: 900 };
+    const useCase = new ReadLocalCostUseCase(
+      sink,
+      new Map([["claude", stubReader([CANDIDATE, larger])]]),
+      NULL_RUN_JOURNAL_READER,
+      NULL_PERSON_IDENTITY_READER,
+      TELEMETRY_EVIDENCE_READER
+    );
+
+    await useCase.execute({ projectRoot: PROJECT_ROOT, env: {}, sessionId: SESSION_ID });
+
+    expect([...sink.files.values()].flat().map((r) => r.output_tokens)).toEqual([20, 900]);
+  });
+
+  // The live index must key on a real identifier and nothing else. Folding the keyless
+  // records under one shared key would let the second of them be matched against the first
+  // and dropped - the opposite of the contract the test below states for a re-read.
+  it("appends every keyless candidate of one batch, never matching two of them to each other", async () => {
+    declareClaudeReadable();
+    const keyless: LocalCostCandidateRecord = { ...CANDIDATE, turn_id: undefined };
+    const sink = new InMemoryTelemetrySink();
+    const useCase = new ReadLocalCostUseCase(
+      sink,
+      new Map([["claude", stubReader([keyless, { ...keyless }])]]),
+      NULL_RUN_JOURNAL_READER,
+      NULL_PERSON_IDENTITY_READER,
+      TELEMETRY_EVIDENCE_READER
+    );
+
+    await useCase.execute({ projectRoot: PROJECT_ROOT, env: {}, sessionId: SESSION_ID });
+
+    expect([...sink.files.values()].flat()).toHaveLength(2);
+  });
+
   it("never synthesises a key for a candidate with no request identifier, and cannot dedup it", async () => {
     declareClaudeReadable();
     const noIdCandidate: LocalCostCandidateRecord = { ...CANDIDATE, turn_id: undefined };


### PR DESCRIPTION
## The defect

`storeNewCandidates` read the index of what the sink already holds once, before its loop, and never updated it as it appended. Two candidates for the same turn inside one batch were both stored: the second was matched only against what an earlier invocation had left behind, never against the line this batch had just written.

## Why a batch holds the same turn twice

Measured on this project's own transcripts: 53,425 usage lines carry a request id, 28,687 of them distinct, and **350 of those ids appear in more than one file**. One read of one session hands both copies over as two candidates.

## What it cost — measured before deciding anything

339 groups of byte-identical records, 474 extra lines out of 29,699, every one a subagent record.

**No reported figure was ever wrong.** `collapseBilledRequests` groups on `tool + vendor_id + billed_request_id`, which is exactly what those groups share:

```
29,699 stored lines  ->  29,207 reported requests
```

This is storage hygiene, not a correction, and the commit claims nothing more.

## Proven end to end

Same real transcripts, same command, two builds:

| Build | Stored lines | Exact-duplicate extra lines |
| --- | --- | --- |
| `origin/next` | 29,171 | 474 |
| this branch | 28,695 | 0 |

The two sinks report an **identical envelope**. Of the 476 lines not written, 474 are the duplicates and 2 are smaller readings of a turn whose larger reading is still stored — which the report already discarded, which is why nothing moved.

## Rejected

- **A content key beside the turn-id one.** 491 extra lines share a `billed_request_id` against 474 sharing full content, so the 17 in between are legitimate corrections. A content key stores those correctly but would be a second key answering the question `turn_id` already answers.
- **Rewriting the 474 lines already in a person's sink.** They cost nothing in any figure, and an append-only sink is not something to rewrite for that.

## Noted, not changed

`pruneOldDayFiles` keeps the newest 90 **day files**, not 90 calendar days. A session re-read after more day files than that would no longer find its own priors. Bounded and deliberate; named so the next reader need not re-derive it.

## Guards

| Guard | Mutation that kills it |
| --- | --- |
| one line stored when a batch hands the same turn twice | leave the index frozen |
| a larger reading in the same batch still lands as a correction | treat every same-turn candidate as a drop |
| every keyless candidate of one batch is appended | key the keyless records together, on both sides |

## Gates

`cd cli && pnpm test` 305 files / 3390 tests green (build included) · `node --test "scripts/__tests__/**/*.test.js"` 365 pass · knip, jscpd, `biome ci`, `tsc --noEmit` green · markdown links and cli layering green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWNxk63AGKkqE8HRqHLjGp