### PR TITLE
fix(cli): clean removes the state it wrote

### DIFF
--- a/aidd_docs/tasks/2026_09/2026_09_04_clean-removes-the-state-it-wrote/plan.md
+++ b/aidd_docs/tasks/2026_09/2026_09_04_clean-removes-the-state-it-wrote/plan.md
@@ -1,0 +1,51 @@
+---
+status: done
+---
+
+# Clean removes the state it wrote
+
+## The defect
+
+`aidd clean --force` prints `Cleaned all AIDD files` and leaves `.aidd/marketplaces.json`
+behind, so `.aidd` survives a run that said it had removed everything. Reproduced on the
+built binary, sandboxed `HOME`:
+
+```
+$ node dist/cli.js marketplace add local <path> --yes
+Marketplace 'local' registered.
+$ ls -A .aidd
+cache  manifest.json  marketplaces.json
+$ node dist/cli.js clean --force
+Cleaned all AIDD files (1 files removed)
+$ ls -A .aidd
+marketplaces.json
+```
+
+The smoke harness has been reporting this as `.aidd survived clean` on every run.
+
+## The cause
+
+`removeAiddState` deletes `.aidd/cache`, `.aidd/plugin-cache` and the manifest, then removes
+`.aidd` only if nothing is left in it. The project-scope marketplace registry is never in
+that list, so the directory is never empty once a marketplace has been registered.
+
+## The rule this follows
+
+`clean-use-case.ts` already states it: *"config.json is the committed telemetry switch: a
+file clean did not write, so clean never removes it."* `marketplaces.json` is the opposite
+case — the CLI wrote it itself, at project scope, and nobody commits it. It goes.
+
+A user-scope registry lives outside the project and is untouched, as it was before.
+
+The filename now lives once, in `paths.ts` beside `AIDD_CONFIG_FILENAME`, and both the
+adapter that writes it and the use-case that removes it read it from there. A second
+spelling is how one of them forgets.
+
+## Guards
+
+| Guard | Mutation that kills it |
+| --- | --- |
+| `clean --force` removes the registry and leaves no `.aidd` | drop the deletion (unit + e2e, 3 failures) |
+| `config.json` is still kept when a registry lived beside it | delete the whole directory instead |
+
+Gates: 3422 tests / 307 files, `tsc`, `biome ci`, knip, bundle within budget.

--- a/cli/src/application/use-cases/clean-use-case.ts
+++ b/cli/src/application/use-cases/clean-use-case.ts
@@ -5,7 +5,12 @@ import {
   type MergeFileEntry,
   removeEntriesFromJson,
 } from "../../domain/models/merge.js";
-import { AIDD_CONFIG_FILENAME, AIDD_DIR, PLUGIN_CACHE_SUBDIR } from "../../domain/models/paths.js";
+import {
+  AIDD_CONFIG_FILENAME,
+  AIDD_DIR,
+  AIDD_MARKETPLACES_FILENAME,
+  PLUGIN_CACHE_SUBDIR,
+} from "../../domain/models/paths.js";
 import { isAiToolId } from "../../domain/models/tool-ids.js";
 import type { FileReader } from "../../domain/ports/file-reader.js";
 import type { FileWriter } from "../../domain/ports/file-writer.js";
@@ -58,15 +63,18 @@ export class CleanUseCase {
   }
 
   // config.json is the committed telemetry switch: a file clean did not write,
