### PR TITLE
fix(telemetry): a turn end is a pause for a flow too

### DIFF
--- a/aidd_docs/tasks/2026_09/2026_09_04_a-turn-end-is-a-pause-for-a-flow-too/plan.md
+++ b/aidd_docs/tasks/2026_09/2026_09_04_a-turn-end-is-a-pause-for-a-flow-too/plan.md
@@ -1,0 +1,132 @@
+---
+status: done
+---
+
+# A turn end is a pause for a flow too
+
+## The defect
+
+`buildFlowIntervals` closes a flow at the first `turn_end` after it opened. The task axis
+stopped doing exactly that on 2026-09-04 — *"a `turn_end` is a pause, not a change of
+subject"*, `task-attribution.ts:28` — and measured 78% of one session mislabelled before the
+fix. The flow axis never followed, and it is the axis where the error is largest.
+
+Measured on this machine's own sink, period `2026-08-01..2026-09-04`, 30,197 requests:
+
+| Axis | What it names for `aidd-orchestrator:01-sdlc` |
+| --- | --- |
+| `by_step` | 2,220 requests |
+| `by_flow` | 56 requests |
+
+A flow is the wider concept — the orchestration and everything it drove — yet it names 40
+times fewer requests than the step inside it. That is the closer, not the data.
+
+The corpus holds exactly one orchestrating `step_start`:
+
+```
+journal …bb2a10bd   window 2026-09-04T05:21:27Z -> 09:27:21Z
+                    step_start 4, turn_end 12, task_declared 46, file_written 12
+                    orchestrating step_start: 1, at 05:56:27Z
+```
+
+The flow opened at 05:56:27 and the first `turn_end` closed it at 06:02:34. The session went
+on writing into the same task folder until 09:27:21 — six minutes named, three and a half
+hours not.
+
+## The change
+
+A flow closes on a `step_end` naming its own skill, and on nothing else but the next
+orchestrating `step_start`. The same rule `buildStepIntervals` adopted when `step_end` was
+introduced (`step-attribution.ts:82-91`): the only line in the journal that *states* an end
+rather than standing in for one, and a `step_end` naming a different skill never closes a
+flow it has no claim on.
+
+`buildClosedIntervals` gains an opener-aware `isCloser`. It cannot be expressed otherwise:
+"a `step_end` naming *this* flow's skill" is a fact about the pair, and the walk currently
+filters closers before it knows which interval is open. The walk becomes a forward scan from
+each opener, which produces the identical intervals for every opener-independent closer —
+`buildTaskIntervals` passes `() => false` and is unaffected.
+
+Unclosed stays unclosed the same way: the journal's own last witnessed moment, capped at the
+report's period end. Never open-ended.
+
+## What this costs, stated
+
+An orchestrating skill that never emits `aidd:step-end` has its flow run to the next
+orchestrating `step_start` or the journal's end. That is the same trade the task axis
+accepted, and the same one it is now measured against. Only `aidd-dev:01-plan` emits the
+marker today; making the three orchestrators emit it is a separate change, in the plugin
+tree, and it is what turns this fallback into the exception rather than the rule.
+
+The `step_end` half is therefore exercised by tests alone in this corpus, not by the sink —
+said here rather than implied by a green run.
+
+## No envelope bump
+
+`cost_report_version` stays 15. The rule is stated where the number lives: *"Adding a field
+a consumer may ignore is not a bump; changing what an existing field means is."* No field
+changes shape or vocabulary; a row still means "the records attributed to this flow". The
+task axis changed its own closer under the same rule and bumped nothing for it.
+
+## Guards
+
+| Guard | Mutation that kills it |
+| --- | --- |
+| a `turn_end` no longer closes a flow | put `turn_end` back in the closer |
+| a `step_end` naming the flow's own skill closes it | drop the closer entirely |
+| a `step_end` naming another skill never closes it | compare nothing, close on any `step_end` |
+| the next orchestrating `step_start` still closes the one before it | stop treating an opener as a closer |
+| an unclosed flow still ends at the journal's last witnessed moment, capped at the period end | end it at the opener, or leave it open |
+| a task interval is unchanged by the opener-aware walk | make the forward scan skip the opener itself |
+
+## Proof
+
+Both binaries run back to back against the same sink, same period, same instant:
+
+| | `cost_report_version` | period total | `by_flow` `aidd-orchestrator:01-sdlc` | `by_flow` unnamed |
+| --- | --- | --- | --- | --- |
+| `origin/next` | 15 | 30,222 | 56 | 30,166 |
+| this branch | 15 | 30,222 | **1,052** | 29,170 |
+
+Every one of the eleven breakdowns sums to 30,222 on both runs. Compared row by row, ten of
+the eleven are byte-identical between the two reports and only `by_flow` differs - so the
+change moved the axis it names and nothing else.
+
+Each guard was killed by its own mutation:
+
+| Mutation | Killed |
+| --- | --- |
+| `turn_end` back in the closer | the pause guards (3) |
+| no closer at all | the `step_end` guards (2) |
+| close on any `step_end` | the other-skill guard (1) |
+| an opener no longer closes the one before it | 1 flow guard, 2 task guards |
+| unclosed ends at its own start | 19 across both axes |
+| the scan starts at the opener itself | 23 across both axes |
+
+The axis also gained an end-to-end guard it did not have. `telemetry-flow-axis.e2e.test.ts`
+passed unchanged through this diff, and it had to: its fixture ends on a `turn_end` with
+nothing witnessed after it, and held no record between a pause and the next orchestrating
+step - the coincidence class the unit fixtures were rewritten to escape. One record at
+09:55, between the pause at 09:50 and the next opener at 10:00, now separates the two rules,
+and putting `turn_end` back into the closer turns three of the five e2e cases red.
+
+Gates: 3416 tests / 306 files, `tsc`, `biome ci`, knip, jscpd, bundle within budget,
+368 repository script tests, 0 broken links, cli layering clean.
+
+## Next, and not here
+
+The three orchestrating skills do not emit `aidd:step-end`, so every flow above closed on
+the journal's own last witnessed moment rather than on a declared end. Making them emit it
+is a plugin-tree change with its own test surface.
+
+## Filed, not fixed here
+
+`by_step` credits `aidd-orchestrator:01-sdlc` with 2,220 requests where the flow, after this
+change, credits 1,052. The difference is not a disagreement about the closer: a `StepInterval`
+is deliberately left open (`POSITIVE_INFINITY`), so roughly 1,168 of those requests fall after
+the journal stopped witnessing anything at all. That is attribution on no evidence, and it is
+a sharper case of *"an unknown is never a zero"* than the one this change fixes.
+
+It is not touched here on purpose. `step-attribution.ts:37-52` argues the open reading
+explicitly and ties it to `aidd telemetry check`'s own `records-join` claim, so changing it
+means re-proving that claim - its own Frame, with its own measurement.

