### PR TITLE
feat(orchestrator): an orchestration says when it is done

### DIFF
--- a/aidd_docs/tasks/2026_09/2026_09_04_an-orchestration-says-when-it-is-done/plan.md
+++ b/aidd_docs/tasks/2026_09/2026_09_04_an-orchestration-says-when-it-is-done/plan.md
@@ -1,0 +1,57 @@
+---
+status: done
+---
+
+# An orchestration says when it is done
+
+## Why now
+
+The reader stopped closing a flow at a `turn_end` — *"a `turn_end` is a pause, not the end of
+an orchestration"*. What closes one now is a `step_end` naming the orchestrating skill, or
+the next orchestrating `step_start`, or, failing both, the journal's own last witnessed
+moment.
+
+The three orchestrators emit no `step_end`. So every flow falls to the last of those three,
+and an orchestration that never says it is done goes on owning everything the session did
+afterwards. The mechanism exists and has exactly one user: `aidd-dev:01-plan`.
+
+## The change
+
+Each orchestrating skill declares its own end where its work actually finishes:
+
+| Skill | Declared once |
+| --- | --- |
+| `aidd-orchestrator:01-sdlc` | the draft pull request exists |
+| `aidd-orchestrator:02-backlog` | the flow reached `done` |
+| `aidd-orchestrator:00-async-dev` | the sub-flow it committed to ran its last action |
+
+Markdown only. No hook change, no reader change: `step-ends.cjs` already reads the marker out
+of a tool call's own arguments, and the reader already treats a `step_end` naming the flow's
+own skill as its closer.
+
+## Guards
+
+`aidd-telemetry-step-end.test.js` already held one guard over this tree — every skill that
+declares an end declares it in the form the hook reads. It says nothing about a skill that
+declares none, which is exactly the new failure.
+
+The second guard reads the reader's own `ORCHESTRATING_SKILLS` and requires each
+plugin-qualified name in it to declare an end the hook resolves to that same name. A fourth
+orchestrator added to that set is covered without this test being told.
+
+| Guard | Mutation that kills it |
+| --- | --- |
+| every skill that opens a flow says when it is over | drop the marker from one orchestrator (1 failure) |
+| the end it declares is its own | point one orchestrator's marker at another skill (2 failures) |
+
+Gates: 369 repository script tests, 0 broken links, skill argument hints clean, catalogs and
+README counts regenerate to no diff.
+
+## The limit this does not remove
+
+The reader compares the two names exactly. A host that names a skill by its folder alone
+writes `01-sdlc` into `step_start` while this marker says `aidd-orchestrator:01-sdlc`, and
+the two do not match — so on Cursor and Codex these declarations still close nothing.
+`aidd-dev:01-plan`'s own marker has carried that limit since it shipped. Making the
+comparison read both spellings belongs where the comparison lives, in
+`flow-attribution.ts` and `step-attribution.ts`, not in a skill's prose.

--- a/plugins/aidd-orchestrator/skills/00-async-dev/SKILL.md
+++ b/plugins/aidd-orchestrator/skills/00-async-dev/SKILL.md
@@ -109,6 +109,19 @@ Default flow: `01 → 02 → (03 → 01 loop if continue) → 04`. Stop conditio
 - If a sub-flow aborts, surface the exit state; do not retry by switching sub-flows.
 - For batch invocations (e.g. multiple ready issues), the workflow re-invokes the skill once per item; the router does not loop.
 
+## Say when this orchestration is over
+
+Once the sub-flow you committed to has run its last action, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-orchestrator:00-async-dev"
+```
+
+No host reports when an orchestration finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that never
+hears this ends the run at the next pause — and an orchestration is mostly pauses. Everything
+it drove afterwards then reads as work that belonged to nothing.
+
 ## References
 
 - `references/routing.md` - full decision tree, signal precedence, conflict resolution.

--- a/plugins/aidd-orchestrator/skills/01-sdlc/SKILL.md
+++ b/plugins/aidd-orchestrator/skills/01-sdlc/SKILL.md
@@ -46,6 +46,19 @@ flowchart TD
   class Frame,Deliver,Check zone
 ```
 
+## Say when this orchestration is over
+
+Once the draft pull request exists, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-orchestrator:01-sdlc"
+```
+
+No host reports when an orchestration finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that never
+hears this ends the run at the next pause — and an orchestration is mostly pauses. Everything
+it drove afterwards then reads as work that belonged to nothing.
+
 ## References
 
 | #   | Reference                               |

--- a/plugins/aidd-orchestrator/skills/02-backlog/SKILL.md
+++ b/plugins/aidd-orchestrator/skills/02-backlog/SKILL.md
@@ -46,3 +46,16 @@ Run the flow above. Read only the next action file.
 - Store each relation once, in its owning artifact.
 - Ask natural questions; never expose internal routes, checks, or unchanged state.
 - Change only authorized artifacts and fields.
+
+## Say when this orchestration is over
+
+Once the flow has reached `done` — an answer given, no change needed, or `verify` reporting a coherent graph, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-orchestrator:02-backlog"
+```
+
+No host reports when an orchestration finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that never
+hears this ends the run at the next pause — and an orchestration is mostly pauses. Everything
+it drove afterwards then reads as work that belonged to nothing.