-  // so clean never removes it. Every directory clean did write must go before
-  // the emptiness check, or its own presence blocks a removal that should
-  // happen.
+  // so clean never removes it. marketplaces.json is the opposite case and goes:
+  // the CLI wrote it itself, and left behind it kept `.aidd` alive after a run
+  // that reported it had cleaned all AIDD files. Every directory and file clean
+  // did write must go before the emptiness check, or its own presence blocks a
+  // removal that should happen.
   private async removeAiddState(projectRoot: string): Promise<void> {
     const aiddDir = join(projectRoot, AIDD_DIR);
     const configKept = await this.fs.fileExists(join(aiddDir, AIDD_CONFIG_FILENAME));
 
     await this.fs.deleteDirectory(join(aiddDir, "cache"));
     await this.fs.deleteDirectory(join(projectRoot, PLUGIN_CACHE_SUBDIR));
+    await this.fs.deleteFile(join(aiddDir, AIDD_MARKETPLACES_FILENAME));
     await this.manifestRepo.delete();
 
     if (!(await this.fs.fileExists(aiddDir))) return;

--- a/cli/src/domain/models/paths.ts
+++ b/cli/src/domain/models/paths.ts
@@ -2,6 +2,9 @@ import { join } from "node:path";
 
 export const AIDD_DIR = ".aidd";
 export const AIDD_CONFIG_FILENAME = "config.json";
+/** The project-scope marketplace registry, named once: `MarketplaceRegistryAdapter` writes
+ * it and `CleanUseCase` removes it, and a second spelling is how one of them forgets. */
+export const AIDD_MARKETPLACES_FILENAME = "marketplaces.json";
 export const DOCS_DIR = "aidd_docs" as const;
 export const RUNS_SUBDIR = "runs" as const;
 export const PLUGIN_CACHE_SUBDIR = join(AIDD_DIR, "plugin-cache");

--- a/cli/src/infrastructure/adapters/marketplace-registry-adapter.ts
+++ b/cli/src/infrastructure/adapters/marketplace-registry-adapter.ts
@@ -6,10 +6,9 @@ import {
   type MarketplaceData,
   type MarketplaceScope,
 } from "../../domain/models/marketplace.js";
-import { AIDD_DIR } from "../../domain/models/paths.js";
+import { AIDD_DIR, AIDD_MARKETPLACES_FILENAME } from "../../domain/models/paths.js";
 import type { MarketplaceRegistry } from "../../domain/ports/marketplace-registry.js";
 
-const REGISTRY_FILENAME = "marketplaces.json";
 const SCHEMA_VERSION = 1;
 
 interface RegistryFile {
@@ -70,13 +69,13 @@ export class MarketplaceRegistryAdapter implements MarketplaceRegistry {
   }
 
   private projectPath(projectRoot: string): string {
-    return join(projectRoot, AIDD_DIR, REGISTRY_FILENAME);
+    return join(projectRoot, AIDD_DIR, AIDD_MARKETPLACES_FILENAME);
   }
 
   private userPath(): string {
     const override = process.env.AIDD_USER_CONFIG_DIR;
     const dir = override ?? join(homedir(), ".config", "aidd");
-    return join(dir, REGISTRY_FILENAME);
+    return join(dir, AIDD_MARKETPLACES_FILENAME);
   }
 
   private async read(path: string, scope: MarketplaceScope): Promise<Marketplace[]> {

--- a/cli/tests/application/use-cases/clean-use-case.unit.test.ts
+++ b/cli/tests/application/use-cases/clean-use-case.unit.test.ts
@@ -125,4 +125,47 @@ describe("clean", () => {
 
     expect(deps.fs.listUnder(join(PROJECT_ROOT, ".aidd")).length).toBe(0);
   });
+
+  it("removes .aidd/marketplaces.json, which the CLI wrote and no person committed", async () => {
+    // The registry is this tool's own project-scope state, unlike config.json, which a
+    // person commits and clean therefore keeps. Left behind, `.aidd` survives a run that
+    // reported it had cleaned all AIDD files.
+    const deps = await buildUnitDeps(PROJECT_ROOT);
+    await initAndInstall(deps, PROJECT_ROOT, "claude" as ToolId);
+
+    const registry = join(PROJECT_ROOT, ".aidd", "marketplaces.json");
+    await deps.fs.writeFile(registry, JSON.stringify({ version: 1, marketplaces: [] }));
+
+    const useCase = new CleanUseCase(
+      deps.fs,
+      deps.manifestRepo,
+      deps.logger,
+      deps.gitignoreUseCase
+    );
+    await useCase.execute({ projectRoot: PROJECT_ROOT, force: true });
+
+    expect(deps.fs.has(registry)).toBe(false);
+    expect(deps.fs.listUnder(join(PROJECT_ROOT, ".aidd")).length).toBe(0);
+  });
+
+  it("still keeps .aidd/config.json when a registry lived beside it", async () => {
+    const deps = await buildUnitDeps(PROJECT_ROOT);
+    await initAndInstall(deps, PROJECT_ROOT, "claude" as ToolId);
+
+    const config = join(PROJECT_ROOT, ".aidd", "config.json");
+    const registry = join(PROJECT_ROOT, ".aidd", "marketplaces.json");
+    await deps.fs.writeFile(config, JSON.stringify({ telemetry: { enabled: true } }));
+    await deps.fs.writeFile(registry, JSON.stringify({ version: 1, marketplaces: [] }));
+
+    const useCase = new CleanUseCase(
+      deps.fs,
+      deps.manifestRepo,
+      deps.logger,
+      deps.gitignoreUseCase
+    );
+    await useCase.execute({ projectRoot: PROJECT_ROOT, force: true });
+
+    expect(deps.fs.has(config)).toBe(true);
+    expect(deps.fs.has(registry)).toBe(false);
+  });
 });

--- a/cli/tests/e2e/clean.e2e.test.ts
+++ b/cli/tests/e2e/clean.e2e.test.ts
@@ -124,4 +124,26 @@ describe.concurrent("E2E: aidd clean", () => {
       await cleanup();
     }
   });
