### PR TITLE
fix(telemetry): a record can predate its journal, and must say so

### DIFF
--- a/aidd_docs/product/cost-report-contract.md
+++ b/aidd_docs/product/cost-report-contract.md
@@ -131,7 +131,29 @@ real count is the ordinary case of reporting from a project whose switch never c
 work, never a contradiction (see "Attributing records to a task" for the same scope split
 elsewhere in this object).
 
-Every object carries `cost_report_version`, currently `13`.
+Every object carries `cost_report_version`, currently `14`.
+
+Bumped from `13` when the reasons a `by_task` or `by_backlog` row can carry gained a
+fifth, **`"precedes-journal"`**: this record's moment is older than the earliest moment its
+own session's journal witnessed. Until then those records read `"precedes-declaration"`,
+which asserts that the work named its task late — and measured on 2026-09-04, 96.2% of a
+real period (28,570 of 29,207 requests) read that way while fewer than one in five hundred
+of them had actually declared late. The population is ordinary, not an anomaly: reading a
+resumed transcript stores the turns it inherited under the session that read them, dated
+when each was *billed*, days before that session opened a journal. Keyed on the journal's
+own earliest witnessed moment, the same field the `"inferred"` bound above already reads,
+never on its `session_start` line. Decided before `"no-declaration"`, so a journal that
+declared nothing *and* did not cover the record is named by the coverage fact. A consumer
+that switched exhaustively on the four previous reasons must add this one; every row's
+`totals` still reconciles to the period total.
+
+Bumped from `12` when **`by_prompt`** joined the top-level breakdowns — the prompt that
+caused the work, grouped by the turn each record came from. It is the one breakdown no host
+limit can leave empty: every record the reader stores already carries its own turn, where
+`by_step` depends on a host naming a skill and reads a few percent on a session whose real
+cost sits in subagents. A row with no `prompt` is a record whose turn nothing named, placed
+last like every other axis' remainder rather than dropped. A consumer that summed every
+breakdown's `requests` against `totals.requests` has one more breakdown to sum.
 
 Bumped from `11` when **`by_task`'s `attribution` stopped being always `"declared"`**. A
 record no declaration covers is now named after the one task folder its session wrote into,