--- a/cli/src/domain/models/flow-attribution.ts
+++ b/cli/src/domain/models/flow-attribution.ts
@@ -76,8 +76,15 @@ export function bareOrchestratingSkillNames(
 }
 
 /** One closed flow interval: from an orchestrating skill's own `step_start` to whichever of
- * the next orchestrating `step_start` or a `turn_end` comes first, or - unclosed - the
- * journal's own last witnessed moment. Read from exactly the same journal a declared task
+ * a `step_end` naming that same skill or the next orchestrating `step_start` comes first,
+ * or - unclosed - the journal's own last witnessed moment.
+ *
+ * **A `turn_end` stopped closing one on 2026-09-04**, for the reason `task-attribution.ts`
+ * already gives for a declared task: it is a pause, not the end of an orchestration. On the
+ * one orchestrated session measured, the flow opened at 05:56:27, the first pause fell at
+ * 06:02:34, and the same orchestration went on writing into the same task folder until
+ * 09:27:21 - six minutes named against three and a half hours not. The step axis inside it
+ * named 2,220 requests for the same skill while the flow, the wider concept, named 56. Read from exactly the same journal a declared task
  * interval already reads (`task-attribution.ts`), one layer wider: no boundary is added for
  * this, and none is captured that was not captured already - see `phase-1.md`'s own "why an
  * axis, not a capture". A non-orchestrating `step_start` neither opens nor closes one of
@@ -91,19 +98,27 @@ export interface FlowInterval extends ClosedInterval {
  * Journal lines in, closed flow intervals out - the same merge and the same "journal's own
  * last witnessed moment" cap `buildTaskIntervals` uses, run through the one shared walk
  * (`buildClosedIntervals`) rather than a second copy of it. An orchestrating `step_start`
- * opens an interval; the next orchestrating `step_start` or a `turn_end` closes it; every
- * other boundary - a non-orchestrating `step_start`, a `file_written`, a `task_declared` -
+ * opens an interval; a `step_end` naming that same skill, or the next orchestrating
+ * `step_start`, closes it; every other boundary - a non-orchestrating `step_start`, a
+ * `step_end` naming another skill, a `turn_end`, a `file_written`, a `task_declared` -
  * neither opens nor closes one, and only ever contributes its own moment toward the
- * journal's last witnessed one for an interval a session crashed before closing.
+ * journal's last witnessed one for an interval nothing ever closed.
+ *
+ * A `step_end` naming a *different* skill is never a closer, the same rule
+ * `buildStepIntervals` follows: a step run inside the orchestration finishing is not the
+ * orchestration finishing, and truncating there is exactly the fault naming the skill
+ * exists to prevent. Only `aidd-dev:01-plan` emits the marker today, so most flows still
+ * close on the next orchestrating `step_start` or the journal's own last witnessed moment;
+ * that fallback is the cost of this rule, stated rather than hidden.
  *
  * Two orchestrated runs of the very same skill in one session yield two distinct
  * `FlowInterval` objects here, never one merged by name: `cost-report.ts`'s own grouping
  * keys a record's flow membership on the interval it actually fell inside, by reference,
  * not on `skill` alone - the fact this function's own two-row acceptance criterion rests
- * on. Never open-ended, for the same reason `buildTaskIntervals` never is: no boundary
- * exposes when an orchestrating skill's own work finishes, so a boundless interval would
- * attribute everything a long-running session goes on to do afterward to the first
- * orchestrating step it ever saw.
+ * on. Never open-ended, for the same reason `buildTaskIntervals` never is: a journal that
+ * ends without the orchestrating skill ever saying it was done exposes nothing about when
+ * it finished, so a boundless interval would attribute everything a long-running session
+ * goes on to do afterward to the first orchestrating step it ever saw.
  */
 export function buildFlowIntervals(
   journal: RunJournal,
@@ -118,7 +133,7 @@ export function buildFlowIntervals(
     periodEndMs,
     (boundary): boundary is RunJournalStepStart =>
       boundary.type === "step_start" && ORCHESTRATING_SKILLS.has(boundary.skill),
-    (boundary) => boundary.type === "turn_end",
+    (boundary, opener) => boundary.type === "step_end" && boundary.skill === opener.skill,
     (opener, startMs, endMs) => ({ skill: opener.skill, startMs, endMs })
   );
 }