+
+  it("leaves no .aidd behind when a marketplace was registered", async () => {
+    // The state the CLI wrote itself. Left behind, `.aidd` survived a run that had just
+    // printed that it cleaned all AIDD files.
+    const { projectDir, fakeHome, cleanup } = await createTestEnv("clean-registry");
+    try {
+      await seedManifest(projectDir);
+      await runCli(["ai", "install", "claude"], projectDir, fakeHome);
+      await writeFile(
+        join(projectDir, AIDD_DIR, "marketplaces.json"),
+        JSON.stringify({ version: 1, marketplaces: [] }),
+        "utf-8"
+      );
+
+      const { exitCode } = await runCli(["clean", "--force"], projectDir, fakeHome);
+
+      expect(exitCode).toBe(0);
+      expect(existsSync(join(projectDir, AIDD_DIR))).toBe(false);
+    } finally {
+      await cleanup();
+    }
+  });
 });


### PR DESCRIPTION
## What

`aidd clean --force` printed `Cleaned all AIDD files` and left `.aidd/marketplaces.json` behind, so `.aidd` survived a run that said it had removed everything.

```
$ aidd marketplace add local <path> --yes
Marketplace 'local' registered.
$ aidd clean --force
Cleaned all AIDD files (1 files removed)
$ ls -A .aidd
marketplaces.json
```

The smoke harness has been reporting this as `.aidd survived clean` on every run.

## Why

`removeAiddState` deletes `.aidd/cache`, `.aidd/plugin-cache` and the manifest, then removes `.aidd` only if nothing is left in it. The project-scope marketplace registry was never in that list.

The rule the file already states decides which way it goes: *"config.json is the committed telemetry switch: a file clean did not write, so clean never removes it."* `marketplaces.json` is the opposite case — the CLI wrote it itself, at project scope, and nobody commits it. A user-scope registry lives outside the project and is untouched.

The filename now lives once in `paths.ts` beside `AIDD_CONFIG_FILENAME`, read by both the adapter that writes it and the use-case that removes it.

## Guards

| Guard | Mutation that kills it |
| --- | --- |
| `clean --force` removes the registry and leaves no `.aidd` | drop the deletion — 2 unit + 1 e2e failures |
| `config.json` is still kept when a registry lived beside it | delete the whole directory instead |

Gates: 3422 tests / 307 files, `tsc`, `biome ci`, knip, bundle within budget, 0 broken links, cli layering clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWNxk63AGKkqE8HRqHLjGp