### PR TITLE
fix(telemetry): an identity names the work it already did

### DIFF
--- a/aidd_docs/product/cost-report-contract.md
+++ b/aidd_docs/product/cost-report-contract.md
@@ -131,7 +131,20 @@ real count is the ordinary case of reporting from a project whose switch never c
 work, never a contradiction (see "Attributing records to a task" for the same scope split
 elsewhere in this object).
 
-Every object carries `cost_report_version`, currently `14`.
+Every object carries `cost_report_version`, currently `15`.
+
+Bumped from `14` when `by_person`'s `resolution` gained a fourth value,
+**`"this-machine"`**: the record carried no identifier of its own, and this machine has
+declared an identity. It exists because `person_id` is written onto a record when the record
+is *stored*, so whether one carries it depends on when the identity was declared relative to
+when that record was read — never on the work. Measured on a live machine: 29,207 requests,
+every one read by that machine's own `aidd`, and `by_person` could name none of them; the
+same sink, the same identity file, answered differently depending on the order those two
+things happened in. Declaring an identity now names the whole history rather than only what
+follows. Sound because the sink has exactly one writer and every line it holds carries
+`provenance: "local-read"` — a record in it was read by this machine's own reader. A consumer
+that switched exhaustively on the three previous values must add this one; every row's
+`totals` still reconciles to the period total.
 
 Bumped from `13` when the reasons a `by_task` or `by_backlog` row can carry gained a
 fifth, **`"precedes-journal"`**: this record's moment is older than the earliest moment its