--- a/cli/src/domain/models/journal-intervals.ts
+++ b/cli/src/domain/models/journal-intervals.ts
@@ -71,9 +71,10 @@ export function momentFallsWithin(
  * already carrying every moment either interval kind might need to cap an unclosed one at.
  *
  * `isOpener` names which boundary starts an interval; `isCloser` names every *other*
- * boundary that can end one early (a `task_declared` interval also closes on the next
- * `task_declared`, which `isOpener` already covers - `closers` below is `isOpener` union
- * `isCloser`, not `isCloser` alone). An opener the walk reaches with no later opener or
+ * boundary that can end one early, and is asked about the open interval's own opener as
+ * well as the candidate (a `task_declared` interval also closes on the next
+ * `task_declared`, which `isOpener` already covers - an interval ends at the first later
+ * boundary either predicate accepts, not at the first `isCloser` alone). An opener the walk reaches with no later opener or
  * closer ends at the journal's own last witnessed moment - itself at the earliest, since
  * the opener is one of those moments - never left open-ended: no
  * boundary here exposes when an interval's own work actually finishes, so an unbounded
@@ -95,7 +96,7 @@ export function buildClosedIntervals<
   boundaryLike: readonly TBoundary[],
   periodEndMs: number | undefined,
   isOpener: (boundary: TBoundary) => boundary is TOpener,
-  isCloser: (boundary: TBoundary) => boolean,
+  isCloser: (boundary: TBoundary, opener: TOpener) => boolean,
   toInterval: (opener: TOpener, startMs: number, endMs: number) => TInterval | null
 ): readonly TInterval[] {
   const everyWitnessedMoment = timed(boundaryLike);
@@ -107,16 +108,34 @@ export function buildClosedIntervals<
     everyWitnessedMoment[everyWitnessedMoment.length - 1].atMs,
     periodEndMs
   );
