### PR TITLE
fix(telemetry): a step end names its skill either way

### DIFF
--- a/aidd_docs/tasks/2026_09/2026_09_04_a-step-end-names-its-skill-either-way/plan.md
+++ b/aidd_docs/tasks/2026_09/2026_09_04_a-step-end-names-its-skill-either-way/plan.md
@@ -1,0 +1,51 @@
+---
+status: done
+---
+
+# A step end names its skill either way
+
+## The limit two changes just declared
+
+Both the flow closer and the step closer compared the two names with `===`. `skill-detection.cjs`
+has two capture routes and each writes a different spelling:
+
+| Route | Hosts | Writes |
+| --- | --- | --- |
+| `skillNameFromArgument` | Claude Code, Copilot | `aidd-dev:01-plan` |
+| `skillNameFromSkillFileRead` | Cursor, Codex | `01-plan` |
+
+The end is not captured by either: it is read out of the text a skill echoes, and a skill
+always names itself in full, because that is what it knows itself as. So on Cursor and Codex
+a step opened as `01-plan` met an end named `aidd-dev:01-plan`, matched nothing, and fell
+back to the next opener as if the skill had never said it was done.
+
+`aidd-dev:01-plan` has carried that since `step_end` shipped. The orchestrators' own markers
+would have carried it from birth.
+
+## The change
+
+One predicate, `namesTheSameSkill`, used by both readers. Equal outright, or equal once a
+`plugin:` prefix comes off — and only when one side carries no plugin at all. Two qualified
+names that disagree stay two skills: `aidd-dev:01-plan` and `aidd-pm:01-plan` are never
+folded together.
+
+The cost is stated where the function lives: an unqualified `01-plan` closes whichever
+`01-plan` is open, whatever plugin it came from. The host threw the plugin away before this
+code saw the line, and no reader can put it back. It is the same limit `ORCHESTRATING_SKILLS`
+already names for a project whose own skill shares a directory name with an orchestrator.
+
+## Guards
+
+| Guard | Mutation that kills it |
+| --- | --- |
+| a bare opener is closed by a full-name end, in a step and in a flow | compare with `===` again (4 failures) |
+| two qualified names that disagree are never folded | drop the both-qualified check (3 failures) |
+| the prefix actually comes off at the colon | return the name unchanged (2 failures) |
+
+Gates: 3434 tests / 308 files, `tsc`, `biome ci`, knip, jscpd, bundle within budget.
+
+## Not proven by the sink
+
+This machine's own journals were written by Claude Code, which spells the name in full both
+times, so the corpus cannot separate the two rules. The guards are the proof, and the hosts
+this fixes are Cursor and Codex.

--- a/cli/src/domain/models/flow-attribution.ts
+++ b/cli/src/domain/models/flow-attribution.ts
@@ -6,6 +6,7 @@ import type {
   RunJournalTaskDeclared,
 } from "../ports/run-journal-reader.js";
 import { buildClosedIntervals, type ClosedInterval } from "./journal-intervals.js";
