### PR TITLE
fix(cli): a repair that repaired nothing says so

### DIFF
--- a/aidd_docs/tasks/2026_09/2026_09_04_a-repair-that-repaired-nothing-says-so/plan.md
+++ b/aidd_docs/tasks/2026_09/2026_09_04_a-repair-that-repaired-nothing-says-so/plan.md
@@ -1,0 +1,107 @@
+---
+status: done
+---
+
+# A repair that repaired nothing says so
+
+## The defect
+
+`aidd restore --force` prints `Nothing to restore — all files are unmodified.` and exits `0`
+while the file it was asked to repair is still modified on disk. Three false statements in
+one run: it asks for the flag it was given, it denies the drift it just detected, and it
+reports success for a repair it never performed.
+
+Reproduced on the built binary, one tracked file (`.claude/settings.json`), sandboxed `HOME`:
+
+```
+$ node dist/cli.js restore --force
+Checking claude for files to restore...
+Warning: [config-restore] Use --force to overwrite modified files in non-interactive mode.
+Nothing to restore — all files are unmodified.
+exit=0
+$ cat .claude/settings.json
+{"MODIFIED":true}
+```
+
+Same project, same second, the sibling command repairs it:
+
+```
+$ node dist/cli.js ai restore --force
+Checking claude for files to restore...
+Restored 1 file, kept 0 files
+```
+
+## The cause
+
+Two independent faults, on the same run.
+
+| # | Where | What |
+| --- | --- | --- |
+| 1 | `commands/restore.ts:19` | `--force` is read into `interactive`, then dropped. `RestoreAllUseCase.execute(projectRoot, interactive)` has no `force` parameter at all |
+| 2 | `global/restore-all-use-case.ts:95` | passes `force: interactive` — so with `--force`, `interactive` is `false` and `force` is `false`. `ResolveRestoreDecisionUseCase` then throws `InputRequiredError` on the first modified file |
+| 3 | `commands/restore.ts:24-29` | the throw is caught into `result.errors`, printed as a warning, and the success line is emitted anyway because `totalRestored`, `pluginNamesRestored` and `unrestorable` are all empty |
+
+`aidd ai restore` and `aidd ide restore` both plumb `force: cmdOptions.force` into the same
+use-case and are correct. Only the top-level command loses it.
+
+Why the smoke harness never caught it: its `restore --force` case deletes a tracked file
+first, and a **deleted** entry returns before the decision (`resolve-restore-decision.ts:20`,
+`if (reason !== "modified") return false`). Only a *modified* file reaches the throw.
+
+## The change
+
+- `RestoreAllUseCase.execute` takes `force` and passes `force: force || interactive` —
+  the checkbox is the consent in interactive mode, `--force` is the consent without a TTY.
+  Non-interactive with neither still refuses, which is the guard working as designed.
+- `restore.ts` passes `cmdOptions.force` through, and stops claiming success when the run
+  produced errors: an execution error exits `1`.
+
+No new flag, no new message, no envelope change. The surface stays what its `--help` already
+promises.
+
+## Guards
+
+| Guard | Mutation that kills it |
+| --- | --- |
+| `restore --force` restores a modified tracked file | drop `force` from the `execute` signature again |
+| `restore --force` never prints the "nothing to restore" line when a file was modified | restore the file but keep printing the success line unconditionally |
+| `restore` without `--force` and without a TTY exits non-zero and says which flag to pass | swallow the error into a warning and exit `0` |
+| interactive restore still repairs the files picked in the checkbox without a second prompt | pass `force: force` instead of `force: force \|\| interactive` |
+
+## Proof
+
+On the built binary, same project as the reproduction above:
+
+```
+$ node dist/cli.js restore --force
+Checking claude for files to restore...
+Restored 1 file(s), kept 0 file(s)          exit=0     (file back to its installed bytes)
+
+$ node dist/cli.js restore           # modified again, no TTY, no --force
+Checking claude for files to restore...
+Warning: [config-restore] Use --force to overwrite modified files in non-interactive mode.
+                                            exit=1     (no success line)
+
+$ node dist/cli.js restore --force   # nothing drifted
+Nothing to restore — all files are unmodified.
+                                            exit=0
+```
+
+Each guard was killed by its own mutation and by no other:
+
+| Mutation | Killed |
+| --- | --- |
+| `force: interactive` (the original) | the `--force` unit guard, and the e2e repair |
+| `force: force` | the interactive guard only |
+| drop `process.exit(1)` on errors | the loud-failure e2e only |
+
+Gates: 3419 tests / 307 files, `tsc`, `biome ci`, knip, jscpd, bundle within budget,
+368 repository script tests, 0 broken links, cli layering clean.
+
+## Left for its own change
+
+- The smoke case `restore --force` appends drift to a `.md` file and then asserts only
+  `exit 0`, which the broken command satisfied. It belongs with the other vacuous harness
+  cases, not here.
+- `cost-report.ts` declares `TaskRowKey` and no longer uses it — a lint warning, unrelated
+  to this command.