--- a/scripts/__tests__/aidd-telemetry-step-end.test.js
+++ b/scripts/__tests__/aidd-telemetry-step-end.test.js
@@ -91,3 +91,40 @@ test("every skill declaring its own end declares it in the form the hook reads",
     assert.equal(read, expected, `${relative} declares an end the hook reads as ${read}`);
   }
 });
+
+// The reader's own list of skills that open a flow, read from where it is declared rather
+// than repeated here - a fourth orchestrator added to that set is covered by this test
+// without this file being told, the same way the test above covers a fifth skill declaring
+// an end. Parsed out of the TypeScript source because that set is the one place the fact
+// lives; a copy kept here would be the second, and the two would disagree first.
+function orchestratingSkillsTheReaderKnows() {
+  const source = fs.readFileSync(
+    path.join(__dirname, "..", "..", "cli", "src", "domain", "models", "flow-attribution.ts"),
+    "utf8"
+  );
+  const declared = /ORCHESTRATING_SKILLS: ReadonlySet<string> = new Set\(\[([^\]]*)\]\)/u.exec(
+    source
+  );
+  assert.ok(declared, "the reader no longer declares its orchestrating skills as a literal set");
+  return [...declared[1].matchAll(/"([^"]+)"/gu)].map((match) => match[1]);
+}
+
+test("every skill that opens a flow also says when that flow is over", () => {
+  // Without the marker a flow closes on the next orchestrating step_start or, failing that,
+  // on the journal's own last witnessed moment - so an orchestration that never says it is
+  // done goes on owning everything the session did afterwards. The reader stopped closing a
+  // flow at a `turn_end` on 2026-09-04, which is what makes this declaration load-bearing
+  // rather than a refinement.
+  const qualified = orchestratingSkillsTheReaderKnows().filter((skill) => skill.includes(":"));
+  assert.ok(qualified.length > 0, "no orchestrating skill is named in the plugin-qualified form");
+
+  for (const skill of qualified) {
+    const [plugin, name] = skill.split(":");
+    const skillFile = path.join(pluginsDir, plugin, "skills", name, "SKILL.md");
+    assert.ok(fs.existsSync(skillFile), `${skill} names no skill in this tree`);
+    const read = declaredStepEnd({
+      tool_input: { command: fs.readFileSync(skillFile, "utf8") },
+    });
+    assert.equal(read, skill, `${skill} declares no end the hook reads as its own`);
+  }
+});


### PR DESCRIPTION
## Why now

Stacked on #763, which stopped a `turn_end` from closing a flow. What closes one now is a `step_end` naming the orchestrating skill, the next orchestrating `step_start`, or — failing both — the journal's own last witnessed moment.

The three orchestrators emit no `step_end`, so every flow falls to the last of those three and an orchestration that never says it is done goes on owning everything the session did afterwards. The mechanism has existed since `step_end` shipped and has exactly one user, `aidd-dev:01-plan`.

## Change

| Skill | Declares its end once |
| --- | --- |
| `aidd-orchestrator:01-sdlc` | the draft pull request exists |
| `aidd-orchestrator:02-backlog` | the flow reached `done` |
| `aidd-orchestrator:00-async-dev` | the sub-flow it committed to ran its last action |

Markdown only. `step-ends.cjs` already reads the marker out of a tool call's own arguments, and the reader already treats a `step_end` naming the flow's own skill as its closer.

## Guard

`aidd-telemetry-step-end.test.js` held one guard over this tree — every skill that *declares* an end declares it in the form the hook reads. It said nothing about a skill that declares none, which is exactly the new failure mode.

The new guard reads the reader's own `ORCHESTRATING_SKILLS` out of `flow-attribution.ts` and requires each plugin-qualified name in it to declare an end the hook resolves to that same name. A fourth orchestrator added to that set is covered without this test being told.

| Mutation | Result |
| --- | --- |
| drop the marker from one orchestrator | 1 failure, naming it |
| point one orchestrator's marker at another skill | 2 failures |

Gates: 369 repository script tests, 0 broken links, skill argument hints clean, catalogs and README counts regenerate to no diff.

## Limit this does not remove

The reader compares the two names exactly. A host that names a skill by its folder alone writes `01-sdlc` into `step_start` while this marker says `aidd-orchestrator:01-sdlc`, so on Cursor and Codex these declarations still close nothing — the same limit `aidd-dev:01-plan`'s marker has carried since it shipped. Making the comparison read both spellings belongs in `flow-attribution.ts` and `step-attribution.ts`, not in a skill's prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWNxk63AGKkqE8HRqHLjGp