+import { namesTheSameSkill } from "./skill-name.js";
 
 /**
  * Which skills open a flow when their own `step_start` fires - declared here, once, rather
@@ -133,7 +134,8 @@ export function buildFlowIntervals(
     periodEndMs,
     (boundary): boundary is RunJournalStepStart =>
       boundary.type === "step_start" && ORCHESTRATING_SKILLS.has(boundary.skill),
-    (boundary, opener) => boundary.type === "step_end" && boundary.skill === opener.skill,
+    (boundary, opener) =>
+      boundary.type === "step_end" && namesTheSameSkill(boundary.skill, opener.skill),
     (opener, startMs, endMs) => ({ skill: opener.skill, startMs, endMs })
   );
 }

--- a/cli/src/domain/models/skill-name.ts
+++ b/cli/src/domain/models/skill-name.ts
@@ -1,0 +1,39 @@
+/** Whether two journal lines name the same skill, when the two hosts that wrote them do not
+ * spell it the same way.
+ *
+ * `skill-detection.cjs` has two capture routes and each writes a different spelling.
+ * `skillNameFromArgument` (Claude Code, Copilot) hands over the host's own argument,
+ * `aidd-dev:01-plan`. `skillNameFromSkillFileRead` (Cursor, Codex) has no such argument and
+ * falls back to the bare directory name a `SKILL.md` path names, `01-plan`. One session can
+ * hold both: the start is captured by whichever route the host allows, and the end is read
+ * out of the text a skill echoes, which always carries the plugin-qualified form because
+ * that is what the skill knows itself as.
+ *
+ * So an exact comparison makes a declared end close nothing at all on Cursor and Codex -
+ * `01-plan` opened, `aidd-dev:01-plan` ended, no match - and the interval falls back to the
+ * next opener as if the skill had never said it was done.
+ *
+ * Qualified against qualified is compared whole: `aidd-dev:01-plan` and `aidd-pm:01-plan`
+ * are two skills, and nothing may fold them together. Only when one side carries no plugin
+ * at all does the bare name decide, because that side has nothing else to offer. The cost is
+ * stated rather than hidden: an unqualified `01-plan` closes whichever `01-plan` is open,
+ * whatever plugin it came from. That is the same limit `ORCHESTRATING_SKILLS` already names
+ * for a project whose own skill shares a directory name with an orchestrator - the host
+ * threw the plugin away before this code ever saw the line, and no reader can put it back.
+ */
+export function namesTheSameSkill(one: string, other: string): boolean {
+  if (one === other) return true;
+  const oneQualified = one.includes(":");
+  const otherQualified = other.includes(":");
+  // Both spellings carry a plugin, and they disagree: two skills, never one.
+  if (oneQualified && otherQualified) return false;
+  return bareSkillName(one) === bareSkillName(other);
+}
+
+/** The skill's own name with any `plugin:` prefix dropped - what a host that never saw the
+ * plugin would have written. The separator is the first colon, matching the one shape this
+ * domain has: `plugin:skill`, or a bare `skill`. */
+function bareSkillName(skill: string): string {
+  const separator = skill.indexOf(":");
+  return separator === -1 ? skill : skill.slice(separator + 1);
+}

--- a/cli/src/domain/models/step-attribution.ts
+++ b/cli/src/domain/models/step-attribution.ts
@@ -1,4 +1,5 @@
 import type { RunJournal, RunJournalBoundary } from "../ports/run-journal-reader.js";
+import { namesTheSameSkill } from "./skill-name.js";
 
 /** How a record's step came to be known. Never collapsed into one field with the step
  * name itself: a name the tool stated and one taken from an interval answer differently
@@ -88,11 +89,14 @@ function parseableBoundaries(boundaries: readonly RunJournalBoundary[]): readonl
  * With no such line, the rule is the one this reader always had - the next `step_start` or
  * `turn_end`, or nothing. A `step_end` naming a *different* skill is never a closer here: it
  * would truncate a step it has no claim on, which is the fault naming the skill exists to
- * prevent. */
+ * prevent. Same or different is `namesTheSameSkill`'s answer, not `===`: the host that
+ * opened the step may have written the skill's bare directory name while the end the skill
+ * echoes carries its plugin. */
 function stepEndsAt(timed: readonly TimedBoundary[], from: number, skill: string): number {
   for (let i = from + 1; i < timed.length; i++) {
     const { boundary } = timed[i];
-    if (boundary.type === "step_end" && boundary.skill === skill) return timed[i].atMs;
+    if (boundary.type === "step_end" && namesTheSameSkill(boundary.skill, skill))
+      return timed[i].atMs;
   }
   for (let i = from + 1; i < timed.length; i++) {
     if (timed[i].boundary.type !== "step_end") return timed[i].atMs;

--- a/cli/tests/domain/models/flow-attribution.unit.test.ts
+++ b/cli/tests/domain/models/flow-attribution.unit.test.ts
@@ -117,6 +117,31 @@ describe("buildFlowIntervals — pure: journal lines -> bounded flow intervals",
     ]);
   });
 