--- a/cli/src/application/commands/restore.ts
+++ b/cli/src/application/commands/restore.ts
@@ -16,9 +16,17 @@ export function registerRestoreCommand(program: Command): void {
       try {
         const deps = await createDeps(projectRoot, { verbose }, output);
         const interactive = !cmdOptions.force && process.stdout.isTTY;
-        const result = await deps.restoreAllUseCase.execute(projectRoot, interactive);
+        const result = await deps.restoreAllUseCase.execute(
+          projectRoot,
+          interactive,
+          cmdOptions.force
+        );
 
         for (const e of result.errors) output.warn(`[${e.scope}] ${e.message}`);
+
+        // A run that errored restored nothing, and saying "nothing to restore" would
+        // report that as the healthy state. Nothing was restored *because* it failed.
+        if (result.errors.length > 0) process.exit(1);
 
         if (
           result.totalRestored === 0 &&

--- a/cli/src/application/use-cases/global/restore-all-use-case.ts
+++ b/cli/src/application/use-cases/global/restore-all-use-case.ts
@@ -22,7 +22,11 @@ export class RestoreAllUseCase {
     private readonly restoreUseCase: RestoreUseCase
   ) {}
 
-  async execute(projectRoot: string, interactive: boolean): Promise<RestoreAllResult> {
+  async execute(
+    projectRoot: string,
+    interactive: boolean,
+    force: boolean
+  ): Promise<RestoreAllResult> {
     const errors: GlobalExecutionError[] = [];
     const manifest = await this.manifestRepo.load();
     if (manifest === null) throw new NoManifestError();
@@ -34,6 +38,7 @@ export class RestoreAllUseCase {
       version,
       effectiveFiles,
       interactive,
+      force,
       manifest,
       errors
     );
@@ -76,6 +81,7 @@ export class RestoreAllUseCase {
     version: string,
     files: string[] | undefined,
     interactive: boolean,
+    force: boolean,
     manifest: Awaited<ReturnType<ManifestRepository["load"]>>,
     errors: GlobalExecutionError[]
   ): Promise<{
@@ -92,7 +98,10 @@ export class RestoreAllUseCase {
         docsDir: DOCS_DIR,
         projectRoot,
         files,
-        force: interactive,
+        // Consent to overwrite a modified file comes from one of two places: the
+        // checkbox the interactive run already made the user answer, or --force
+        // when there is no TTY to ask. Neither is a reason to ask a second time.
+        force: force || interactive,
         interactive,
         manifest,
       });

--- a/cli/tests/application/use-cases/restore-all-use-case.unit.test.ts
+++ b/cli/tests/application/use-cases/restore-all-use-case.unit.test.ts
@@ -101,7 +101,7 @@ describe("RestoreAllUseCase — plugin materialization", () => {
     // Counting reader wired only from here — installPlugin's own read() must not count.
     const { reader, count } = countingReader(deps.fs);
     const useCase = makeRestoreAllUseCase(deps, reader);
-    await useCase.execute(PROJECT_ROOT, false);
+    await useCase.execute(PROJECT_ROOT, false, false);
 
     expect(deps.fs.getFile(pluginFile)).not.toBe("CORRUPTED CONTENT");
     expect(deps.fs.getFile(pluginFile)).toContain("Greet from sample-plugin.");
@@ -133,7 +133,7 @@ describe("RestoreAllUseCase — plugin materialization", () => {
     // Counting reader wired only from here — installPlugin's own read() must not count.
     const { reader, count } = countingReader(deps.fs);
     const useCase = makeRestoreAllUseCase(deps, reader, new OverwritePrompter(), true);
-    await useCase.execute(PROJECT_ROOT, false);
+    await useCase.execute(PROJECT_ROOT, false, false);
 
     expect(deps.fs.getFile(pluginFile)).not.toBe("CORRUPTED CONTENT");
     expect(count()).toBe(1);
@@ -149,7 +149,7 @@ describe("RestoreAllUseCase — plugin materialization", () => {
     const pluginFile = join(PROJECT_ROOT, ".claude/plugins/sample-plugin/commands/greet.md");
     await deps.fs.writeFile(pluginFile, "CORRUPTED CONTENT");
 
-    const result = await makeRestoreAllUseCase(deps, reader).execute(PROJECT_ROOT, false);
+    const result = await makeRestoreAllUseCase(deps, reader).execute(PROJECT_ROOT, false, false);
 
     expect(result.pluginNamesRestored).toEqual(["sample-plugin"]);
     expect(result.errors).toHaveLength(0);
@@ -168,7 +168,7 @@ describe("RestoreAllUseCase — plugin materialization", () => {
       ?.getPlugins("claude")
       .find((p) => p.name === "sample-plugin");
 
-    const result = await makeRestoreAllUseCase(deps, reader).execute(PROJECT_ROOT, false);
+    const result = await makeRestoreAllUseCase(deps, reader).execute(PROJECT_ROOT, false, false);
 
     expect(result.pluginNamesRestored).toEqual([]);
     expect(result.errors).toHaveLength(0);
@@ -207,7 +207,7 @@ describe("RestoreAllUseCase — plugin materialization", () => {
       ScriptedPrompter.answer.checkbox([".vscode/keybindings.json"]),
     ]);
     const useCase = makeRestoreAllUseCase(deps, reader, prompter);
-    await useCase.execute(PROJECT_ROOT, true);
+    await useCase.execute(PROJECT_ROOT, true, false);
 
     expect(deps.fs.getFile(pluginFile)).toBe("CORRUPTED CONTENT");
   });
@@ -240,9 +240,71 @@ describe("RestoreAllUseCase — plugin materialization", () => {
     await deps.fs.writeFile(claudePluginFile, "CORRUPTED CLAUDE");
     await deps.fs.writeFile(codexPluginFile, "CORRUPTED CODEX");
 
-    await makeRestoreAllUseCase(deps, reader).execute(PROJECT_ROOT, false);
+    await makeRestoreAllUseCase(deps, reader).execute(PROJECT_ROOT, false, false);
 
     expect(deps.fs.getFile(claudePluginFile)).not.toBe("CORRUPTED CLAUDE");
     expect(deps.fs.getFile(codexPluginFile)).not.toBe("CORRUPTED CODEX");
+  });
+});
+
+describe("RestoreAllUseCase — consent to overwrite", () => {
+  type RestoreOptions = Parameters<RestoreUseCase["execute"]>[0];
+
+  /** Records what RestoreAllUseCase asks the restore to do, without doing it. */
+  function recordAsks(restoreUseCase: RestoreUseCase): RestoreOptions[] {
+    const seen: RestoreOptions[] = [];
+    restoreUseCase.execute = async (options: RestoreOptions) => {
+      seen.push(options);
+      return {
+        tools: [],
+        totalRestored: 0,
+        totalKept: 0,
+        totalPluginFilesRestored: 0,
+        restoredPluginNames: [],
+        unrestorable: [],
+      };
+    };
+    return seen;
+  }
+
+  async function askedWith(interactive: boolean, force: boolean): Promise<RestoreOptions> {
+    const deps = await buildUnitDeps(PROJECT_ROOT);
+    await initAndInstall(deps, PROJECT_ROOT, "claude");
+    const prompter = new OverwritePrompter();
+    const statusUseCase = new StatusUseCase(
+      deps.fs,
+      deps.manifestRepo,
+      deps.hasher,
+      new DetectPluginDriftUseCase(deps.fs)
+    );
+    const restoreUseCase = new RestoreUseCase(
+      deps.fs,
+      deps.manifestRepo,
+      deps.hasher,
+      deps.logger,
+      new FakePlatform("linux"),
+      prompter
+    );
+    const seen = recordAsks(restoreUseCase);
+    await new RestoreAllUseCase(deps.manifestRepo, prompter, statusUseCase, restoreUseCase).execute(
+      PROJECT_ROOT,
+      interactive,
+      force
+    );
+    const asked = seen[0];
+    expect(asked).toBeDefined();
+    return asked as RestoreOptions;
+  }
+
+  it("carries --force through to the restore it delegates to", async () => {
+    expect((await askedWith(false, true)).force).toBe(true);
+  });
+
+  it("does not overwrite without consent when neither --force nor a TTY is there", async () => {
+    expect((await askedWith(false, false)).force).toBe(false);
+  });
+
+  it("treats the interactive file selection as the consent, so nothing is asked twice", async () => {
+    expect((await askedWith(true, false)).force).toBe(true);
   });
 });

--- a/cli/tests/e2e/restore-force.e2e.test.ts
+++ b/cli/tests/e2e/restore-force.e2e.test.ts
@@ -1,0 +1,88 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { createTestEnv, runCli } from "./helpers.js";
+
+const MODIFIED = '{"MODIFIED":true}';
+
+async function seedManifest(projectDir: string): Promise<void> {
+  await mkdir(join(projectDir, ".aidd"), { recursive: true });
+  await writeFile(
+    join(projectDir, ".aidd", "manifest.json"),
+    JSON.stringify({ version: 5, tools: {}, marketplaces: {} }),
+    "utf-8"
+  );
+}
+
+/** The first regular file `ai install claude` tracked, as the manifest records it. */
+async function firstTrackedFile(projectDir: string): Promise<string> {
+  const raw = await readFile(join(projectDir, ".aidd", "manifest.json"), "utf-8");
+  const manifest = JSON.parse(raw) as {
+    tools: Record<string, { files: Array<{ relativePath: string }> }>;
+  };
+  const relativePath = manifest.tools.claude?.files[0]?.relativePath;
+  if (relativePath === undefined) throw new Error("no tracked file to modify");
+  return relativePath;
+}
+
+async function installAndModify(
+  projectDir: string,
+  fakeHome: string
+): Promise<{ tracked: string; installed: string }> {
+  await seedManifest(projectDir);
+  await runCli(["ai", "install", "claude"], projectDir, fakeHome);
+  const tracked = await firstTrackedFile(projectDir);
+  const installed = await readFile(join(projectDir, tracked), "utf-8");
+  await writeFile(join(projectDir, tracked), MODIFIED, "utf-8");
+  return { tracked, installed };
+}
+
+describe.concurrent("E2E: aidd restore --force", () => {
+  it("repairs a modified tracked file instead of reporting nothing to restore", async () => {
+    const { projectDir, fakeHome, cleanup } = await createTestEnv("restore-force-modified");
+    try {
+      const { tracked, installed } = await installAndModify(projectDir, fakeHome);
+
+      const { stdout, exitCode } = await runCli(["restore", "--force"], projectDir, fakeHome);
+
+      expect(exitCode).toBe(0);
+      expect(stdout).not.toContain("Nothing to restore");
+      expect(stdout).toContain("Restored 1 file");
+      expect(await readFile(join(projectDir, tracked), "utf-8")).toBe(installed);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("without --force and without a TTY, fails loudly instead of claiming success", async () => {
+    const { projectDir, fakeHome, cleanup } = await createTestEnv("restore-no-force-modified");
+    try {
+      const { tracked } = await installAndModify(projectDir, fakeHome);
+
+      const { stdout, stderr, exitCode } = await runCli(["restore"], projectDir, fakeHome);
+
+      expect(exitCode).not.toBe(0);
+      expect(stdout).not.toContain("Nothing to restore");
+      expect(`${stdout}${stderr}`).toContain("--force");
+      // It refused, so it must not have touched the file either.
+      expect(await readFile(join(projectDir, tracked), "utf-8")).toBe(MODIFIED);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("still reports nothing to restore when nothing drifted", async () => {
+    const { projectDir, fakeHome, cleanup } = await createTestEnv("restore-force-clean");
+    try {
+      await seedManifest(projectDir);
+      await runCli(["ai", "install", "claude"], projectDir, fakeHome);
+
+      const { stdout, exitCode } = await runCli(["restore", "--force"], projectDir, fakeHome);
+
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain("Nothing to restore");
+    } finally {
+      await cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## What

`aidd restore --force` reported success while repairing nothing.

```
$ aidd restore --force
Checking claude for files to restore...
Warning: [config-restore] Use --force to overwrite modified files in non-interactive mode.
Nothing to restore — all files are unmodified.
exit=0
$ cat .claude/settings.json
{"MODIFIED":true}
```

Three false statements in one run: it asked for the flag it was given, it denied the drift it had just detected, and it reported success for a repair it never performed. Same project, same second, the sibling command repaired it: `aidd ai restore --force` → `Restored 1 file`.

## Why

- `commands/restore.ts` read `--force` into `interactive` and then dropped it; `RestoreAllUseCase.execute` had no `force` parameter at all.
- `restore-all-use-case.ts` passed `force: interactive`, so with `--force` the use-case received `force: false` and `ResolveRestoreDecisionUseCase` threw on the first modified file.
- The throw was caught into `result.errors`, printed as a warning, and the success line was emitted anyway.

`aidd ai restore` and `aidd ide restore` both plumb `force: cmdOptions.force` correctly. Only the top-level command lost it.

The smoke harness never caught it because its `restore --force` case asserts only `exit 0`, which the broken command satisfied.

## After

```
$ aidd restore --force            → Restored 1 file(s), kept 0 file(s)   exit=0
$ aidd restore    (no TTY)        → Warning: … Use --force …             exit=1
$ aidd restore --force  (clean)   → Nothing to restore …                 exit=0
```

## Guards

| Guard | Mutation that kills it |
| --- | --- |
| `--force` reaches the restore it delegates to | `force: interactive` (the original) |
| the interactive checkbox is still the consent, nothing asked twice | `force: force` |
| a run with errors exits non-zero and prints no success line | drop the `process.exit(1)` |

Each mutation killed its own guard and no other.

Gates: 3419 tests / 307 files, `tsc`, `biome ci`, knip, jscpd, bundle within budget, 368 repository script tests, 0 broken links, cli layering clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWNxk63AGKkqE8HRqHLjGp