-  const closers = everyWitnessedMoment.filter(
-    (entry) => isOpener(entry.boundary) || isCloser(entry.boundary)
-  );
   const intervals: TInterval[] = [];
-  for (let i = 0; i < closers.length; i++) {
-    const { atMs: startMs, boundary } = closers[i];
+  for (let i = 0; i < everyWitnessedMoment.length; i++) {
+    const { atMs: startMs, boundary } = everyWitnessedMoment[i];
     if (!isOpener(boundary)) continue;
-    const endMs = closers[i + 1]?.atMs ?? lastMs;
+    const endMs = firstCloserAfter(everyWitnessedMoment, i, boundary, isOpener, isCloser) ?? lastMs;
     const interval = toInterval(boundary, startMs, endMs);
     if (interval !== null) intervals.push(interval);
   }
   return intervals;
+}
+
+/** The moment the interval opened at `from` ends, or `undefined` when nothing closes it.
+ *
+ * Scanned forward from the opener rather than filtered once for the whole journal, because
+ * `isCloser` is asked about the pair: a `step_end` closes the flow whose skill it names and
+ * no other, which a single pre-filtered list of closers cannot express. For an `isCloser`
+ * that ignores its opener - `buildTaskIntervals` passes one - this answers exactly what the
+ * pre-filtered walk answered. */
+function firstCloserAfter<TBoundary extends { readonly at: string }, TOpener extends TBoundary>(
+  everyWitnessedMoment: readonly TimedBoundary<TBoundary>[],
+  from: number,
+  opener: TOpener,
+  isOpener: (boundary: TBoundary) => boundary is TOpener,
+  isCloser: (boundary: TBoundary, opener: TOpener) => boolean
+): number | undefined {
+  for (let i = from + 1; i < everyWitnessedMoment.length; i++) {
+    const { atMs, boundary } = everyWitnessedMoment[i];
+    if (isOpener(boundary) || isCloser(boundary, opener)) return atMs;
+  }
+  return undefined;
 }

--- a/cli/tests/domain/models/flow-attribution.unit.test.ts
+++ b/cli/tests/domain/models/flow-attribution.unit.test.ts
@@ -31,6 +31,26 @@ const HAND_RUN_STEP = {
   skill: "aidd-dev:02-implement",
 } as const;
 const TURN_END = { type: "turn_end", at: "2026-08-17T12:00:00Z" } as const;