@@ -230,7 +252,7 @@ one. Adding a field you may ignore is not a bump; changing what an existing fiel
 
 ```jsonc
 {
-  "cost_report_version": 13,
+  "cost_report_version": 14,
   "period": { "from_day": "2026-07-01", "to_day": "2026-07-31" },
   "measurement_enabled": true,                  // this project's own switch, right now — see Versioning
   "task": "2026_08/2026_08_21_cost-reporter",   // absent unless --task was given
@@ -245,7 +267,7 @@ one. Adding a field you may ignore is not a bump; changing what an existing fiel
   "by_prompt":  [{ "prompt": "a-prompt-id", "started_at": "2026-07-01T09:00:00Z", "totals": {} }, { "totals": {} }],  // one row per prompt, largest first; the last row, undated, is every record that named none
   "by_tool":    [{ "tool": "codex", "coverage": "covered", "reason": "…", "capability": {}, "totals": {}, "session_totals": {} }],  // session_totals absent unless the tool has one (Copilot, today)
   "by_project": [{ "project": "acme/widgets", "totals": {} }],   // a row with no `project` names none known
-  "by_task":    [{ "task": "2026_08/2026_08_21_cost-reporter", "attribution": "declared", "totals": {} }, { "reason": "precedes-declaration", "totals": {} }],  // a row with no `task` carries `reason` instead, naming which of four facts applies; up to four such rows
+  "by_task":    [{ "task": "2026_08/2026_08_21_cost-reporter", "attribution": "declared", "totals": {} }, { "reason": "precedes-declaration", "totals": {} }],  // a row with no `task` carries `reason` instead, naming which of five facts applies; up to five such rows
   "by_backlog": [{ "backlog": "ai-driven-dev/framework#661", "totals": {} }, { "declaration": "none", "totals": {} }, { "declaration": "unreadable", "totals": {} }, { "reason": "precedes-declaration", "totals": {} }],  // a row with no `backlog` carries `declaration` (a known task naming none, or one whose declaration could not be read) or `reason` (a record in no task at all) — never both, never neither
   "by_flow":    [{ "flow": "aidd-orchestrator:01-sdlc", "started_at": "2026-07-01T09:00:00Z", "totals": {} }, { "flow": "aidd-orchestrator:01-sdlc", "started_at": "2026-07-01T11:00:00Z", "totals": {} }, { "totals": {} }],  // two runs of the same skill are two rows, told apart by `started_at`; the last row is work that fell in no flow interval at all
   "by_day":     [{ "day": "2026-07-01", "totals": {} }],         // every day in the period, in order, gaps included
@@ -286,7 +308,7 @@ read. Ordered by `cost_micro_usd` where a row has one, and by all four token cou
 summed where it does not — never by `input_tokens` and `output_tokens` alone, which every
 tool here dwarfs with cache. `by_task` places every row for what fell in no declared
 interval last regardless of size, in `reason`'s own fixed order (`"no-journal"`,
-`"no-declaration"`, `"precedes-declaration"`, `"journal-silent"`) — the same convention
+`"precedes-journal"`, `"no-declaration"`, `"precedes-declaration"`, `"journal-silent"`) — the same convention
 `by_person` gives its own no-identifier row, a reader sees tasks before the remainder, and
 the remainder in the
 same order every time. `by_backlog` places its own named rows first, then the row for a
@@ -342,11 +364,12 @@ read, the rest facts about the work:
 | `reason` | What it means |
 | --- | --- |
 | `"no-journal"` | No usable run journal reached this record's session. Either none was read for it at all — the journals are on another machine, the period was read from outside any checkout, the session's own journal was removed — or one was read and could not be used, its `session_start` header torn, so nothing here knows which session its lines belong to. Never says the work declared nothing. |
+| `"precedes-journal"` | This record's moment is older than the earliest moment its session's journal witnessed. Nothing declared late here; no journal existed yet. Reading a resumed transcript stores the turns it inherited under the session that read them, dated when each was billed — so this row is ordinarily the largest one in a period, and says nothing about how the work behaved. |
 | `"no-declaration"` | This record's session never declared a task at all. |
-| `"precedes-declaration"` | A task was declared, but some declared interval in this session starts *after* this record's own moment — true both for a record before the session's very first declaration and for one landing in the gap a `turn_end` leaves between two declarations. That gap is real, but it is the journal still going, never the journal falling silent. |
+| `"precedes-declaration"` | A task was declared, this record's moment falls inside what the journal witnessed, and some declared interval starts *after* it — a record before the session's very first declaration. Declared intervals run contiguously from each declaration to the next, so no gap exists between two of them. |
 | `"journal-silent"` | A task was declared, every declared interval starts at or before this record's moment, and none of them reaches it — the journal's own declared coverage ran out before this record's moment did. |
 
-Up to four such rows can appear in one period — one per reason actually present, never
+Up to five such rows can appear in one period — one per reason actually present, never
 fewer, and never two different gaps collapsed into one row the way a single, undifferentiated
 "no declared interval" row used to read before `cost_report_version` `6`. A session whose
 declaration could not be read produces the same `"no-declaration"` row a session that never

--- a/aidd_docs/tasks/2026_09/2026_09_04_a-record-can-predate-its-journal/plan.md
+++ b/aidd_docs/tasks/2026_09/2026_09_04_a-record-can-predate-its-journal/plan.md
@@ -1,0 +1,108 @@
+---
+status: done
+---
+
+# A record can predate its journal
+
+## The claim being made today
+
+96.2% of a real period reads `"precedes-declaration"`, whose own doc comment says what that
+asserts: "a record before the session's very first declaration". Read plainly, the report
+tells a person their flow declares its task late, almost always.
+
+That is false for nearly all of them.
+
+## Measured, on this project's own sink and its two run journals
+
+The period holds 29,207 reported requests across two sessions. Splitting the
+`"precedes-declaration"` population by where each record's moment falls against its own
+journal:
+
+| Where the record's moment falls | Records | Share |
+| --- | --- | --- |
+| before the journal witnessed anything at all | 28,570 | 96.2% |
+| at or after that session's first declaration | 1,045 | 3.5% |
+| after `session_start`, before the first declaration | 50 | 0.2% |
+| no journal for this session | 34 | 0.1% |
+
+Two journals. One opened at `2026-09-04T05:21:27Z` and first declared at `05:59:09Z`; the
+other opened at `09:54:43Z` and first declared at `10:23:36Z`.
+
+So of everything currently labelled "before this session declared a task", **fewer than one
+in five hundred** was actually a late declaration. The rest are billed turns the session
+inherited: a resumed transcript carries its earlier turns, and reading it stores them under
+the session that read them, dated when they were billed — days before that session's journal
+was ever written.
+
+## The fault, one level down from the fault `"no-journal"` fixed
+
+`"no-journal"` was added because folding a fact about the read into `"no-declaration"` made
+the report assert that a session declared nothing when the truth was that its journal was
+never found. The same shape is here: folding "no journal covered this moment" into
+`"precedes-declaration"` makes the report assert late declaring when the truth is that no
+journal existed yet.
+
+## The change
+
+A fifth `TaskUnattributedReason`, `"precedes-journal"`: this record's moment is older than
+the earliest moment its session's journal witnessed.
+
+Keyed on `CostReportSessionJournal.witnessed.fromMs`, which already exists and already means
+exactly that — not on the `session_start` line, which would be a second notion of when a
+session began. Verified on both journals that `min(at)` over every line equals `session_start`,
+so the key is the same split with one less field threaded through.
+
+Checked before `"no-declaration"`: a journal that declared nothing *and* did not cover the
+record is described by the coverage fact, which is the one that explains why no declaration
+could have covered it.
+
+## Guards
+
+| Guard | Mutation that kills it |
+| --- | --- |
+| a record older than everything its journal witnessed reads `"precedes-journal"` | drop the coverage check |
+| a record inside the span, before the first declaration, still reads `"precedes-declaration"` | widen the check to every unattributed record |
+| a journal that declared nothing and did not cover the record reads `"precedes-journal"`, not `"no-declaration"` | order the coverage check after the empty-intervals check |
+| a journal carrying no readable moment never claims coverage | default an absent span to `Infinity` |
+| the report itself passes the journal's span, not only the function | drop the third argument at the call site |
+| every consumer names the fifth reason | remove one key from `TASK_UNATTRIBUTED_LABELS` |
+
+A sixth guard, unrelated to the reason but found while making this change: nothing checked
+the `cost_report_version` the skill names against the one the CLI emits. The contract
+document has had that guard since version 10; the skill, which refuses an object whose
+version it does not know, had none — so a bump could ship leaving the skill set to refuse
+the object it was built to read. Killed by leaving `03-report.md` naming `12`.
+
+Rejected as an equivalent mutant: defaulting an absent span to `0`. Every moment this
+function is ever asked about is after 1970, so `momentMs < 0` is false and the mutant
+behaves identically. `Infinity` is the mutation that actually flips the branch.
+
+## Envelope
+
+`cost_report_version` `13` -> `14`: an existing field gains a value a consumer switching
+exhaustively on the four previous reasons does not know. Same precedent as the `"no-journal"`
+bump.
+
+Rebased onto `by_prompt`'s own bump to `13` once that merged. Found in the rebase: that
+change bumped the number and never wrote its entry in the contract's version history, which
+jumped from `currently 13` straight to "Bumped from `11`". Both entries are written here.
+## Proven end to end
+
+Built binary, the real sink copied read-only into a sandbox `HOME` and
+`AIDD_USER_CONFIG_DIR`, same command on both builds, period 2026-08-01 to 2026-09-30:
+
+| Row | `origin/next` | this branch |
+| --- | --- | --- |
+| older than anything this session's journal witnessed | — | 28,079 |
+| before the next task this session declares | 28,101 | 22 |
+| no usable run journal for this session | 33 | 33 |
+| named tasks (5 rows) | 1,073 | 1,073 |
+
+`by_task` and `by_backlog` both sum to 29,207, the period total, on both builds.
+
+So what the report now says the flow declared late is **22 requests, 0.08% of the period** —
+where it said 28,101, 96.2%. The other 28,079 are named for what they are.
+
+The 28 records the earlier measurement counted between `session_start` and the first
+declaration do not appear in either reason row: the `"inferred"` route names them first,
+from the one task folder that session wrote into. 28 + 22 is the 50 that measurement found.

--- a/cli/src/application/display/cost-report-display.ts
+++ b/cli/src/application/display/cost-report-display.ts
@@ -42,12 +42,20 @@ export const TASK_ATTRIBUTION_LABELS: Record<TaskAttributionSource, string> = {
  * it - never one label standing in for all of them, which is the fault this breakdown
  * exists to avoid (see `CostReportTaskRow`).
  *
- * The first names a fact about the read, the rest facts about the work, and the wording
- * keeps them apart: "no usable run journal" says this layer never had a journal it could
- * attach to this session - none read, or one read whose header was torn - where "no usable
- * task declaration" says it had one and found no declaration in it. */
+ * The first names a fact about the read, the second a fact about the record's own age, the
+ * rest facts about how the work behaved, and the wording keeps all three apart: "no usable
+ * run journal" says this layer never had a journal it could attach to this session - none
+ * read, or one read whose header was torn - where "no usable task declaration" says it had
+ * one and found no declaration in it.
+ *
+ * The second is worded as a fact about the record's age, not about declaring, because that
+ * is what it is: a resumed transcript's inherited turns were billed before the session that
+ * read them ever opened a journal. Saying "before this session declared a task" of them -
+ * which this breakdown did until 2026-09-04, for 96.2% of a real period - reads as a
+ * complaint about the flow. */
 export const TASK_UNATTRIBUTED_LABELS: Record<TaskUnattributedReason, string> = {
   "no-journal": "no usable run journal for this session",
+  "precedes-journal": "older than anything this session's journal witnessed",
   "no-declaration": "no usable task declaration in this session",
   "precedes-declaration": "before the next task this session declares",
   "journal-silent": "the journal falls silent before this record",

--- a/cli/src/application/display/cost-report-display.ts
+++ b/cli/src/application/display/cost-report-display.ts
@@ -108,8 +108,10 @@ const MAX_PRINTED_PROMPTS = 10;
 
 // A year asked for by day is 365 rows - the envelope always carries every one of them, but
 // a terminal is not the place to read that many. Above this, the text rendering names the
-// count and points at --json rather than printing a screen nobody can scan. Must match
-// render.cjs's own MAX_PRINTED_DAYS: the byte-compare e2e test holds the two to it.
+// count and points at --json rather than printing a screen nobody can scan. This used to
+// carry a second sentence pinning it to a plugin script's own copy of the number, held
+// equal by a byte-compare e2e test; both went when the CLI took the read path, so this is
+// the only place the limit lives.
 const MAX_PRINTED_DAYS = 31;
 
 /** Exported alongside `formatAmount` and `totalTokens` so the interactive telemetry screen

--- a/cli/src/domain/models/cost-report-envelope.ts
+++ b/cli/src/domain/models/cost-report-envelope.ts
@@ -102,7 +102,7 @@ import type { AiToolId } from "./tool-ids.js";
  * `by_project`'s `project` to optional back when that row was added.
  *
  * Bumped to 2: `by_project` and `by_day` are new top-level breakdowns. */
-export const COST_REPORT_ENVELOPE_VERSION = 13;
+export const COST_REPORT_ENVELOPE_VERSION = 14;
 
 /** Money as whole micro-dollars, the way the report carries it: an integer, so a consumer
  * summing several reports gets the same answer this one did. Divide by 1,000,000 for

--- a/cli/src/domain/models/cost-report.ts
+++ b/cli/src/domain/models/cost-report.ts
@@ -221,7 +221,7 @@ export interface CostReportTaskRow {
  *   still counted, here and in every other breakdown, exactly as `by_task` counts a record
  *   whose declaration could not be read.
  * - `reason` — the record belongs to no task at all, carrying the same
- *   `TaskUnattributedReason` `CostReportTaskRow` gives it; up to four such rows, one per
+ *   `TaskUnattributedReason` `CostReportTaskRow` gives it; up to five such rows, one per
  *   reason actually present, never collapsed into one. */
 export interface CostReportBacklogRow {
   readonly backlog?: string;
@@ -804,7 +804,11 @@ function taskRowOf(
   if (inferred !== null && witnessed(journal, record.event_timestamp)) {
     return { task: inferred, attribution: "inferred" };
   }
-  return taskUnattributedReason(intervals, record.event_timestamp);
+  // The journal's own earliest witnessed moment, so a record older than everything this
+  // session saw is named for that rather than for declaring late - the distinction 96.2% of
+  // a real period turns on. Absent for a journal with no readable moment, which then makes
+  // no coverage claim at all.
+  return taskUnattributedReason(intervals, record.event_timestamp, journal?.witnessed?.fromMs);
 }
 
 /** Which `byBacklog` row a record's own task-row key belongs in - built from

--- a/cli/src/domain/models/task-attribution.ts
+++ b/cli/src/domain/models/task-attribution.ts
@@ -102,8 +102,8 @@ export function buildTaskIntervals(
 }
 
 /** Why a record belongs to no task - the distinct facts a person acts on differently, and
- * no more than those. This function itself answers only the three that are facts about the
- * work; `"no-journal"`, the fact about the read, is decided by `declaredTaskKeyOf` before
+ * no more than those. This function itself answers only the four that are facts about the
+ * record; `"no-journal"`, the fact about the read, is decided by `declaredTaskKeyOf` before
  * this is ever called. Never called for a moment `momentFallsWithin`
  * already reads as covered; that caller already knows which interval and needs no reason for
  * what it found.
@@ -120,8 +120,8 @@ export function buildTaskIntervals(
  *   own per-session map. It belongs in
  *   this type all the same: it is one of the reasons a `by_task` row carries, and keeping it
  *   in the same closed set is what makes `Record<TaskUnattributedReason, string>` force
- *   every consumer to name it. The three below are facts about the work; this one is a fact
- *   about the read, and merging it into `"no-declaration"` asserted that a session declared
+ *   every consumer to name it. The four below are facts about the record itself; this one is
+ *   a fact about the read, and merging it into `"no-declaration"` asserted that a session declared
  *   nothing when the truth was that its journal was never found - measured on 2026-09-04,
  *   where running the report from a subdirectory reported 100% "no usable task declaration"
  *   for a period whose journals were all present one directory up.
@@ -131,11 +131,26 @@ export function buildTaskIntervals(
  *   The two are indistinguishable from here, which is why this reason is worded "no usable
  *   declaration" rather than "none was ever declared" - the latter would be false for a
  *   session whose journal really does hold a line, just not a readable one.
+ * - `"precedes-journal"`: this record's moment is older than the earliest moment its
+ *   session's journal witnessed. Nothing was declared late here; no journal existed yet.
+ *   The population is large and it is not an anomaly: reading a resumed transcript stores
+ *   the turns it inherited under the session that read them, dated when each was *billed* -
+ *   days before that session ever started. Measured on 2026-09-04, 96.2% of a real period
+ *   fell here and read `"precedes-declaration"`, which told a person their flow declares its
+ *   task late in 96% of cases when fewer than one in five hundred of those records actually
+ *   did. Separated for the same reason `"no-journal"` was separated from `"no-declaration"`:
+ *   a fact about what the journal could cover is not a fact about how the work behaved.
+ *   Decided before `"no-declaration"`, so a journal that declared nothing *and* did not cover
+ *   the record is named by the coverage fact - the one that explains why no declaration
+ *   could have covered it. Keyed on the journal's own earliest witnessed moment, never on
+ *   its `session_start` line, which would be a second notion of when a session began.
  * - `"precedes-declaration"`: a task was declared, but some declared interval starts *after*
  *   this moment. Since 2026-09-04 that means one thing only — a record before the session's
  *   very first declaration. Intervals now run contiguously from each declaration to the
  *   next, so the gap a `turn_end` used to leave between two of them no longer exists, and
- *   the test that described it was deleted rather than reworded.
+ *   the test that described it was deleted rather than reworded. Since the reason above
+ *   joined it, this is only ever a record the journal did witness: a genuinely late
+ *   declaration, which is what the words say.
  * - `"journal-silent"`: a task was declared, every declared interval starts at or before this
  *   moment, and still none of them reaches it - the journal's own declared coverage ran out
  *   before this record's moment did. A record with no moment at all, or an unparseable one,
@@ -145,6 +160,7 @@ export function buildTaskIntervals(
  *   undated record off before any of this runs - but the function stays correct standalone. */
 export type TaskUnattributedReason =
   | "no-journal"
+  | "precedes-journal"
   | "no-declaration"
   | "precedes-declaration"
   | "journal-silent";
@@ -154,17 +170,30 @@ export type TaskUnattributedReason =
  * ordered by how much of a period each accounted for. */
 export const TASK_UNATTRIBUTED_REASONS: readonly TaskUnattributedReason[] = [
   "no-journal",
+  "precedes-journal",
   "no-declaration",
   "precedes-declaration",
   "journal-silent",
 ];
 
+/** `journalFirstWitnessedMs` is the earliest moment this session's journal witnessed, absent
+ * for a journal that carries no readable moment at all. Absent means no coverage claim, never
+ * a `0` that would place every record after it: a journal that witnessed nothing cannot
+ * testify that a record predates it. */
 export function taskUnattributedReason(
   intervals: readonly TaskInterval[],
-  momentIso: string | undefined
+  momentIso: string | undefined,
+  journalFirstWitnessedMs?: number
 ): TaskUnattributedReason {
-  if (intervals.length === 0) return "no-declaration";
   const momentMs = momentIso === undefined ? Number.NaN : Date.parse(momentIso);
+  if (
+    !Number.isNaN(momentMs) &&
+    journalFirstWitnessedMs !== undefined &&
+    momentMs < journalFirstWitnessedMs
+  ) {
+    return "precedes-journal";
+  }
+  if (intervals.length === 0) return "no-declaration";
   if (Number.isNaN(momentMs)) return "journal-silent";
   const somethingDeclaredAfter = intervals.some((interval) => interval.startMs > momentMs);
   return somethingDeclaredAfter ? "precedes-declaration" : "journal-silent";

--- a/cli/tests/domain/models/cost-report-task.unit.test.ts
+++ b/cli/tests/domain/models/cost-report-task.unit.test.ts
@@ -319,6 +319,48 @@ describe("buildCostReport — by_task groups by the declared interval a record f
 
     expect(built.byTasks).toHaveLength(1);
     expect(built.byTasks[0]?.task).toBeUndefined();
+    expect(built.byTasks[0]?.reason).toBe("precedes-journal");
+  });
+
+  // The live shape, and what the reason is for. A resumed transcript hands over turns billed
+  // days before the session that read them opened its journal; the same session then declares
+  // a task and works inside it. Both records are unattributed and they are unattributed for
+  // two different reasons - one predates the journal entirely, one is a genuinely late
+  // declaration - and one row for both would say the flow declared late in every case.
+  it("separates a record older than its journal from one that merely preceded a declaration", () => {
+    const journals: readonly CostReportSessionJournal[] = [
+      {
+        vendorId: "s-resumed",
+        tool: "claude-code",
+        writtenPaths: [],
+        taskIntervals: [
+          {
+            path: "aidd_docs/tasks/2026_08/first-task/plan.md",
+            startMs: Date.parse("2026-08-21T10:00:00Z"),
+            endMs: Date.parse("2026-08-21T12:00:00Z"),
+          },
+        ],
+        flowIntervals: [],
+        witnessed: {
+          fromMs: Date.parse("2026-08-21T09:00:00Z"),
+          toMs: Date.parse("2026-08-21T12:00:00Z"),
+        },
+      },
+    ];
+    const records: readonly TelemetrySinkRecord[] = [
+      request({ vendor_id: "s-resumed", event_timestamp: "2026-08-17T10:00:00Z" }),
+      request({ vendor_id: "s-resumed", event_timestamp: "2026-08-21T09:30:00Z" }),
+      request({ vendor_id: "s-resumed", event_timestamp: "2026-08-21T11:00:00Z" }),
+    ];
+
+    const built = report({ records, journals });
+
+    expect(built.byTasks).toEqual([
+      { task: FIRST_TASK, attribution: "declared", totals: expect.anything() },
+      { reason: "precedes-journal", totals: expect.anything() },
+      { reason: "precedes-declaration", totals: expect.anything() },
+    ]);
+    expect(sumOf(built.byTasks).requests).toBe(built.totals.requests);
   });
 
   it("never lets the whole-session written-path inference the --task filter uses leak into this breakdown", () => {

--- a/cli/tests/domain/models/task-attribution.unit.test.ts
+++ b/cli/tests/domain/models/task-attribution.unit.test.ts
@@ -244,7 +244,7 @@ describe("task-attribution — pure: journal lines -> bounded intervals", () => 
   });
 });
 
-describe("taskUnattributedReason — which of three distinct facts applies", () => {
+describe("taskUnattributedReason — which of four distinct facts applies", () => {
   it("names no-declaration for a session whose journal never declared a task", () => {
     expect(taskUnattributedReason([], "2026-08-17T10:00:00Z")).toBe("no-declaration");
   });
@@ -261,6 +261,47 @@ describe("taskUnattributedReason — which of three distinct facts applies", () 
   // contiguously from each declaration to the next and no such gap can arise.
   // `precedes-declaration` stays reachable only before a session's first declaration,
   // which the test above covers.
+
+  // The live case, and the reason this reason exists. A resumed transcript carries turns
+  // billed days before the session that read them ever started, so the sink dates them
+  // before its journal witnessed anything. Measured on 2026-09-04: 96.2% of a real period
+  // fell here and read `precedes-declaration`, which asserts the flow declared late.
+  it("names precedes-journal for a record older than everything its journal witnessed", () => {
+    const intervals = buildTaskIntervals(journalOf([WANTED], [TURN_END]));
+    const journalFromMs = Date.parse("2026-08-17T09:30:00Z");
+
+    expect(taskUnattributedReason(intervals, "2026-08-10T12:00:00Z", journalFromMs)).toBe(
+      "precedes-journal"
+    );
+  });
+
+  it("still names precedes-declaration inside the span, before the first declaration", () => {
+    const intervals = buildTaskIntervals(journalOf([WANTED], [TURN_END]));
+    const journalFromMs = Date.parse("2026-08-17T09:30:00Z");
+
+    expect(taskUnattributedReason(intervals, "2026-08-17T09:45:00Z", journalFromMs)).toBe(
+      "precedes-declaration"
+    );
+  });
+
+  // Why the coverage check runs first: a journal that declared nothing and never covered
+  // this record is described by the coverage fact, which is the one that explains why no
+  // declaration could have covered it.
+  it("names precedes-journal, not no-declaration, when the journal declared nothing either", () => {
+    const journalFromMs = Date.parse("2026-08-17T09:30:00Z");
+
+    expect(taskUnattributedReason([], "2026-08-10T12:00:00Z", journalFromMs)).toBe(
+      "precedes-journal"
+    );
+  });
+
+  it("never claims coverage for a journal that carries no readable moment", () => {
+    const intervals = buildTaskIntervals(journalOf([WANTED], [TURN_END]));
+
+    expect(taskUnattributedReason(intervals, "2026-08-10T12:00:00Z", undefined)).toBe(
+      "precedes-declaration"
+    );
+  });
 
   it("names journal-silent for a record after the last declared interval's own end", () => {
     const intervals = buildTaskIntervals(journalOf([WANTED], [TURN_END]));

--- a/cli/tests/e2e/telemetry-lifecycle.e2e.test.ts
+++ b/cli/tests/e2e/telemetry-lifecycle.e2e.test.ts
@@ -260,6 +260,6 @@ describe("measurement, from nothing to off and back", () => {
     const { measurement_enabled: _before, ...historicalFigures } = envelope;
     const { measurement_enabled: _after, ...historicalFiguresAfterOff } = afterOff;
     expect(historicalFiguresAfterOff).toEqual(historicalFigures);
-    expect(envelope.cost_report_version).toBe(13);
+    expect(envelope.cost_report_version).toBe(14);
   }, 60_000);
 });

--- a/cli/tests/e2e/telemetry-multi-tool.e2e.test.ts
+++ b/cli/tests/e2e/telemetry-multi-tool.e2e.test.ts
@@ -444,7 +444,7 @@ describe("the flow a person can actually follow", () => {
     expect(first.exitCode, first.stderr).toBe(0);
     expect(second.stdout).toBe(first.stdout);
     const parsed = JSON.parse(first.stdout);
-    expect(parsed.cost_report_version).toBe(13);
+    expect(parsed.cost_report_version).toBe(14);
     expect(parsed.period).toEqual({ from_day: "2026-07-01", to_day: "2026-07-31" });
     expect(parsed.attribution.map((row: { attribution: string }) => row.attribution)).toEqual([
       "tool-stated",

--- a/cli/tests/fixtures/cli-owns-read/expected-envelope.json
+++ b/cli/tests/fixtures/cli-owns-read/expected-envelope.json
@@ -1,5 +1,5 @@
 {
-  "cost_report_version": 13,
+  "cost_report_version": 14,
   "period": {
     "from_day": "2026-01-01",
     "to_day": "2026-01-31"

--- a/plugins/aidd-telemetry/skills/01-cost/actions/03-report.md
+++ b/plugins/aidd-telemetry/skills/01-cost/actions/03-report.md
@@ -65,7 +65,7 @@ else.
 
 | Task | Share | Tokens | Attribution |
 | --- | --- | --- | --- |
-| <task, or the reason it fell in none: "no usable run journal for this session" \| "no usable task declaration in this session" \| "before the next task this session declares" \| "the journal falls silent before this record"> | <n>% | <tokens> | <declared by the flow \| inferred from a written file \| —> |
+| <task, or the reason it fell in none: "no usable run journal for this session" \| "older than anything this session's journal witnessed" \| "no usable task declaration in this session" \| "before the next task this session declares" \| "the journal falls silent before this record"> | <n>% | <tokens> | <declared by the flow \| inferred from a written file \| —> |
 
 **By backlog item**
 
@@ -93,9 +93,14 @@ A breakdown the object leaves empty is a section left out, never a table of zero
    - One axis: `aidd telemetry report --axis <axis> --from 2026-08-01 --to 2026-08-31`.
    - Everything: `aidd telemetry report --from 2026-08-01 --to 2026-08-31 --json`, reading the shape from [cost-report-contract.md](../../../../../aidd_docs/product/cost-report-contract.md).
    - The figure will be kept or compared: give `--from` and `--to`, since `--days` resolves against today and two identical calls on two days cover two different periods.
-3. **Refuse an unknown shape.** `cost_report_version` is `13` today, read from the `--json`
+3. **Refuse an unknown shape.** `cost_report_version` is `14` today, read from the `--json`
    path - the `--axis` path prints text the script already built from that same object, so
-   there is no separate version to check there. The bump from `12` to `13` added `by_prompt`
+   there is no separate version to check there. The bump from `13` to `14` did not add a
+   breakdown: the reasons a `by_task` or `by_backlog` row can carry gained a fifth,
+   `precedes-journal`, for a record older than everything its own session's journal
+   witnessed. Report it as what it is - work billed before that session opened a journal,
+   which a resumed transcript carries - never as the flow declaring its task late. The bump
+   from `12` to `13` added `by_prompt`
    to the top-level breakdowns: the prompt that caused the work, the one breakdown no host
    limit can leave empty, since every record the reader stores already carries the turn it
    came from. The bump from `11` to `12` did not add a

--- a/scripts/__tests__/aidd-telemetry-cost-skill.test.js
+++ b/scripts/__tests__/aidd-telemetry-cost-skill.test.js
@@ -300,6 +300,22 @@ test("the check skill calls the CLI, never a script of its own", () => {
   assert.ok(!/\.cjs\b/u.test(check), "must not name a script beside itself any more");
 });
 
+// The skill names the version it refuses to read past. Nothing checked that number against
+// the one the CLI emits, so a bump could ship with the skill still naming the version
+// before it - a skill that then refuses the object it was built to read. Same guard the
+// contract document already has (`cost-report-contract.unit.test.ts`), for the second place
+// the number is written down.
+test("the cost skill names the envelope version the CLI actually emits", () => {
+  const envelopeSource = fs.readFileSync(
+    path.resolve(__dirname, "../../cli/src/domain/models/cost-report-envelope.ts"),
+    "utf8",
+  );
+  const emitted = /COST_REPORT_ENVELOPE_VERSION = (\d+)/u.exec(envelopeSource)?.[1];
+  const named = /`cost_report_version` is `(\d+)` today/u.exec(everything)?.[1];
+
+  assert.equal(named, emitted, "the skill's stated version must be the one the CLI emits");
+});
+
 // A skill told to "report what it printed" leaves the shape to the model, and two runs
 // answer differently. The shape is stated so a user reads the same table every time.
 test("the cost skill states the shape of its answer", () => {


### PR DESCRIPTION
## What it says today

`by_task` tells a person their flow declares its task late in **96.2%** of a real period.

Measured on this project's own sink, 29,207 requests over 2026-08-01..09-30: of the 28,101
requests reading `"before the next task this session declares"`, **22 actually did**.

## Why

The rest are older than anything their session's journal witnessed. Reading a resumed
transcript stores the turns it inherited under the session that read them, dated when each
was *billed* — days before that session ever opened a journal. There was no journal to
declare anything in, so nothing was declared late.

Verified on both of this repository's run journals that `min(at)` over every line equals the
`session_start` line, so the journal's own `witnessed.fromMs` — which already exists, and
which the `"inferred"` bound already reads — is the key, not a second notion of when a
session began.

## The change

A fifth `TaskUnattributedReason`, `"precedes-journal"`. Decided before `"no-declaration"`, so
a journal that declared nothing *and* did not cover the record is named by the coverage
fact — the one that explains why no declaration could have covered it.

The same separation `"no-journal"` made from `"no-declaration"` at version 11, one level
down: a fact about what the journal could cover is not a fact about how the work behaved.

## Proven end to end

Built binary, the real sink copied read-only into a sandbox `HOME` and
`AIDD_USER_CONFIG_DIR`, same command on both builds:

| Row | `origin/next` | this branch |
| --- | --- | --- |
| older than anything this session's journal witnessed | — | 28,079 |
| before the next task this session declares | 28,101 | **22** |
| no usable run journal for this session | 33 | 33 |
| named tasks (5 rows) | 1,073 | 1,073 |

`by_task` and `by_backlog` both sum to 29,207 — the period total — on both builds.

## Guards, each with the mutation that kills it

| Guard | Mutation |
| --- | --- |
| a record older than everything its journal witnessed reads `"precedes-journal"` | drop the coverage check |
| a record inside the span, before the first declaration, still reads `"precedes-declaration"` | widen the check to every unattributed record |
| a journal that declared nothing and did not cover the record is named by the coverage fact | order the coverage check after the empty-intervals check |
| a journal carrying no readable moment never claims coverage | default an absent span to `Infinity` |
| the report passes the journal's span, not only the function | drop the third argument at the call site |
| every consumer names the fifth reason | remove one key from `TASK_UNATTRIBUTED_LABELS` |

Rejected as an equivalent mutant: defaulting an absent span to `0`. Every moment this
function is ever asked about is after 1970, so the mutant behaves identically.

## Found while making the change

Nothing checked the `cost_report_version` the **skill** names against the one the CLI emits.
The contract document has had that guard since version 10; the skill, which refuses any
object whose version it does not know, had none — so a bump could ship leaving it set to
refuse the object it was built to read. Added, and it failed before `03-report.md` was
updated.

## Envelope

`cost_report_version` `13` → `14`. A consumer switching exhaustively on the four previous
reasons must add this one; every row's `totals` still reconciles.

Rebased onto #757 once it merged, so this takes `14`. Found in that rebase: #757 bumped the number and never wrote its entry in the contract's version history, which jumped from `currently 13` straight to "Bumped from `11`". Both entries are written here.
Whichever lands second renumbers to `14` — the constant, the contract heading and its
version history, the skill, and the fixture envelope.

## Gates

`pnpm build` + `vitest run` 3392/3392 · `tsc --noEmit` · `biome ci` · `knip --production` ·
`jscpd` · bundle 588.6/590 KB · repo `node --test scripts/__tests__` 366/366 · markdown
links 0 broken · catalogs and README counts regenerate to no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWNxk63AGKkqE8HRqHLjGp