### PR TITLE
test(cli): the smoke harness runs in its own home, not the user's

### DIFF
--- a/cli/scripts/smoke-tools.sh
+++ b/cli/scripts/smoke-tools.sh
@@ -106,6 +106,19 @@ trap 'rm -rf "$TMPROOT"' EXIT
 TOKEN="${AIDD_TOKEN:-$(gh auth token 2>/dev/null || true)}"
 export AIDD_TOKEN="$TOKEN"
 
+# Only now, never earlier: `gh auth token` above reads the REAL home, and moving it first
+# makes every authenticated case silently unauthenticated.
+#
+# Three of the tools this harness loops over activate plugins through their own CLI, and
+# those write into the USER's home, not the project directory - a fresh /tmp project
+# isolates nothing there. Until this existed the harness sandboxed AIDD_USER_CONFIG_DIR for
+# every case and HOME for exactly one, so `plugin install --tool codex|copilot|claude` ran
+# against the real ~/.claude, ~/.codex and ~/.copilot of whoever typed `pnpm smoke`.
+# CODEX_HOME is separate because HOME does not move Codex: it reads that variable, and falls
+# back to the real ~/.codex when it is unset.
+export HOME="$TMPROOT/home"; mkdir -p "$HOME"
+export CODEX_HOME="$TMPROOT/codex-home"; mkdir -p "$CODEX_HOME"
+
 # ════════════════════════════════════════════════════════════════
 # OFFLINE / LOCAL — runs without a token
 # ════════════════════════════════════════════════════════════════

--- a/cli/tests/infrastructure/smoke-harness-isolation.unit.test.ts
+++ b/cli/tests/infrastructure/smoke-harness-isolation.unit.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const harness = readFileSync(
+  fileURLToPath(new URL("../../scripts/smoke-tools.sh", import.meta.url)),
+  "utf8"
+);
+
+/** The smoke harness drives the real binary across every command and every tool, and three
+ * of those tools activate plugins through their own CLI - which writes into the *user's*
+ * home, never the project directory. A fresh `/tmp` project isolates nothing there.
+ *
+ * `testing.md` has stated the rule since the work that discovered it ("this work polluted
+ * the repo + `~/.copilot` twice before the env-sandbox was right"), and nothing enforced it:
+ * the harness sandboxed `AIDD_USER_CONFIG_DIR` for every case and `HOME` for exactly one,
+ * so `plugin install --tool codex|copilot|claude` ran against the real home of whoever ran
+ * `pnpm smoke`. */
+describe("the smoke harness never runs against the real user home", () => {
+  it("gives every case a home under its own temporary root", () => {
+    expect(harness).toMatch(/export HOME="\$TMPROOT\/[^"]+"/u);
+  });
+
+  // `HOME` does not isolate Codex: it reads `CODEX_HOME`, and falls back to the real
+  // `~/.codex` when that is unset.
+  it("gives Codex its own home too, which HOME alone does not move", () => {
+    expect(harness).toMatch(/export CODEX_HOME="\$TMPROOT\/[^"]+"/u);
+  });
+
+  // Ordering is the whole guard: the token is resolved through `gh`, which reads the real
+  // home. Exporting the sandbox before that line makes every authenticated case silently
+  // unauthenticated, so the sandbox must come after it and before the first case that runs.
+  it("resolves the token before moving home, and moves it before the first case", () => {
+    const token = harness.indexOf("gh auth token");
+    const home = harness.search(/export HOME="\$TMPROOT/u);
+    const firstCase = harness.indexOf("section ");
+
+    expect(token).toBeGreaterThan(-1);
+    expect(home).toBeGreaterThan(token);
+    expect(home).toBeLessThan(firstCase);
+  });
+});


### PR DESCRIPTION
## The defect

`pnpm smoke` drives the real binary across 70 cases and five tools. Three of those tools
activate plugins through their own CLI, and those write into the **user's home**, not the
project directory — a fresh `/tmp` project isolates nothing there.

```
scripts/smoke-tools.sh:103   export AIDD_USER_CONFIG_DIR   # all 70 cases
scripts/smoke-tools.sh:133   env HOME=…                     # exactly one case (auth login)
scripts/smoke-tools.sh:222   plugin install aidd-dev --tool <claude|codex|copilot|…>
```

So line 222 ran against the real `~/.claude`, `~/.codex` and `~/.copilot` of whoever typed
`pnpm smoke`. `testing.md` has stated the rule since the work that found it — *"this work
polluted the repo + `~/.copilot` twice before the env-sandbox was right"* — and nothing
enforced it.

## The change

`HOME` and `CODEX_HOME` exported for the whole run, under the harness's own `$TMPROOT`.

Both, because `HOME` does not move Codex: it reads `CODEX_HOME` and falls back to the real
`~/.codex` when unset.

Placed **after** `gh auth token`, never before — that call reads the real home. Measured: a
run that moves home first silently loses its token and covers **13 of 70** cases at 29%
coverage instead of 70 at 100%.

## Guards, each red before the change

| Guard | Mutation |
| --- | --- |
| every case gets a home under the harness's own temporary root | drop the `export HOME` |
| Codex gets its own home too | drop the `export CODEX_HOME` |
| token resolved before home moves, home moves before the first case | move the export above `gh auth token` |

## What is and is not demonstrated

**Not demonstrated by running the unfixed harness.** Demonstrating it means writing into the
real home this change exists to protect. The argument is the shell's own: nothing exported
`HOME`, so every spawned CLI inherited the real one — `AbstractNativePluginCliAdapter.run`
calls `spawnSync` with no `env`, so it passes the harness's environment straight through.

**Measured**, `origin/next` and this branch, both with an externally sandboxed home and
`AIDD_TOKEN` pre-resolved so coverage is comparable:

| | PASS | FAIL | coverage |
| --- | --- | --- | --- |
| `origin/next` | 70 | 7 | 100% |
| this branch | 70 | 7 | 100% |

Identical — **the seven failures are pre-existing**, not this change:

```
update (exit 1, want 0)            Use --force to overwrite modified files
ai update (all) (exit 1, want 0)   idem
.aidd survived clean
corrupt → non-actionable (×4)      Plugin 'aidd-dev' is already installed.
```

Worth their own issue; out of scope here.

The writes seen in the real `~/.codex` during both runs are an **ambient codex process**,
not the harness: a 240-second window with no harness running touches the same three files
(`logs_2.sqlite-wal`, `logs_2.sqlite-shm`, `models_cache.json`). Two direct probes confirm
the variable is honoured — `codex --version` and `codex plugin list` under a sandboxed
`CODEX_HOME` touch nothing real.

## Gates

`pnpm build` + `vitest run` 3390/3390 across 306 files · `tsc --noEmit` · `biome ci` ·
`knip --production` · bundle within budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWNxk63AGKkqE8HRqHLjGp