+const EARLIER_TURN_END = { type: "turn_end", at: "2026-08-17T11:00:00Z" } as const;
+/** The orchestrating skill saying its own work is over. */
+const SDLC_ENDS = {
+  type: "step_end",
+  at: "2026-08-17T11:00:00Z",
+  skill: "aidd-orchestrator:01-sdlc",
+} as const;
+/** A step *inside* the orchestration saying it is done - which the orchestration is not. */
+const PLAN_ENDS = {
+  type: "step_end",
+  at: "2026-08-17T11:00:00Z",
+  skill: "aidd-dev:01-plan",
+} as const;
+/** Something the journal witnessed after all of the above, so "closed there" and "not closed
+ * there" are two different numbers rather than the same one twice. */
+const WRITTEN_LATE = {
+  type: "file_written",
+  at: "2026-08-17T11:30:00Z",
+  path: "aidd_docs/tasks/x/spec.md",
+} as const;
 
 describe("ORCHESTRATING_SKILLS — declared once, both capture spellings", () => {
   it("names every orchestrator skill, in the argument spelling and the bare directory spelling", () => {
@@ -85,52 +105,55 @@ describe("buildFlowIntervals — pure: journal lines -> bounded flow intervals",
     ]);
   });
 
-  it("closes a flow at turn_end when nothing else orchestrates first", () => {
-    const intervals = buildFlowIntervals(journalOf([SDLC_OPENS, TURN_END]));
+  it("closes a flow where its own skill said it was done", () => {
+    const intervals = buildFlowIntervals(journalOf([SDLC_OPENS, SDLC_ENDS, TURN_END]));
 
     expect(intervals).toEqual([
       {
         skill: SDLC_OPENS.skill,
         startMs: Date.parse(SDLC_OPENS.at),
-        endMs: Date.parse(TURN_END.at),
+        endMs: Date.parse(SDLC_ENDS.at),
       },
     ]);
   });
 
-  it("closes at the turn_end itself, not at whatever the journal witnessed after it", () => {
-    // The separating case, and the one every other fixture here missed: with `turn_end`
-    // last, the moment it closes at and the journal's own last witnessed moment are the
-    // same number, so a build that ignored the closer entirely produced identical intervals
-    // and every test stayed green. Something witnessed *after* the turn end is what tells
-    // the two apart — replacing the closer with `() => false` moves this end from 11:00 to
-    // 11:30 and turns this red.
-    const writtenAfterTheTurnEnded = {
-      type: "file_written",
-      at: "2026-08-17T11:30:00Z",
-      path: "aidd_docs/tasks/x/spec.md",
-    } as const;
-    const earlierTurnEnd = { type: "turn_end", at: "2026-08-17T11:00:00Z" } as const;
+  it("never closes a flow on a step_end naming some other skill", () => {
+    // A step run inside the orchestration ends; the orchestration does not. Distinguishing:
+    // something is witnessed after that end, so closing there and not closing there are two
+    // different numbers.
+    const intervals = buildFlowIntervals(journalOf([SDLC_OPENS, PLAN_ENDS], [], [WRITTEN_LATE]));
 
-    const intervals = buildFlowIntervals(
-      journalOf([SDLC_OPENS, earlierTurnEnd], [], [writtenAfterTheTurnEnded])
-    );
-
-    expect(intervals[0]?.endMs).toBe(Date.parse(earlierTurnEnd.at));
-    expect(intervals[0]?.endMs).not.toBe(Date.parse(writtenAfterTheTurnEnded.at));
+    expect(intervals[0]?.endMs).toBe(Date.parse(WRITTEN_LATE.at));
+    expect(intervals[0]?.endMs).not.toBe(Date.parse(PLAN_ENDS.at));
   });
 
-  it("leaves work done after the turn ended outside the flow that turn opened", () => {
-    // The consequence a person actually reads. A flow that failed to close swallows every
-    // record through to the next one — so this asserts the moment, not just the interval.
-    const writtenAfterTheTurnEnded = {
-      type: "file_written",
-      at: "2026-08-17T11:30:00Z",
-      path: "aidd_docs/tasks/x/spec.md",
-    } as const;
-    const earlierTurnEnd = { type: "turn_end", at: "2026-08-17T11:00:00Z" } as const;
+  it("does not close a flow at a turn_end - a pause is not the end of an orchestration", () => {
+    // The separating case: with `turn_end` last, the moment it would close at and the
+    // journal's own last witnessed moment are the same number, so a fixture ending on the
+    // pause proves nothing either way. Something witnessed *after* the pause is what tells
+    // the two rules apart — this end is 11:30, and was 11:00 while a `turn_end` closed one.
     const intervals = buildFlowIntervals(
-      journalOf([SDLC_OPENS, earlierTurnEnd], [], [writtenAfterTheTurnEnded])
+      journalOf([SDLC_OPENS, EARLIER_TURN_END], [], [WRITTEN_LATE])
     );
+
+    expect(intervals[0]?.endMs).toBe(Date.parse(WRITTEN_LATE.at));
+    expect(intervals[0]?.endMs).not.toBe(Date.parse(EARLIER_TURN_END.at));
+  });
+
+  it("keeps work done after the pause inside the flow that was still running", () => {
+    // The consequence a person actually reads: the orchestration measured here paused at
+    // 06:02 and worked on for three more hours, and every one of those records used to fall
+    // outside its own flow.
+    const intervals = buildFlowIntervals(
+      journalOf([SDLC_OPENS, EARLIER_TURN_END], [], [WRITTEN_LATE])
+    );
+
+    expect(momentFallsWithin(intervals, "2026-08-17T10:30:00Z")).toBe(true);
+    expect(momentFallsWithin(intervals, "2026-08-17T11:15:00Z")).toBe(true);
+  });
+
+  it("stops at the end its own skill declared, even with work witnessed after it", () => {
+    const intervals = buildFlowIntervals(journalOf([SDLC_OPENS, SDLC_ENDS], [], [WRITTEN_LATE]));
 
     expect(momentFallsWithin(intervals, "2026-08-17T10:30:00Z")).toBe(true);
     expect(momentFallsWithin(intervals, "2026-08-17T11:15:00Z")).toBe(false);
@@ -158,6 +181,8 @@ describe("buildFlowIntervals — pure: journal lines -> bounded flow intervals",
       SDLC_OPENS.skill,
       SDLC_OPENS.skill,
     ]);
+    // The first closes on the second's own start, not on the pause between them.
+    expect(intervals[0]?.endMs).toBe(Date.parse(secondSdlcRun.at));
     expect(intervals[1]?.endMs).toBe(Date.parse(secondSdlcRun.at)); // unclosed - capped at its own start
   });
 

--- a/cli/tests/e2e/telemetry-flow-axis.e2e.test.ts
+++ b/cli/tests/e2e/telemetry-flow-axis.e2e.test.ts
@@ -61,6 +61,14 @@ const RECORDS = [
   }),
   // Inside the first sdlc run, but from the hand-run skill - the journal cannot tell it apart.
   record({ turn_id: "first-run-hand-run", event_timestamp: "2026-03-10T09:35:00Z", cost_usd: 3 }),
+  // After the turn ended, before the next orchestrating step opens - still the first sdlc
+  // run, which a pause does not end. The separating record for this axis: while a turn_end
+  // closed a flow, this one fell outside every flow.
+  record({
+    turn_id: "first-run-after-pause",
+    event_timestamp: "2026-03-10T09:55:00Z",
+    cost_usd: 5,
+  }),
   // Inside the second, distinct sdlc run.
   record({ turn_id: "second-run", event_timestamp: "2026-03-10T10:10:00Z", cost_usd: 4 }),
 ];
@@ -126,8 +134,8 @@ describe("aidd telemetry report — by_flow through the real adapter, on real di
     // The first run holds both the orchestrator's own record and the hand-run skill's -
     // the journal cannot tell them apart, so both count inside it.
     const firstRun = sdlcRuns.find((row) => row.started_at === "2026-03-10T09:20:00Z");
-    expect(firstRun?.totals.requests).toBe(2);
-    expect(firstRun?.totals.cost_micro_usd).toBe(5_000_000);
+    expect(firstRun?.totals.requests).toBe(3);
+    expect(firstRun?.totals.cost_micro_usd).toBe(10_000_000);
     const secondRun = sdlcRuns.find((row) => row.started_at === "2026-03-10T10:00:00Z");
     expect(secondRun?.totals.requests).toBe(1);
     expect(secondRun?.totals.cost_micro_usd).toBe(4_000_000);
@@ -142,6 +150,22 @@ describe("aidd telemetry report — by_flow through the real adapter, on real di
     const outside = envelope.by_flow.find((row) => row.flow === undefined);
     expect(outside?.totals.requests).toBe(1);
     expect(outside?.totals.cost_micro_usd).toBe(1_000_000);
+  });
+
+  it("keeps a record made after the turn ended inside the flow that was still running", async () => {
+    // The rule this axis changed on 2026-09-04, end to end: a `turn_end` is a pause, not the
+    // end of an orchestration. This record sits between the pause at 09:50 and the next
+    // orchestrating step at 10:00, so where it lands is the whole difference between the two
+    // rules - it used to be counted outside every flow.
+    const { projectDir, fakeHome } = await seed();
+
+    const result = await runCli(["telemetry", "report", ...PERIOD, "--json"], projectDir, fakeHome);
+    const envelope = JSON.parse(result.stdout) as Envelope;
+
+    const firstRun = envelope.by_flow.find((row) => row.started_at === "2026-03-10T09:20:00Z");
+    expect(firstRun?.totals.cost_micro_usd).toBe(10_000_000); // 2 + 3 + 5, the record at 09:55 included
+    const outside = envelope.by_flow.find((row) => row.flow === undefined);
+    expect(outside?.totals.cost_micro_usd).toBe(1_000_000); // the 09:10 record alone
   });
 
   it("reconciles by_flow to the same total as the period", async () => {


### PR DESCRIPTION
## What

`buildFlowIntervals` closed a flow at the first `turn_end` after it opened. The task axis stopped doing exactly that on 2026-09-04 — *"a `turn_end` is a pause, not a change of subject"* (`task-attribution.ts:28`) — and the flow axis never followed.

It is the axis where the error is largest. On this machine's sink, period `2026-08-01..2026-09-04`:

| Axis | What it named for `aidd-orchestrator:01-sdlc` |
| --- | --- |
| `by_step` | 2,220 requests |
| `by_flow` | 56 requests |

A flow is the wider concept — the orchestration and everything it drove — yet it named 40× fewer requests than the step inside it. The journal shows why: the flow opened at 05:56:27, the first `turn_end` closed it at 06:02:34, and the same session went on writing into the same task folder until 09:27:21.

## Change

A flow closes on a `step_end` naming its own skill, or on the next orchestrating `step_start`. The same rule `buildStepIntervals` adopted when `step_end` was introduced; a `step_end` naming a *different* skill never closes a flow it has no claim on.

`buildClosedIntervals` gains an opener-aware `isCloser` — "a `step_end` naming *this* flow's skill" is a fact about the pair, which a pre-filtered closer list cannot express. The walk becomes a forward scan from each opener and answers identically for an opener-independent closer, which is what `buildTaskIntervals` passes.

`cost_report_version` stays 15: no field changes shape or vocabulary, and the task axis changed its own closer under the same rule without a bump.

## Proof

Both binaries run back to back, same sink, same instant:

| | version | period total | `by_flow` sdlc | `by_flow` unnamed |
| --- | --- | --- | --- | --- |
| `origin/next` | 15 | 30,222 | 56 | 30,166 |
| this branch | 15 | 30,222 | **1,052** | 29,170 |

All eleven breakdowns sum to 30,222 on both runs, and ten of the eleven are byte-identical between the two reports — the change moved the axis it names and nothing else.

| Mutation | Killed |
| --- | --- |
| `turn_end` back in the closer | the pause guards (3) |
| no closer at all | the `step_end` guards (2) |
| close on any `step_end` | the other-skill guard (1) |
| an opener no longer closes the one before it | 1 flow guard, 2 task guards |
| unclosed ends at its own start | 19 across both axes |
| the scan starts at the opener itself | 23 across both axes |

## The residue this does not close

After the fix the flow still names fewer requests than the step inside it — 1,052 against 2,220 — and the reason is not the closer. A `StepInterval` is deliberately left open (`POSITIVE_INFINITY`), so about 1,168 of the step's requests fall after the journal stopped witnessing anything. That is a separate defect with its own reasoned defence at `step-attribution.ts:37-52`, tied to `telemetry check`'s `records-join` claim; it is filed in the plan, not touched here.

## Cost, stated

Only `aidd-dev:01-plan` emits `aidd:step-end` today, so a flow still usually closes on the next orchestrating `step_start` or the journal's own last witnessed moment. Making the three orchestrators emit the marker is a separate change in the plugin tree.

The axis also gained the end-to-end guard it lacked: `telemetry-flow-axis.e2e.test.ts` passed unchanged through this diff because its fixture ended on a `turn_end` with nothing witnessed after it — the coincidence class the unit fixtures were rewritten to escape. One record at 09:55, between the pause and the next opener, now separates the two rules, and putting `turn_end` back turns three of its five cases red.

Gates: 3416 tests / 306 files, `tsc`, `biome ci`, knip, jscpd, bundle within budget, 368 repository script tests, 0 broken links, cli layering clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWNxk63AGKkqE8HRqHLjGp