+  it("closes a flow opened by its bare name with the end the orchestrator declares in full", () => {
+    // Cursor and Codex write `01-sdlc` into step_start - the plugin never reaches the
+    // journal - while the end the skill echoes always carries it. Compared exactly, the
+    // declaration those hosts capture closed nothing at all.
+    const bareOpener = {
+      type: "step_start",
+      at: "2026-08-17T10:00:00Z",
+      skill: "01-sdlc",
+    } as const;
+    const intervals = buildFlowIntervals(journalOf([bareOpener, SDLC_ENDS], [], [WRITTEN_LATE]));
+
+    expect(intervals[0]?.endMs).toBe(Date.parse(SDLC_ENDS.at));
+  });
+
+  it("still refuses an end whose plugin disagrees with the one that opened the flow", () => {
+    const otherPlugin = {
+      type: "step_end",
+      at: "2026-08-17T11:00:00Z",
+      skill: "acme:01-sdlc",
+    } as const;
+    const intervals = buildFlowIntervals(journalOf([SDLC_OPENS, otherPlugin], [], [WRITTEN_LATE]));
+
+    expect(intervals[0]?.endMs).toBe(Date.parse(WRITTEN_LATE.at));
+  });
+
   it("never closes a flow on a step_end naming some other skill", () => {
     // A step run inside the orchestration ends; the orchestration does not. Distinguishing:
     // something is witnessed after that end, so closing there and not closing there are two

--- a/cli/tests/domain/models/skill-name.unit.test.ts
+++ b/cli/tests/domain/models/skill-name.unit.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { namesTheSameSkill } from "../../../src/domain/models/skill-name.js";
+
+describe("namesTheSameSkill — one skill, two hosts, two spellings", () => {
+  it("holds for the identical spelling", () => {
+    expect(namesTheSameSkill("aidd-dev:01-plan", "aidd-dev:01-plan")).toBe(true);
+    expect(namesTheSameSkill("01-plan", "01-plan")).toBe(true);
+  });
+
+  it("holds when only one side carries the plugin, whichever side that is", () => {
+    // The case this exists for: Cursor and Codex open a step as `01-plan`, and the end the
+    // skill echoes always says `aidd-dev:01-plan`.
+    expect(namesTheSameSkill("01-plan", "aidd-dev:01-plan")).toBe(true);
+    expect(namesTheSameSkill("aidd-dev:01-plan", "01-plan")).toBe(true);
+  });
+
+  it("never folds two qualified names together, however alike their skill halves", () => {
+    expect(namesTheSameSkill("aidd-dev:01-plan", "aidd-pm:01-plan")).toBe(false);
+  });
+
+  it("says no to two skills that share no name at all", () => {
+    expect(namesTheSameSkill("aidd-dev:01-plan", "aidd-dev:06-test")).toBe(false);
+    expect(namesTheSameSkill("01-plan", "06-test")).toBe(false);
+  });
+
+  it("drops the plugin at the first colon, the one shape this domain has", () => {
+    // A hyphenated skill name is still one name; only the `plugin:` prefix comes off.
+    expect(namesTheSameSkill("artifact-design", "aidd-context:artifact-design")).toBe(true);
+    expect(namesTheSameSkill("artifact-design", "aidd-context:artifact-diagramming")).toBe(false);
+  });
+});

--- a/cli/tests/domain/models/step-attribution.unit.test.ts
+++ b/cli/tests/domain/models/step-attribution.unit.test.ts
@@ -75,6 +75,38 @@ describe("step-attribution — pure: journal lines + records -> intervals", () =
     expect(outer?.endMs).toBe(Date.parse("2026-08-20T10:05:00Z"));
   });
 
+  // Cursor and Codex name a skill by its folder alone - the plugin never reaches the journal
+  // - while the end a skill echoes always carries the plugin, because that is what the skill
+  // knows itself as. Compared exactly, a declared end closed nothing at all on those hosts.
+  it("closes a step opened by its bare name with the end its skill declares in full", () => {
+    const bareStart = {
+      type: "step_start",
+      at: "2026-08-20T10:00:00Z",
+      skill: "02-implement",
+    } as const;
+    const intervals = buildStepIntervals(
+      journalOf(
+        bareStart,
+        { type: "turn_end", at: "2026-08-20T10:10:00Z" },
+        { type: "step_end", at: "2026-08-20T10:30:00Z", skill: "aidd-dev:02-implement" }
+      )
+    );
+
+    expect(intervals[0]?.endMs).toBe(Date.parse("2026-08-20T10:30:00Z"));
+  });
+
+  it("still refuses an end whose plugin disagrees with the one that opened the step", () => {
+    const intervals = buildStepIntervals(
+      journalOf(A_START, {
+        type: "step_end",
+        at: "2026-08-20T10:02:00Z",
+        skill: "aidd-pm:02-implement",
+      })
+    );
+
+    expect(intervals[0]?.endMs).not.toBe(Date.parse("2026-08-20T10:02:00Z"));
+  });
+
   // An end for a skill that never started names nothing to close. Read as a boundary all the
   // same it would truncate whatever interval was running, which is a step it has no claim on.
   it("ignores an end for a skill this session never started", () => {


### PR DESCRIPTION
## What

Both closers compared the two names with `===`. `skill-detection.cjs` has two capture routes and they disagree:

| Route | Hosts | Writes |
| --- | --- | --- |
| `skillNameFromArgument` | Claude Code, Copilot | `aidd-dev:01-plan` |
| `skillNameFromSkillFileRead` | Cursor, Codex | `01-plan` |

The end is captured by neither — it is read out of the text a skill echoes, and a skill always names itself in full, because that is what it knows itself as. So on Cursor and Codex a step opened as `01-plan` met an end named `aidd-dev:01-plan`, matched nothing, and ran on as if the skill had never said it was done.

`aidd-dev:01-plan` has carried this since `step_end` shipped; #763 and #764 both had to declare it as a standing limit. This removes it.

## Change

One predicate, `namesTheSameSkill`, for the step axis and the flow axis: equal outright, or equal once a `plugin:` prefix comes off — and only when one side carries no plugin at all. Two qualified names that disagree stay two skills, so `aidd-dev:01-plan` and `aidd-pm:01-plan` are never folded together.

The cost is stated where the function lives: an unqualified `01-plan` closes whichever `01-plan` is open, whatever plugin it came from. The host threw the plugin away before this code saw the line, and no reader can put it back — the same limit `ORCHESTRATING_SKILLS` already names.

## Guards

| Guard | Mutation that kills it |
| --- | --- |
| a bare opener is closed by a full-name end, in a step and in a flow | compare with `===` again — 4 failures |
| two qualified names that disagree are never folded | drop the both-qualified check — 3 failures |
| the prefix actually comes off at the colon | return the name unchanged — 2 failures |

## Not proven by the sink

This machine's journals were written by Claude Code, which spells the name in full on both sides, so the corpus cannot separate the two rules. The guards are the proof; the hosts this fixes are Cursor and Codex.

## What this does not change

`by_step` keys its rows on the spelling the `step_start` wrote, and `--step <name>` matches that same stored value exactly. Both are unchanged: this PR moves only where an interval *ends*, never how the row it produces is named. Two openers of one skill spelled differently in the same period therefore still read as two rows - the standing limit already stated on `ORCHESTRATING_SKILLS`, not one this introduces. Verified: no other site in `cli/src/domain` or `cli/src/application` compares two skill names, so the two closers are the only comparisons and both now go through `namesTheSameSkill`.

Gates: 3434 tests / 308 files, `tsc`, `biome ci`, knip, jscpd, bundle within budget, 369 repository script tests, 0 broken links, cli layering clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWNxk63AGKkqE8HRqHLjGp