@@ -252,7 +265,7 @@ one. Adding a field you may ignore is not a bump; changing what an existing fiel
 
 ```jsonc
 {
-  "cost_report_version": 14,
+  "cost_report_version": 15,
   "period": { "from_day": "2026-07-01", "to_day": "2026-07-31" },
   "measurement_enabled": true,                  // this project's own switch, right now — see Versioning
   "task": "2026_08/2026_08_21_cost-reporter",   // absent unless --task was given
@@ -479,20 +492,21 @@ always carries them all.
 never against a git author, an email or a hostname. That file describes exactly one person:
 its own `person_id`, how it was obtained (`origin`: `"minted"` here or `"adopted"` from
 another machine), and every identifier added onto it with `aidd telemetry identity link`
-(`also_me`). Each row's `resolution` is one of three:
+(`also_me`). Each row's `resolution` is one of four:
 
 | `resolution` | Means |
 | --- | --- |
 | `mapped` | The identifier is this machine's own person — its `person_id` or a member of `also_me`. `person` carries the canonical identifier, and `identities` carries every raw identifier behind the row, including that canonical one. |
 | `unresolved` | The identifier is real, but the identity file does not cover it. `identities` carries that one raw identifier; `person` is absent. |
-| `none` | The record carried no identifier at all — a different fact from `unresolved`: nobody opted in, rather than somebody did on a machine or tool this identity has not heard of. |
+| `this-machine` | The record carried no identifier of its own, and this machine has declared an identity. `person` and `identities` carry that identity exactly as a `mapped` row does; the two are kept apart because they are different facts — `mapped` is the record naming a person this identity claims, this is the identity claiming a record that named nobody. |
+| `none` | The record carried no identifier at all **and** no identity is declared — a different fact from `unresolved`: nobody opted in, rather than somebody did on a machine or tool this identity has not heard of. |
 
 **Two raw identifiers one person declared merge into one `mapped` row; two unplaced
 identifiers never merge into each other.** The identity file describes exactly one person,
 so there is no shape in which two people could claim one identifier in the first place —
-unlike a lookup table, nothing here can be edited into that state. Rows are ordered mapped
-first, then every unresolved identity, then the one `none` row last; largest first within
-the mapped and the unresolved groups.
+unlike a lookup table, nothing here can be edited into that state. Rows are ordered by how strong the claim is: `mapped`
+first, then the one `this-machine` row, then every unresolved identity, then the one `none`
+row last; largest first within each group.
 
 `by_person` sums to `totals.requests` exactly like every other breakdown — a damaged or
 undeclared identity changes how records are labelled, never how many are counted.

--- a/aidd_docs/tasks/2026_09/2026_09_04_an-identity-names-past-work/plan.md
+++ b/aidd_docs/tasks/2026_09/2026_09_04_an-identity-names-past-work/plan.md
@@ -1,0 +1,88 @@
+---
+status: done
+---
+
+# An identity names the work it already did
+
+## The defect
+
+`person_id` is stamped onto a record in `stampProvenanceAndTool`, at the moment the record
+is stored. So what a period reports for `by_person` depends on **when the identity was
+declared relative to when each record was read**, not on the work itself.
+
+Two reads of the same sink, with the same `identity.json`, answer differently depending on
+the order those two things happened in. That is the determinism defect, and it is the one
+`by_person`'s 0% on a real machine actually is: 29,207 requests, every one of them read by
+this machine's own `aidd`, none of them nameable by the person who ran them.
+
+It also contradicts this repository's own rule — *store what was observed, derive what was
+judged*. Which person a record belongs to is a judgement, and it is re-judgeable.
+
+## Measured before designing
+
+The fallback is only sound if a sink can hold exactly one person's records. It can:
+
+| Question | Answer |
+| --- | --- |
+| Callers of `TelemetrySink.appendRecord` | one, `read-local-cost-use-case.ts:537` |
+| `provenance` values across 29,699 stored lines | `local-read`, all of them |
+| Distinct `person_id` values | none — the field is absent on every line |
+| `sink_schema_version` values | `2`, all of them |
+
+Nothing else writes the sink, so every record in it was read by this machine's own reader.
+
+## The change
+
+`resolvePerson` gains a fourth `PersonResolution`, `"this-machine"`: the record carried no
+identifier of its own, and this machine has declared an identity. Deterministic given the
+pair (sink, `identity.json`), and retroactive — declaring once names the whole history.
+
+Kept apart from `"mapped"` rather than folded into it, because the two are not the same
+fact: `"mapped"` is the record naming a person this identity claims, `"this-machine"` is
+this identity claiming a record that named nobody. An attribution says its own strength.
+
+`"none"` stays reachable and keeps its meaning: no identifier on the record **and** no
+identity declared. A machine that never declared one reports exactly as it does today.
+
+Store-time stamping stays. The field is what an export carries to a destination, so a
+record must be able to name its own person without the reader's `identity.json` beside it.
+
+## Guards
+
+| Guard | Mutation that kills it |
+| --- | --- |
+| an unstamped record resolves to this machine's declared identity | drop the fallback branch |
+| an unstamped record with no identity declared still resolves `"none"` | fall back before the null-identity check |
+| a stamped identifier this identity does not claim still resolves `"unresolved"` | fall back before the match check |
+| the row carries the identity's own evidence, like a mapped row | return an empty `identities` |
+| every renderer names the fourth value rather than silently reading it as "no identifier" | add the value without touching `personLabel` |
+
+## Envelope
+
+`cost_report_version` `14` -> `15`: `by_person`'s `resolution` gains a value a consumer
+switching exhaustively on the three previous ones does not know.
+
+## Proven end to end
+
+Built binary, the real sink copied read-only into a sandbox, one `identity.json` written in
+a sandboxed `HOME`, same command on both builds:
+
+| Build | `by_person` |
+| --- | --- |
+| `origin/next` | `no identity — nobody opted in` — 29,207 requests, 0 named |
+| this branch | `A Person` — 29,207 requests, **100% named** |
+
+Same sink, same identity file, same period. Nothing was re-read and no record was rewritten:
+the difference is entirely that the judgement now happens where it can be re-made.
+
+## Found while making the change
+
+`personRows` selected its output with one filter per resolution and concatenated them, so a
+`"this-machine"` row summed into no group and vanished — the rows existed, the totals they
+belonged to stayed, and the breakdown silently stopped reconciling by omission. `personLabel`
+had the same shape one layer up: an if-chain whose fallback printed any unnamed resolution as
+"nobody opted in", the exact opposite of what the row said.
+
+Both are now written over the whole union as a `Record<PersonResolution, …>`, so the next
+value added fails to compile in both places instead of disappearing in one and being
+mislabelled in the other.

--- a/cli/src/application/display/cost-report-artefact.ts
+++ b/cli/src/application/display/cost-report-artefact.ts
@@ -10,6 +10,7 @@ import type {
   CostReportEnvelopeTotals,
 } from "../../domain/models/cost-report-envelope.js";
 import { bareOrchestratingSkillNames } from "../../domain/models/flow-attribution.js";
+import type { PersonResolution } from "../../domain/models/person-resolution.js";
 import { getAiToolConfig } from "../../domain/tools/registry.js";
 import {
   ATTRIBUTION_LABELS,
@@ -376,10 +377,24 @@ function mappedPersonLabel(row: CostReportEnvelopePersonRow): string {
   return row.display_name ?? row.person ?? "";
 }
 
+/** One label per resolution, exhaustively - a `Record` rather than an if-chain with a
+ * fallback, so a value added to `PersonResolution` fails to compile here instead of
+ * reaching a reader as "nobody opted in". That is not hypothetical: `this-machine` was
+ * added on 2026-09-04 and the fallback swallowed it silently, printing rows a declared
+ * identity claims as rows nobody claimed. Same mechanism `TASK_UNATTRIBUTED_LABELS` uses
+ * one axis over. */
+const PERSON_LABELS: Record<PersonResolution, (row: CostReportEnvelopePersonRow) => string> = {
+  mapped: mappedPersonLabel,
+  // This machine's own person, reached because the record named nobody. The same label a
+  // mapped row gets: it is the same person, and the row's `resolution` already carries how
+  // it was reached for a reader who needs that.
+  "this-machine": mappedPersonLabel,
+  unresolved: (row) => unresolvedPersonLabel(row.identities[0] ?? ""),
+  none: () => NO_PERSON_IDENTIFIER,
+};
+
 function personLabel(row: CostReportEnvelopePersonRow): string {
-  if (row.resolution === "mapped") return mappedPersonLabel(row);
-  if (row.resolution === "unresolved") return unresolvedPersonLabel(row.identities[0] ?? "");
-  return NO_PERSON_IDENTIFIER;
+  return PERSON_LABELS[row.resolution](row);
 }
 
 /** A third column beside every other axis's two, because a person line the contract can

--- a/cli/src/domain/models/cost-report-envelope.ts
+++ b/cli/src/domain/models/cost-report-envelope.ts
@@ -102,7 +102,7 @@ import type { AiToolId } from "./tool-ids.js";
  * `by_project`'s `project` to optional back when that row was added.
  *
  * Bumped to 2: `by_project` and `by_day` are new top-level breakdowns. */
-export const COST_REPORT_ENVELOPE_VERSION = 14;
+export const COST_REPORT_ENVELOPE_VERSION = 15;
 
 /** Money as whole micro-dollars, the way the report carries it: an integer, so a consumer
  * summing several reports gets the same answer this one did. Divide by 1,000,000 for

--- a/cli/src/domain/models/cost-report.ts
+++ b/cli/src/domain/models/cost-report.ts
@@ -1589,28 +1589,42 @@ function personRowOf(group: PersonGroup): CostReportPersonRow {
   };
 }
 
-/** Mapped people first, then every unplaced identity, then the one no-identifier row last -
- * `bySize` alone cannot give this order, since it sorts purely on weight and a large
- * unresolved row would otherwise outrank a small mapped one. Largest first within the
- * mapped group and within the unresolved group; the no-identifier row is never sorted
- * against either, since there is at most one. */
+/** The order every `by_person` breakdown is read in, strongest claim first: a person the
+ * record itself named, then the one this machine's identity claims for records that named
+ * nobody, then every unplaced identity, then the one no-identifier row.
+ *
+ * A `Record` over the whole union rather than a filter per group, because a filter per
+ * group silently *drops* whatever it does not name - which is what happened when
+ * `"this-machine"` was added on 2026-09-04: the rows existed, summed into no group, and
+ * vanished from the breakdown while the totals they belonged to stayed. This shape makes
+ * that a compile error. */
+const PERSON_ROW_ORDER: Record<PersonResolution, number> = {
+  mapped: 0,
+  "this-machine": 1,
+  unresolved: 2,
+  none: 3,
+};
+
+/** Grouped in `PERSON_ROW_ORDER`, largest first within each group - `bySize` alone cannot
+ * give this order, since it sorts purely on weight and a large unresolved row would
+ * otherwise outrank a small mapped one. Sorting inside the single-row groups
+ * (`"this-machine"`, `"none"`, at most one each) costs nothing and needs no exception. */
 function personRows(
   people: ReadonlyMap<PersonRowKey, PersonGroup>
 ): readonly CostReportPersonRow[] {
   const rows = [...people.values()].map(personRowOf);
   const keyOf = (row: CostReportPersonRow) => row.person ?? row.identities[0] ?? "";
-  const mapped = bySize(
-    rows.filter((row) => row.resolution === "mapped"),
-    (row) => row.totals,
-    keyOf
-  );
-  const unresolved = bySize(
-    rows.filter((row) => row.resolution === "unresolved"),
-    (row) => row.totals,
-    keyOf
-  );
-  const none = rows.filter((row) => row.resolution === "none");
-  return [...mapped, ...unresolved, ...none];
+  return Object.keys(PERSON_ROW_ORDER)
+    .sort(
+      (a, b) => PERSON_ROW_ORDER[a as PersonResolution] - PERSON_ROW_ORDER[b as PersonResolution]
+    )
+    .flatMap((resolution) =>
+      bySize(
+        rows.filter((row) => row.resolution === resolution),
+        (row) => row.totals,
+        keyOf
+      )
+    );
 }
 
 /**

--- a/cli/src/domain/models/person-resolution.ts
+++ b/cli/src/domain/models/person-resolution.ts
@@ -7,11 +7,27 @@ import type { PersonIdentity } from "../ports/person-identity-reader.js";
  * - `"mapped"` — the identifier is this machine's own person: their `personId`, or one of
  *   the identifiers listed in `alsoMe`.
  * - `"unresolved"` — the identifier is real, but nobody's identity covers it.
- * - `"none"` — there was no identifier to resolve at all, a different fact from one nobody
- *   claimed: a record with no identifier says nobody opted in, while an unresolved one says
+ * - `"this-machine"` — the record carried no identifier of its own, and this machine has
+ *   declared an identity. Not folded into `"mapped"`, which is the record naming a person
+ *   this identity claims; this is the identity claiming a record that named nobody.
+ *
+ *   It exists because `person_id` is stamped when a record is *stored*
+ *   (`stampProvenanceAndTool`), so whether a record carries one depends on when the identity
+ *   was declared relative to when that record was read - never on the work itself. Two reads
+ *   of one sink, with one `identity.json`, answered differently depending on the order those
+ *   two things happened in. Measured on a live machine: 29,207 requests, every one read by
+ *   that machine's own `aidd`, and `by_person` could name none of them.
+ *
+ *   Sound because the sink has exactly one writer - `read-local-cost-use-case.ts` is the
+ *   only caller of `TelemetrySink.appendRecord`, and every line it writes carries
+ *   `provenance: "local-read"`. A record in this sink was read by this machine's own reader,
+ *   and this machine has said who that is. If a second writer is ever added, this branch is
+ *   the one that stops being true.
+ * - `"none"` — there was no identifier to resolve **and** no identity declared, a different
+ *   fact from one nobody claimed: it says nobody opted in, while an unresolved one says
  *   somebody did, on a machine or under a tool this identity has not heard of yet.
  */
-export type PersonResolution = "mapped" | "unresolved" | "none";
+export type PersonResolution = "mapped" | "unresolved" | "none" | "this-machine";
 
 /** What resolving one raw identifier against an identity answers. `identities` always
  * carries what produced the row — including the canonical `personId` when mapped, and the
@@ -28,6 +44,21 @@ function matches(identity: PersonIdentity, rawId: string): boolean {
   return identity.personId === rawId || identity.alsoMe.includes(rawId);
 }
 
+/** One identity, as the person a row names and the evidence behind it — shared by the two
+ * routes that end at this machine's own person so they cannot describe them differently.
+ *
+ * `alsoMe` can no longer contain `identity.personId` itself: `link` treats an identifier
+ * equal to the person's own as already listed and refuses to append it
+ * (`PersonIdentityUseCase.link`). No runtime check replaces that guard here — do not
+ * reintroduce a branch for a shape `link` no longer lets anyone write. */
+function claimedBy(identity: PersonIdentity): Omit<ResolvedPerson, "resolution"> {
+  return {
+    personId: identity.personId,
+    ...(identity.displayName === undefined ? {} : { displayName: identity.displayName }),
+    identities: [identity.personId, ...identity.alsoMe],
+  };
+}
+
 /**
  * Resolves one raw identifier against this machine's own identity — `identity` is `null`
  * for no identity declared at all, which resolves every identifier as `unresolved` exactly
@@ -35,9 +66,11 @@ function matches(identity: PersonIdentity, rawId: string): boolean {
  * figure the same way whether the gap is "no identity" or "an identity that does not know
  * this identifier".
  *
- * `rawId` undefined or empty answers `"none"` with no identities: nobody opted in is not a
- * failure to resolve, and is never conflated with an identifier this identity failed to
- * place.
+ * `rawId` undefined or empty answers `"this-machine"` when an identity is declared, and
+ * `"none"` with no identities when none is - nobody opted in is not a failure to resolve,
+ * and neither is ever conflated with an identifier this identity failed to place. The
+ * fallback is reached only when the record named nobody: an identifier it did carry is
+ * resolved on its own merits, mapped or unresolved, and this never overrules it.
  *
  * There is no shape here for two people claiming one identifier — `PersonIdentity`
  * describes exactly one machine's own user, so that ambiguity cannot be constructed, let
@@ -47,20 +80,15 @@ export function resolvePerson(
   identity: PersonIdentity | null,
   rawId: string | undefined
 ): ResolvedPerson {
-  if (rawId === undefined || rawId === "") return { resolution: "none", identities: [] };
+  if (rawId === undefined || rawId === "") {
+    return identity === null
+      ? { resolution: "none", identities: [] }
+      : { ...claimedBy(identity), resolution: "this-machine" };
+  }
   if (identity === null || !matches(identity, rawId)) {
     return { resolution: "unresolved", identities: [rawId] };
   }
-  return {
-    resolution: "mapped",
-    personId: identity.personId,
-    ...(identity.displayName === undefined ? {} : { displayName: identity.displayName }),
-    // `alsoMe` can no longer contain `identity.personId` itself: `link` treats an
-    // identifier equal to the person's own as already listed and refuses to append it
-    // (`PersonIdentityUseCase.link`). No runtime check replaces that guard here either -
-    // do not reintroduce a branch for a shape `link` no longer lets anyone write.
-    identities: [identity.personId, ...identity.alsoMe],
-  };
+  return { ...claimedBy(identity), resolution: "mapped" };
 }
 
 /** `identity` with `value` added to `alsoMe`, deduplicated, and never the person's own

--- a/cli/tests/application/display/cost-report-artefact.unit.test.ts
+++ b/cli/tests/application/display/cost-report-artefact.unit.test.ts
@@ -65,6 +65,22 @@ function onePersonMapping(): PersonIdentity {
 }
 
 describe("buildCostReportArtefact", () => {
+  // The row a declared identity now names retroactively. Rendered as that person, never as
+  // "nobody opted in": `personLabel` used to fall through to the no-identifier label for
+  // every resolution it did not name, so a value added to `PersonResolution` reached a
+  // reader as its opposite without the compiler saying a word.
+  it("names a row this machine's identity claims after that person, not as nobody", () => {
+    const envelope = envelopeOf({
+      records: [request({ turn_id: "a", event_timestamp: "2026-08-17T10:00:00Z" })],
+      identity: onePersonMapping(),
+    });
+
+    const artefact = buildCostReportArtefact(envelope, "person");
+
+    expect(artefact).toContain("Ada");
+    expect(artefact).not.toContain("nobody opted in");
+  });
+
   it("lists person among the known axes", () => {
     expect(ARTEFACT_AXES).toContain("person");
     expect(isArtefactAxis("person")).toBe(true);
@@ -143,9 +159,11 @@ describe("buildCostReportArtefact", () => {
     expect(unresolvedLines).toHaveLength(2);
   });
 
+  // No identity declared on this machine: only then is "nobody opted in" the truth for a
+  // record that carried no identifier. With one declared, that same record is this
+  // machine's own person - the case the test above pins.
   it("labels the no-identifier row distinctly from an unresolved one", () => {
     const envelope = envelopeOf({
-      identity: onePersonMapping(),
       records: [request({ turn_id: "a" }), request({ turn_id: "b", person_id: "a-stranger" })],
     });
 

--- a/cli/tests/domain/models/cost-report-person.unit.test.ts
+++ b/cli/tests/domain/models/cost-report-person.unit.test.ts
@@ -115,17 +115,31 @@ describe("byPeople — one raw identity resolved per group, never merged or drop
     ]);
   });
 
-  it("a record with no identifier lands in its own row, distinct from every unresolved one", () => {
+  // With an identity declared, a record that carried no identifier is this machine's own
+  // person: the sink has one writer, and every line in it was read by this machine. Kept
+  // apart from `mapped`, which is the record naming a person this identity claims.
+  it("a record with no identifier lands in this machine's own row, distinct from every unresolved one", () => {
     const built = report({
       identity: twoIdentitiesOnePerson(),
       records: [request({ turn_id: "a", person_id: "a-stranger" }), request({ turn_id: "b" })],
     });
 
+    const thisMachine = built.byPeople.filter((row) => row.resolution === "this-machine");
+    expect(thisMachine).toHaveLength(1);
+    expect(thisMachine[0]?.person).toBe("person-a");
+    const unresolved = built.byPeople.filter((row) => row.resolution === "unresolved");
+    expect(unresolved).toHaveLength(1);
+    expect(built.byPeople.filter((row) => row.resolution === "none")).toHaveLength(0);
+  });
+
+  // The other half of the same contract: with nothing declared, nobody opted in, and the
+  // report says exactly that rather than naming a person no file names.
+  it("a record with no identifier stays a no-identifier row when no identity was declared", () => {
+    const built = report({ records: [request({ turn_id: "b" })] });
+
     const none = built.byPeople.filter((row) => row.resolution === "none");
     expect(none).toHaveLength(1);
     expect(none[0]?.person).toBeUndefined();
-    const unresolved = built.byPeople.filter((row) => row.resolution === "unresolved");
-    expect(unresolved).toHaveLength(1);
   });
 
   it("summing every person row's requests equals the report's own total", () => {
@@ -189,8 +203,11 @@ describe("byPeople — one raw identity resolved per group, never merged or drop
     expect(built.totals.cacheCreationTokens).toBe(20);
   });
 
-  it("orders mapped rows first, then unresolved, then the no-identifier row last", () => {
-    const built = report({
+  // Strongest claim first, and every resolution present is placed - a filter per group
+  // drops whatever it does not name, which is exactly how `this-machine` rows went missing
+  // from this breakdown while the totals they belonged to stayed.
+  it("orders mapped rows first, then this machine's own, then unresolved, then no identifier", () => {
+    const withIdentity = report({
       identity: twoIdentitiesOnePerson(),
       records: [
         request({ turn_id: "a", person_id: "machine-1" }),
@@ -198,8 +215,30 @@ describe("byPeople — one raw identity resolved per group, never merged or drop
         request({ turn_id: "c" }),
       ],
     });
+    const withoutIdentity = report({ records: [request({ turn_id: "c" })] });
 
-    expect(built.byPeople.map((row) => row.resolution)).toEqual(["mapped", "unresolved", "none"]);
+    expect(withIdentity.byPeople.map((row) => row.resolution)).toEqual([
+      "mapped",
+      "this-machine",
+      "unresolved",
+    ]);
+    expect(withoutIdentity.byPeople.map((row) => row.resolution)).toEqual(["none"]);
+  });
+
+  // The determinism claim itself, stated as a test: the same sink and the same identity
+  // answer the same way whether or not the records were stamped when they were stored.
+  it("answers the same whether a record was stamped at store time or named at report time", () => {
+    const stamped = report({
+      identity: twoIdentitiesOnePerson(),
+      records: [request({ turn_id: "a", person_id: "person-a" })],
+    });
+    const unstamped = report({
+      identity: twoIdentitiesOnePerson(),
+      records: [request({ turn_id: "a" })],
+    });
+
+    expect(unstamped.byPeople[0]?.person).toBe(stamped.byPeople[0]?.person);
+    expect(unstamped.byPeople[0]?.totals.requests).toBe(stamped.byPeople[0]?.totals.requests);
   });
 });
 

--- a/cli/tests/domain/models/person-resolution.unit.test.ts
+++ b/cli/tests/domain/models/person-resolution.unit.test.ts
@@ -44,18 +44,50 @@ describe("resolvePerson", () => {
     expect(resolved.identities).toEqual(["nobody-claimed-this"]);
   });
 
-  it("resolves nothing at all as none, not unresolved", () => {
+  // The determinism fix. `person_id` is stamped when a record is stored, so whether a
+  // record carries one depends on when the identity was declared relative to when that
+  // record was read - not on the work. The sink has exactly one writer and every line in it
+  // is `local-read`, so a record that named nobody was read by this machine's own reader,
+  // and this machine has said who that is.
+  it("names an unstamped record after this machine's own declared identity", () => {
     const resolved = resolvePerson(identityWithAlsoMe(), undefined);
+
+    expect(resolved.resolution).toBe("this-machine");
+    expect(resolved.personId).toBe("person-a");
+    expect(resolved.displayName).toBe("Ada");
+  });
+
+  // Same evidence a mapped row carries, for the same reason: a person line must be
+  // traceable back to what produced it without a second lookup.
+  it("carries this identity's own identifiers as the evidence behind that row", () => {
+    const resolved = resolvePerson(identityWithAlsoMe(), undefined);
+
+    expect(resolved.identities).toEqual(["person-a", "claude-machine-1", "codex-machine-2"]);
+  });
+
+  it("resolves nothing at all as none when no identity was ever declared", () => {
+    const resolved = resolvePerson(null, undefined);
 
     expect(resolved.resolution).toBe("none");
     expect(resolved.identities).toEqual([]);
   });
 
-  it("distinguishes none from unresolved", () => {
-    const none = resolvePerson(identityWithAlsoMe(), undefined);
+  // The fallback must never overrule what a record actually said. An identifier this
+  // identity does not claim stays unresolved, and one it does claim stays mapped.
+  it("never lets the fallback overrule an identifier the record carried", () => {
+    const unresolved = resolvePerson(identityWithAlsoMe(), "nobody-claimed-this");
+    const mapped = resolvePerson(identityWithAlsoMe(), "claude-machine-1");
+
+    expect(unresolved.resolution).toBe("unresolved");
+    expect(mapped.resolution).toBe("mapped");
+  });
+
+  it("distinguishes none, this-machine and unresolved from one another", () => {
+    const none = resolvePerson(null, undefined);
+    const thisMachine = resolvePerson(identityWithAlsoMe(), undefined);
     const unresolved = resolvePerson(identityWithAlsoMe(), "nobody-claimed-this");
 
-    expect(none.resolution).not.toBe(unresolved.resolution);
+    expect(new Set([none.resolution, thisMachine.resolution, unresolved.resolution]).size).toBe(3);
   });
 
   it("two identifiers nobody added stay distinct, never merged into one bucket", () => {

--- a/cli/tests/e2e/telemetry-lifecycle.e2e.test.ts
+++ b/cli/tests/e2e/telemetry-lifecycle.e2e.test.ts
@@ -260,6 +260,6 @@ describe("measurement, from nothing to off and back", () => {
     const { measurement_enabled: _before, ...historicalFigures } = envelope;
     const { measurement_enabled: _after, ...historicalFiguresAfterOff } = afterOff;
     expect(historicalFiguresAfterOff).toEqual(historicalFigures);
-    expect(envelope.cost_report_version).toBe(14);
+    expect(envelope.cost_report_version).toBe(15);
   }, 60_000);
 });

--- a/cli/tests/e2e/telemetry-multi-tool.e2e.test.ts
+++ b/cli/tests/e2e/telemetry-multi-tool.e2e.test.ts
@@ -444,7 +444,7 @@ describe("the flow a person can actually follow", () => {
     expect(first.exitCode, first.stderr).toBe(0);
     expect(second.stdout).toBe(first.stdout);
     const parsed = JSON.parse(first.stdout);
-    expect(parsed.cost_report_version).toBe(14);
+    expect(parsed.cost_report_version).toBe(15);
     expect(parsed.period).toEqual({ from_day: "2026-07-01", to_day: "2026-07-31" });
     expect(parsed.attribution.map((row: { attribution: string }) => row.attribution)).toEqual([
       "tool-stated",

--- a/cli/tests/fixtures/cli-owns-read/expected-envelope.json
+++ b/cli/tests/fixtures/cli-owns-read/expected-envelope.json
@@ -1,5 +1,5 @@
 {
-  "cost_report_version": 14,
+  "cost_report_version": 15,
   "period": {
     "from_day": "2026-01-01",
     "to_day": "2026-01-31"

--- a/plugins/aidd-telemetry/skills/01-cost/actions/03-report.md
+++ b/plugins/aidd-telemetry/skills/01-cost/actions/03-report.md
@@ -93,9 +93,13 @@ A breakdown the object leaves empty is a section left out, never a table of zero
    - One axis: `aidd telemetry report --axis <axis> --from 2026-08-01 --to 2026-08-31`.
    - Everything: `aidd telemetry report --from 2026-08-01 --to 2026-08-31 --json`, reading the shape from [cost-report-contract.md](../../../../../aidd_docs/product/cost-report-contract.md).
    - The figure will be kept or compared: give `--from` and `--to`, since `--days` resolves against today and two identical calls on two days cover two different periods.
-3. **Refuse an unknown shape.** `cost_report_version` is `14` today, read from the `--json`
+3. **Refuse an unknown shape.** `cost_report_version` is `15` today, read from the `--json`
    path - the `--axis` path prints text the script already built from that same object, so
-   there is no separate version to check there. The bump from `13` to `14` did not add a
+   there is no separate version to check there. The bump from `14` to `15` did not add a
+   breakdown: `by_person`'s `resolution` gained a fourth value, `this-machine`, for a record
+   that named nobody on a machine that has declared an identity. Report such a row as that
+   person - declaring an identity names past work too, not only what follows. The bump
+   from `13` to `14` did not add a
    breakdown: the reasons a `by_task` or `by_backlog` row can carry gained a fifth,
    `precedes-journal`, for a record older than everything its own session's journal
    witnessed. Report it as what it is - work billed before that session opened a journal,


### PR DESCRIPTION
## The determinism defect

`person_id` is written onto a record when the record is **stored**
(`stampProvenanceAndTool`). So what a period reports for `by_person` depends on when the
identity was declared relative to when each record was read — never on the work itself.

The same sink, with the same `identity.json`, answers differently depending on the order
those two things happened in. Measured on a live machine: **29,207 requests, every one read
by that machine's own `aidd`, and `by_person` could name none of them.**

It also contradicts this repository's own rule — *store what was observed, derive what was
judged*. Which person a record belongs to is a judgement, and it is re-judgeable.

## Measured before designing

The fallback is only sound if a sink can hold exactly one person's records:

| Question | Answer |
| --- | --- |
| Callers of `TelemetrySink.appendRecord` | one, `read-local-cost-use-case.ts:537` |
| `provenance` across 29,699 stored lines | `local-read`, all of them |
| Distinct `person_id` values | none — the field is absent on every line |

## The change

A fourth `PersonResolution`, **`"this-machine"`**: the record carried no identifier of its
own, and this machine has declared an identity. Deterministic given the pair (sink,
`identity.json`), and retroactive.

Kept apart from `"mapped"`, which is the record naming a person this identity claims; this is
the identity claiming a record that named nobody. `"none"` keeps its meaning and stays
reachable — no identifier **and** no identity declared — so a machine that never declared one
reports exactly as it does today.

Store-time stamping stays: the field is what an export carries to a destination, so a record
must be able to name its own person without the reader's `identity.json` beside it.

## Proven end to end

Built binary, real sink copied read-only into a sandbox, one `identity.json` in a sandboxed
`HOME`, same command on both builds:

| Build | `by_person` |
| --- | --- |
| `origin/next` | `no identity — nobody opted in` — 29,207 requests, **0 named** |
| this branch | `A Person` — 29,207 requests, **100% named** |

Nothing was re-read and no record rewritten. The difference is entirely that the judgement
now happens where it can be re-made.

## Found while making the change

`personRows` selected its output with **one filter per resolution** and concatenated them, so
a `this-machine` row summed into no group and vanished from the breakdown while the totals it
belonged to stayed. `personLabel` had the same shape one layer up: an if-chain whose fallback
printed any unnamed resolution as "nobody opted in" — the opposite of what the row said.

Both are now written over the whole union as a `Record<PersonResolution, …>`, so the next
value added fails to compile in both places instead of disappearing in one and being
mislabelled in the other.

## Guards, each with the mutation that kills it

| Guard | Mutation |
| --- | --- |
| an unstamped record resolves to this machine's declared identity | drop the fallback branch |
| an unstamped record with no identity declared still resolves `"none"` | fall back before the null-identity check |
| an identifier this identity does not claim still resolves `"unresolved"` | fall back before the match check |
| the row carries the identity's own evidence, like a mapped row | return an empty `identities` |
| every renderer names the fourth value | add the value without touching `personLabel` |
| the same sink answers the same stamped or unstamped | — the determinism claim itself, asserted directly |

## Envelope

`cost_report_version` `14` → `15`. A consumer switching exhaustively on the three previous
`resolution` values must add this one; every row's `totals` still reconciles.

## Gates

`pnpm build` + `vitest run` 3413/3413 across 306 files · `tsc --noEmit` · `biome ci` ·
`knip --production` · `jscpd` · bundle within budget · repo `node --test scripts/__tests__`
368/368 · markdown links 0 broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWNxk63AGKkqE8HRqHLjGp
