### PR TITLE
feat(telemetry): a flow the tool named is a flow

### DIFF
--- a/aidd_docs/product/cost-report-contract.md
+++ b/aidd_docs/product/cost-report-contract.md
@@ -282,7 +282,7 @@ one. Adding a field you may ignore is not a bump; changing what an existing fiel
   "by_project": [{ "project": "acme/widgets", "totals": {} }],   // a row with no `project` names none known
   "by_task":    [{ "task": "2026_08/2026_08_21_cost-reporter", "attribution": "declared", "totals": {} }, { "reason": "precedes-declaration", "totals": {} }],  // a row with no `task` carries `reason` instead, naming which of five facts applies; up to five such rows
   "by_backlog": [{ "backlog": "ai-driven-dev/framework#661", "totals": {} }, { "declaration": "none", "totals": {} }, { "declaration": "unreadable", "totals": {} }, { "reason": "precedes-declaration", "totals": {} }],  // a row with no `backlog` carries `declaration` (a known task naming none, or one whose declaration could not be read) or `reason` (a record in no task at all) — never both, never neither
-  "by_flow":    [{ "flow": "aidd-orchestrator:01-sdlc", "started_at": "2026-07-01T09:00:00Z", "totals": {} }, { "flow": "aidd-orchestrator:01-sdlc", "started_at": "2026-07-01T11:00:00Z", "totals": {} }, { "totals": {} }],  // two runs of the same skill are two rows, told apart by `started_at`; the last row is work that fell in no flow interval at all
+  "by_flow":    [{ "flow": "aidd-orchestrator:01-sdlc", "attribution": "journal-interval", "started_at": "2026-07-01T09:00:00Z", "totals": {} }, { "flow": "aidd-orchestrator:01-sdlc", "attribution": "journal-interval", "started_at": "2026-07-01T11:00:00Z", "totals": {} }, { "flow": "aidd-orchestrator:01-sdlc", "attribution": "tool-stated", "totals": {} }, { "attribution": "unattributed", "totals": {} }],  // two runs of the same skill are two rows, told apart by `started_at`; a `tool-stated` row is every run of that skill only the record's own tool named, so it carries no `started_at`; the last row is work that joined neither
   "by_day":     [{ "day": "2026-07-01", "totals": {} }],         // every day in the period, in order, gaps included
   "by_person":  [{ "resolution": "mapped", "person": "a-person-id", "identities": ["a-person-id", "a-machine-id"], "totals": {} }],  // mapped rows first, then every unplaced identity, then the one row for records carrying none
   "attribution": [{ "attribution": "tool-stated", "totals": {} }],
@@ -437,8 +437,10 @@ unrelated to a task: `aidd-orchestrator:01-sdlc` running end to end is one flow,
 tasks or backlog items it touched along the way. Nothing new is captured for it. Skill
 detection already writes a `step_start` line for any skill, orchestrating or not (the same
 lines `by_step` reads), so a flow is *read* from that sequence, never declared by a hook:
-one flow opens at an orchestrating skill's own `step_start` and closes at whichever of the
-next orchestrating `step_start` or a `turn_end` comes first.
+one flow opens at an orchestrating skill's own `step_start` and closes at a `step_end`
+naming that same skill, at the next orchestrating `step_start`, or — for a flow nothing ever
+closes — at the journal's own last witnessed moment. A `turn_end` is a pause, not a close: a
+flow spanning three prompts is exactly the case a `turn_end` used to cut short.
 
 **Which skills orchestrate is declared, once, never matched from a plugin string.** No
 skill's own frontmatter says it orchestrates, and more than one skill in this framework's
@@ -448,15 +450,34 @@ argument-stated name and a bare directory name — see that module's own doc com
 why both exist) — extending it for a project's own orchestrator is the one change adding a
 new one to this axis ever needs.
 
-A row's `flow` names the orchestrating skill; `started_at` names the moment it opened. Both
-are needed to tell two rows apart: **two orchestrated runs of the same skill in one session
-are two rows, never merged into one** — `by_flow` groups by the closed interval a record's
-own moment falls inside, not by the skill's name alone, the same distinction `by_step`
-already draws between a step reached by two different routes. A row with neither field is
-every record whose own moment fell in no flow interval at all — work before the first
-orchestrating step, or between one flow's `turn_end` and the next flow's own opening. There
-is no `reason` breakdown the way `by_task`'s remainder has one: a flow is read from the same
-sequence whichever way a record misses it, so there is only ever the one fact to state.
+A row's `flow` names the orchestrating skill, `attribution` says how that flow came to be
+known, and `started_at` names the moment it opened. All three tell two rows apart: **two
+orchestrated runs of the same skill in one session are two rows, never merged into one** —
+an `attribution: "journal-interval"` row groups by the closed interval a record's own moment
+falls inside, not by the skill's name alone, the same distinction `by_step` already draws
+between a step reached by two different routes. A row with no `flow` at all, carrying
+`attribution: "unattributed"`, is every record that joined neither an interval nor a stated
+flow. There is no `reason` breakdown the way `by_task`'s remainder has one: a flow is read
+from the same sequence whichever way a record misses it, so there is only ever the one fact
+to state.
+
+**A flow a record's own tool named is a flow.** A session resumed after its context was
+compacted invokes nothing again, so no `step_start` hook fires and its journal opens no flow
+— while the transcript goes on stating the step on every record it produces. A record no
+interval covers, whose own `step_attribution` is `tool-stated` and whose `step` names an
+orchestrating skill, joins a row for that skill carrying `attribution: "tool-stated"`. That
+row has no `started_at`: it is a bucket drawn from however many runs of that skill the tool
+named, and a name is not a run. Only the tool's own statement opens such a row — a
+`journal-interval` step is an inference from the very intervals already checked, and a
+`prompt-matched` one names a step rather than an orchestration.
+
+**An interval wins over a stated flow, and the reason is granularity, not strength.** Where
+a record falls inside an interval, that interval's row is the one it joins, even though its
+tool stated the same skill. Elsewhere the preference runs the other way — `withStepBackfill`
+prefers a tool-stated step over a journal-interval one — and the two are not in conflict,
+because they answer different questions. There the question is *which skill*, and the tool
+naming its own beats an inference from a moment. Here the question is *which run*, and only
+an interval can say.
 
 **A skill a person runs by hand while a flow is open counts inside it.** The journal cannot
 tell a hand-run skill from one the orchestrator itself invoked — both write the identical

--- a/aidd_docs/tasks/2026_09/2026_09_05_a-flow-the-tool-named-is-a-flow/plan.md
+++ b/aidd_docs/tasks/2026_09/2026_09_05_a-flow-the-tool-named-is-a-flow/plan.md
@@ -1,0 +1,140 @@
+---
+status: done
+---
+
+# A flow the tool named is a flow
+
+## The defect
+
+`by_flow` decides a record's flow from journal intervals and nothing else
+(`cost-report.ts`'s `flowKeyOf`). A record whose own transcript states the orchestrating
+skill it ran under is reported in the unnamed row, however plainly it says so.
+
+Measured on this machine's sink, period `2026-08-06..2026-09-05`, 30,222 requests, on the
+binary built from `9fc819ef`:
+
+| Axis | `aidd-orchestrator:01-sdlc` | Attribution |
+| --- | --- | --- |
+| `by_step` | 2,220 | `tool-stated` |
+| `by_step` | 1 | `journal-interval` |
+| `by_flow` | 1,052 | journal interval, the only source it has |
+
+The two axes are not disagreeing about one flow. They are looking at two different
+sessions:
+
+- The 1,052 come from the session whose journal holds the corpus's only orchestrating
+  `step_start`, window `05:21:27Z -> 09:27:21Z` on 2026-09-04.
+- The 2,220 come from a second session, `2026-08-18T11:14Z -> 2026-09-02T19:48Z`, that has
+  a journal on disk with **six `step_end` lines and no `step_start` at all**. Every one of
+  its 2,699 orchestrating records (2,220 inside the period) carries
+  `step_attribution: "tool-stated"` — the transcript itself naming the skill, the strongest
+  evidence this system has.
+
+So `by_flow` reports 2,220 requests as belonging to no flow while `by_step`, reading the
+same records, names the flow they ran under.
+
+### Correcting two earlier claims
+
+- The plan for #763 compares `by_step` 2,220 against `by_flow` 56 as though both described
+  one flow. They never did: the 2,220 were always tool-stated and always came from the
+  other session. #763's own fix stands — it moved that session's flow from 56 to 1,052,
+  measured on the same journal — but the "40 times fewer" framing overstated what a single
+  closer could ever account for.
+- The same plan files `buildStepIntervals`'s open last interval (`POSITIVE_INFINITY`) as
+  attributing roughly 1,168 requests after the journal stopped witnessing. It does not.
+  Neither journal in the corpus has an unclosed `step_start`, and the whole corpus yields
+  exactly **one** record attributed by journal interval on this axis. The open interval is a
+  real asymmetry, and it is not where a number is wrong.
+- That plan also records, as a reason not to close the last interval, that
+  `aidd telemetry check`'s `records-join` claim "starts failing for every unclosed session".
+  It does not: `joinedVerdict` fails only when `joined.length === 0`
+  (`telemetry-claim.ts:432`), never on a ratio.
+
+## Why a session states a step its journal never opened
+
+`step_start` is written by a hook when a skill is invoked. A session resumed after its
+context was compacted carries its skills forward in the restored context, so nothing is
+invoked again and no hook fires — while the transcript keeps stating the step on every
+record it produces. The journal for that session shows exactly that shape: ends without
+starts.
+
+This is not an error to repair at the write path. It is a capture the journal cannot make,
+and a second source that already made it.
+
+## The change
+
+`flowKeyOf` gains one fallback, and only one: a record that falls inside no flow interval,
+whose own `step_attribution` is `tool-stated` and whose `step` names an orchestrating skill,
+joins a row for that skill.
+
+Two row kinds, never merged:
+
+| Row | Keyed on | `attribution` | `started_at` |
+| --- | --- | --- | --- |
+| a flow the journal witnessed | the `FlowInterval` object, by reference | `journal-interval` | the interval's own start |
+| a flow only the tool named | the skill name | `tool-stated` | absent |
+
+Keeping them apart is what preserves the property `buildFlowIntervals` argues for: two
+orchestrated runs of one skill in one session are two rows, because two intervals are two
+objects. A name is not a run, so the tool-stated row cannot make that distinction and must
+not pretend to — it is a bucket drawn from many runs, and carries no start for the same
+reason the no-prompt row carries none.
+
+**An interval wins over a tool-stated step, and the reason is granularity, not strength.**
+`withStepBackfill` prefers a tool-stated step over a journal-interval one, and this
+preference runs the other way; the two are not in conflict because they answer different
+questions. There, the question is *which skill* — and the tool naming its own skill beats an
+inference from a moment. Here, the question is *which run* — and only an interval can say.
+A record inside an interval is already inside the run the tool would have named anyway.
+
+## Reconciliation
+
+`by_flow` must keep summing to the period total. The unnamed row loses exactly what the new
+row gains; nothing is counted twice, because a record joins the tool-stated row only when it
+joined no interval.
+
+## Envelope
+
+No bump. The flow row gains `attribution`, a field a consumer may ignore, and no existing
+field changes meaning — the rule stated at `cost-report-envelope.ts`. Every consumer of
+`by_flow` is enumerated and updated in the same commit: the terminal display, the `--axis`
+artefact, and the envelope's own type.
+
+## Guards
+
+| Guard | Mutation that must kill it |
+| --- | --- |
+| a tool-stated orchestrating record with no interval joins a row named for its skill | drop the fallback |
+| a record inside an interval stays on the interval's row, never the tool-stated one | let the fallback run first |
+| a tool-stated step that names no orchestrating skill joins no flow row | drop the `ORCHESTRATING_SKILLS` check |
+| a `journal-interval` step attribution never opens a flow row | accept any attribution, not only `tool-stated` |
+| every `by_flow` row sums to the period total | remove the record from the unnamed row without adding it elsewhere |
+
+## Proof
+
+Two binaries, `9fc819ef` and this branch, run back to back against one copy of the sink in a
+sandboxed `HOME`, period `--days 30`, 30,222 requests on both.
+
+| `by_flow` row | `9fc819ef` | this branch |
+| --- | --- | --- |
+| `aidd-orchestrator:01-sdlc`, `journal-interval` | 1,052 | 1,052 |
+| `aidd-orchestrator:01-sdlc`, `tool-stated` | — | **2,208** |
+| no flow | 29,170 | 26,962 |
+
+The unnamed row drops by exactly 2,208, and all eleven breakdowns sum to 30,222 on both.
+
+**2,208, not the 2,220 `by_step` names.** The twelve missing are the twelve tool-stated
+records that fall inside the journal's own interval — the precedence rule, visible in real
+data: an interval wins, so those twelve stay on the `journal-interval` row rather than
+being counted twice or moved.
+
+## Still outstanding
+
+`by_prompt`'s doc comment calls it *"the one breakdown that is complete by construction"*
+(`cost-report.ts`, `cost-report-envelope.ts`). Measured the same day on the same sink: 843
+of 30,714 records carry no `prompt_id` — 811 of them in one session, all stored under CLI
+`5.2.2` before the transcript reader resolved the field, and 90 of the 91 whose transcript
+lines survive resolve one today from unchanged bytes. The claim needs correcting to what
+the census shows, and the cause named: `storeNewCandidates` freezes a record's field set at
+first sight, so a gap a later reader could fill stays permanently. Not folded in here — it
+is a different axis and its own argument.

--- a/cli/src/application/display/cost-report-artefact.ts
+++ b/cli/src/application/display/cost-report-artefact.ts
@@ -282,21 +282,40 @@ function backlogArtefact(envelope: CostReportEnvelope): string {
 const OUTSIDE_EVERY_FLOW_LABEL = "outside any flow";
 
 /** What this axis cannot tell apart, printed with the figures rather than left in a doc
- * comment no reader of a report ever opens. Both are standing properties of reading a flow
- * out of the journal, never a damaged read the way `caveats()`'s own lines are - which is
- * why they are assembled here and not there.
+ * comment no reader of a report ever opens. Every line here is a standing property of how a
+ * flow is read, never a damaged read the way `caveats()`'s own lines are - which is why they
+ * are assembled here and not there.
  *
- * Only when a named flow row exists: with no flow in the period, neither limit has bitten
- * anything, and a report that lists what could have gone wrong with an answer it did not
- * give is noise. */
+ * Each set is gated on a row it actually describes being present. A limit is a statement
+ * about a mechanism that ran: printing the journal's own two for a period whose only flow
+ * came from a record's own tool would name a reading nothing here performed, and a report
+ * that lists what could have gone wrong with an answer it did not give is noise. */
 function flowLimits(envelope: CostReportEnvelope): readonly string[] {
-  if (!envelope.by_flow.some((row) => row.flow !== undefined)) return [];
+  return [...journalFlowLimits(envelope), ...toolStatedFlowLimits(envelope)];
+}
+
+/** Both properties of walking the journal's own step sequence, so both are gated on a row
+ * that walk produced. */
+function journalFlowLimits(envelope: CostReportEnvelope): readonly string[] {
+  if (!envelope.by_flow.some((row) => row.attribution === "journal-interval")) return [];
   return [
     "a skill run by hand while a flow was open is counted inside it: the orchestrator's own " +
       "call and a person's write the identical step_start line",
     `a skill of this project named ${orAny(bareOrchestratingSkillNames())} opens a flow of ` +
       "its own: outside a plugin a host names a skill by its folder alone, and this axis " +
       "has only that name to go on",
+  ];
+}
+
+/** The one property of a flow no interval bounded: it is a name, and a name cannot say how
+ * many runs it stands for. Stated wherever such a row is printed, because a reader who takes
+ * it for a single run reads its total as one orchestration's cost. */
+function toolStatedFlowLimits(envelope: CostReportEnvelope): readonly string[] {
+  if (!envelope.by_flow.some((row) => row.attribution === "tool-stated")) return [];
+  return [
+    "a flow only a record's own tool named is every run of that skill at once: its journal " +
+      "opened no flow to bound one run from the next, so the row has no opening moment and " +
+      "its total is not one orchestration's",
   ];
 }
 
@@ -308,23 +327,26 @@ function orAny(names: readonly string[]): string {
   return `${names.slice(0, -1).join(", ")} or ${names[names.length - 1]}`;
 }
 
-/** A third column beside the generic `table()` helper's two, for the same reason
+/** Two columns beside the generic `table()` helper's two, for the same reason
  * `stepArtefact` carries one: two rows can share a `flow` name - the same orchestrating
- * skill run twice in one session - and this table must never let the two read as one run
- * double-counted. `startedAt` is what tells them apart; the row for work outside every
- * flow carries neither and prints an em dash the same way `taskArtefact` does for a
- * reason-only row's own missing attribution. */
+ * skill run twice in one session, or a run the journal witnessed beside one only the tool
+ * named - and this table must never let them read as one flow double-counted. `Attribution`
+ * and `Opened at` are what tell them apart; a `tool-stated` row is a bucket drawn from
+ * however many runs the tool named, so it has no single opening moment and prints an em
+ * dash there, as does the row for work outside every flow - the same way `taskArtefact`
+ * does for a reason-only row's own missing attribution. */
 function flowArtefact(envelope: CostReportEnvelope): string {
   const rows = envelope.by_flow.map((row) => {
     const flow = row.flow ?? OUTSIDE_EVERY_FLOW_LABEL;
     const openedAt = row.started_at ?? "—";
-    return `| ${flow} | ${openedAt} | ${figure(row.totals, envelope)} |`;
+    const attribution = ATTRIBUTION_LABELS[row.attribution];
+    return `| ${flow} | ${attribution} | ${openedAt} | ${figure(row.totals, envelope)} |`;
   });
   return [
     header(envelope, "by flow"),
     "",
-    "| Flow | Opened at | Total |",
-    "| --- | --- | --- |",
+    "| Flow | Attribution | Opened at | Total |",
+    "| --- | --- | --- | --- |",
     ...rows,
     ...flowLimits(envelope),
     ...caveats(envelope),

--- a/cli/src/domain/models/cost-report-envelope.ts
+++ b/cli/src/domain/models/cost-report-envelope.ts
@@ -7,6 +7,7 @@ import type {
   CostTotals,
   PersonIdentityUnusableCause,
 } from "./cost-report.js";
+import type { FlowAttributionSource } from "./flow-attribution.js";
 import type { PersonResolution } from "./person-resolution.js";
 import type { StepAttributionSource } from "./step-attribution.js";
 import type { TaskAttributionSource, TaskUnattributedReason } from "./task-attribution.js";
@@ -221,8 +222,14 @@ export interface CostReportEnvelopePromptRow {
   readonly totals: CostReportEnvelopeTotals;
 }
 
+/** `attribution` says how this flow came to be known, the same three-way shape `by_step`
+ * carries: `journal-interval` for a flow the journal opened and closed, `tool-stated` for
+ * one only a record's own tool named, `unattributed` for the row of work that joined
+ * neither. A `tool-stated` row carries no `started_at` - it is a bucket drawn from however
+ * many runs of that skill the tool named, and a name is not a run. */
 export interface CostReportEnvelopeFlowRow {
   readonly flow?: string;
+  readonly attribution: FlowAttributionSource;
   readonly started_at?: string;
   readonly totals: CostReportEnvelopeTotals;
 }
@@ -414,6 +421,7 @@ function promptRow(row: CostReport["byPrompts"][number]): CostReportEnvelopeProm
 function flowRow(row: CostReport["byFlows"][number]): CostReportEnvelopeFlowRow {
   return {
     ...(row.flow === undefined ? {} : { flow: row.flow }),
+    attribution: row.attribution,
     ...(row.startedAt === undefined ? {} : { started_at: row.startedAt }),
     totals: totals(row.totals),
   };

--- a/cli/src/domain/models/cost-report.ts
+++ b/cli/src/domain/models/cost-report.ts
@@ -1,6 +1,7 @@
 import type { TelemetryRouteSupply } from "../capabilities/telemetry-capability.js";
 import type { PersonIdentity } from "../ports/person-identity-reader.js";
-import type { FlowInterval } from "./flow-attribution.js";
+import type { FlowAttributionSource, FlowInterval } from "./flow-attribution.js";
+import { ORCHESTRATING_SKILLS } from "./flow-attribution.js";
 import { type PersonResolution, type ResolvedPerson, resolvePerson } from "./person-resolution.js";
 import { STEP_ATTRIBUTION_SOURCES, type StepAttributionSource } from "./step-attribution.js";
 import {
@@ -250,6 +251,7 @@ export interface CostReportBacklogRow {
  * neither can this breakdown. */
 export interface CostReportFlowRow {
   readonly flow?: string;
+  readonly attribution: FlowAttributionSource;
   readonly startedAt?: string;
   readonly totals: CostTotals;
 }
@@ -848,7 +850,7 @@ const OUTSIDE_EVERY_FLOW = Symbol("record falls outside every flow interval");
 // `byFlows` for free the property `phase-1.md` asks of it: a record outside every flow can
 // never collide with one inside, since `OUTSIDE_EVERY_FLOW` is a symbol no interval object
 // can ever equal.
-type FlowRowKey = FlowInterval | typeof OUTSIDE_EVERY_FLOW;
+type FlowRowKey = FlowInterval | string | typeof OUTSIDE_EVERY_FLOW;
 
 /** Every session's own closed flow intervals, keyed by vendor id - the same shape
  * `allTaskIntervalsByVendorId` gives task intervals, one layer wider. */
@@ -877,7 +879,30 @@ function flowKeyOf(
   const interval = intervals.find((candidate) =>
     momentFallsWithin([candidate], record.event_timestamp)
   );
-  return interval ?? OUTSIDE_EVERY_FLOW;
+  return interval ?? flowTheToolNamed(record) ?? OUTSIDE_EVERY_FLOW;
+}
+
+/** The orchestrating skill a record's own tool named, for a record no interval covers -
+ * the skill name itself as the key, which no `FlowInterval` object and no symbol can ever
+ * equal, so the two row kinds never collide.
+ *
+ * Only `tool-stated`. A `journal-interval` step is an inference from a moment, and the
+ * intervals it was inferred from are the very ones just checked; a `prompt-matched` one
+ * names the step a prompt opened, which is a step and not an orchestration. Neither says a
+ * flow was orchestrated, and reading either as one would put work inside a flow on the
+ * strength of the reader's own guess.
+ *
+ * Why this capture exists at all: a session resumed after its context was compacted invokes
+ * nothing again, so no `step_start` hook fires and its journal opens no flow, while the
+ * transcript goes on stating the step on every record it produces. Measured on this
+ * machine - one such session, six `step_end` lines, no `step_start`, and 2,220 records in a
+ * 30-day period that `by_flow` placed outside every flow while `by_step` named the very
+ * skill they ran under. */
+function flowTheToolNamed(record: TelemetrySinkRecord): string | undefined {
+  if (record.step_attribution !== "tool-stated") return undefined;
+  return record.step !== undefined && ORCHESTRATING_SKILLS.has(record.step)
+    ? record.step
+    : undefined;
 }
 
 // A record with no identifier is its own row, keyed on a symbol the same way
@@ -1497,11 +1522,19 @@ function flowRows(flows: ReadonlyMap<FlowRowKey, TotalsAccumulator>): readonly C
   let outsideEveryFlow: CostReportFlowRow | undefined;
   for (const [key, accumulator] of flows) {
     if (key === OUTSIDE_EVERY_FLOW) {
-      outsideEveryFlow = { totals: accumulator.build() };
+      outsideEveryFlow = { attribution: "unattributed", totals: accumulator.build() };
+      continue;
+    }
+    // A name is not a run. The tool-stated row is a bucket drawn from however many runs of
+    // that skill the tool named, so it carries no `startedAt` - the same reason the row for
+    // records that named no prompt carries none.
+    if (typeof key === "string") {
+      named.push({ flow: key, attribution: "tool-stated", totals: accumulator.build() });
       continue;
     }
     named.push({
       flow: key.skill,
+      attribution: "journal-interval",
       startedAt: isoSecondsFromMs(key.startMs),
       totals: accumulator.build(),
     });
@@ -1509,7 +1542,7 @@ function flowRows(flows: ReadonlyMap<FlowRowKey, TotalsAccumulator>): readonly C
   const sorted = bySize(
     named,
     (row) => row.totals,
-    (row) => `${row.flow ?? ""}@${row.startedAt ?? ""}`
+    (row) => `${row.flow ?? ""}@${row.attribution}@${row.startedAt ?? ""}`
   );
   return outsideEveryFlow === undefined ? sorted : [...sorted, outsideEveryFlow];
 }

--- a/cli/src/domain/models/flow-attribution.ts
+++ b/cli/src/domain/models/flow-attribution.ts
@@ -52,6 +52,17 @@ import { namesTheSameSkill } from "./skill-name.js";
  * OpenCode names no skill at all on any route (`opencode.cjs`'s own `stepStart: null` - the
  * same limit `bySteps` already lives with), so no third spelling exists to add.
  */
+/** How a record's flow came to be known - the same three-way shape `by_step` carries, and
+ * for the same reason: a flow an interval placed a record inside and one the record's own
+ * tool named are two different claims, and merging them presents an inference as a
+ * measurement.
+ *
+ * Narrower than `StepAttributionSource`, deliberately. `prompt-matched` resolves a step
+ * from the prompt a `step_start` line was opened under, which names a step and never a
+ * flow; carrying a value nothing here can produce would invite a consumer to handle a case
+ * that cannot arise. */
+export type FlowAttributionSource = "journal-interval" | "tool-stated" | "unattributed";
+
 export const ORCHESTRATING_SKILLS: ReadonlySet<string> = new Set([
   "aidd-orchestrator:00-async-dev",
   "00-async-dev",

--- a/cli/tests/application/display/cost-report-artefact.unit.test.ts
+++ b/cli/tests/application/display/cost-report-artefact.unit.test.ts
@@ -368,6 +368,35 @@ describe("buildCostReportArtefact — the flow axis states its own limits with t
     expect(artefact).not.toContain("opens a flow of its own");
   });
 
+  // A limit is a statement about a mechanism that ran. A period whose only flow came from a
+  // record's own tool never walked a step sequence, so the two limits of that walk describe
+  // nothing that happened here and must not be printed.
+  it("states no journal limit for a period whose only flow its own tool named", () => {
+    const statedOnly = envelopeOf({
+      records: [
+        request({
+          event_timestamp: "2026-08-17T10:30:00Z",
+          input_tokens: 10,
+          step_attribution: "tool-stated",
+          step: "aidd-orchestrator:01-sdlc",
+        }),
+      ],
+      journals: [],
+    });
+
+    const artefact = buildCostReportArtefact(statedOnly, "flow");
+
+    expect(artefact).toContain("is every run of that skill at once");
+    expect(artefact).not.toContain("counted inside it");
+    expect(artefact).not.toContain("opens a flow of its own");
+  });
+
+  it("states no tool-stated limit for a period whose flows the journal all witnessed", () => {
+    expect(buildCostReportArtefact(withOneFlow(), "flow")).not.toContain(
+      "is every run of that skill at once"
+    );
+  });
+
   it("states them on the flow axis alone, never on every axis", () => {
     const envelope = withOneFlow();
     for (const axis of ARTEFACT_AXES.filter((name) => name !== "flow")) {

--- a/cli/tests/domain/models/cost-report.unit.test.ts
+++ b/cli/tests/domain/models/cost-report.unit.test.ts
@@ -1268,6 +1268,141 @@ describe("buildCostReport — by_flow reads the journal's own sequence, nothing 
     expect(outside?.totals.requests).toBe(1);
   });
 
+  // A session resumed after its context was compacted invokes nothing again, so no
+  // `step_start` hook fires and its journal opens no flow - while the transcript goes on
+  // stating the step on every record it produces. Measured on this machine: one such
+  // session, six `step_end` lines, no `step_start`, and 2,220 records in a 30-day period
+  // that `by_flow` reported as belonging to no flow at all.
+  it("names the flow a record's own tool stated, where no interval covers it", () => {
+    const records: readonly TelemetrySinkRecord[] = [
+      request({
+        vendor_id: "s-no-journal",
+        cost_usd: 4,
+        event_timestamp: "2026-08-17T10:30:00Z",
+        step_attribution: "tool-stated",
+        step: "aidd-orchestrator:01-sdlc",
+      }),
+    ];
+
+    const built = report({ records, journals: [] });
+
+    const named = built.byFlows.find((row) => row.flow === "aidd-orchestrator:01-sdlc");
+    expect(named?.attribution).toBe("tool-stated");
+    expect(named?.totals.requests).toBe(1);
+    // A name is not a run: the row is a bucket drawn from every run of that skill the tool
+    // named, so it asserts no single moment the way an interval-derived row does.
+    expect(named?.startedAt).toBeUndefined();
+  });
+
+  it("keeps a record the journal witnessed on the interval's row, never the tool-stated one", () => {
+    const journals: readonly CostReportSessionJournal[] = [
+      {
+        vendorId: "s-both",
+        tool: "claude-code",
+        writtenPaths: [],
+        taskIntervals: [],
+        flowIntervals: [
+          {
+            skill: "aidd-orchestrator:01-sdlc",
+            startMs: Date.parse("2026-08-17T10:00:00Z"),
+            endMs: Date.parse("2026-08-17T11:00:00Z"),
+          },
+        ],
+      },
+    ];
+    const records: readonly TelemetrySinkRecord[] = [
+      request({
+        vendor_id: "s-both",
+        cost_usd: 5,
+        event_timestamp: "2026-08-17T10:30:00Z",
+        step_attribution: "tool-stated",
+        step: "aidd-orchestrator:01-sdlc",
+      }),
+    ];
+
+    const built = report({ records, journals });
+
+    const rows = built.byFlows.filter((row) => row.flow === "aidd-orchestrator:01-sdlc");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.attribution).toBe("journal-interval");
+    expect(rows[0]?.startedAt).toBe("2026-08-17T10:00:00Z");
+  });
+
+  it("opens no flow for a tool-stated step that names no orchestrating skill", () => {
+    const records: readonly TelemetrySinkRecord[] = [
+      request({
+        vendor_id: "s-plain-skill",
+        cost_usd: 6,
+        event_timestamp: "2026-08-17T10:30:00Z",
+        step_attribution: "tool-stated",
+        step: "aidd-dev:01-plan",
+      }),
+    ];
+
+    const built = report({ records, journals: [] });
+
+    expect(built.byFlows.map((row) => row.flow)).toEqual([undefined]);
+    expect(built.byFlows[0]?.attribution).toBe("unattributed");
+  });
+
+  // An interval is the only thing that can say *which run*. A step the reader inferred from
+  // a moment says neither run nor, on its own, that a flow was ever orchestrated - so it
+  // opens no flow row, and only the tool's own statement does.
+  it("opens no flow for an orchestrating step the reader merely inferred", () => {
+    const records: readonly TelemetrySinkRecord[] = [
+      request({
+        vendor_id: "s-inferred",
+        cost_usd: 7,
+        event_timestamp: "2026-08-17T10:30:00Z",
+        step_attribution: "journal-interval",
+        step: "aidd-orchestrator:01-sdlc",
+      }),
+    ];
+
+    const built = report({ records, journals: [] });
+
+    expect(built.byFlows.map((row) => row.flow)).toEqual([undefined]);
+  });
+
+  it("reconciles by_flow to the same total when a tool-stated flow row is present", () => {
+    const journals: readonly CostReportSessionJournal[] = [
+      {
+        vendorId: "s-interval",
+        tool: "claude-code",
+        writtenPaths: [],
+        taskIntervals: [],
+        flowIntervals: [
+          {
+            skill: "aidd-orchestrator:01-sdlc",
+            startMs: Date.parse("2026-08-17T10:00:00Z"),
+            endMs: Date.parse("2026-08-17T11:00:00Z"),
+          },
+        ],
+      },
+    ];
+    const records: readonly TelemetrySinkRecord[] = [
+      request({ vendor_id: "s-interval", cost_usd: 1, event_timestamp: "2026-08-17T10:30:00Z" }),
+      request({
+        vendor_id: "s-stated",
+        cost_usd: 2,
+        event_timestamp: "2026-08-17T12:00:00Z",
+        step_attribution: "tool-stated",
+        step: "aidd-orchestrator:02-backlog",
+      }),
+      request({ vendor_id: "s-neither", cost_usd: 3, event_timestamp: "2026-08-17T13:00:00Z" }),
+    ];
+
+    const built = report({ records, journals });
+
+    expect(built.byFlows).toHaveLength(3);
+    expect(sumOf(built.byFlows)).toEqual({
+      requests: built.totals.requests,
+      costMicroUsd: built.totals.costMicroUsd,
+      inputTokens: built.totals.inputTokens ?? 0,
+      outputTokens: built.totals.outputTokens ?? 0,
+    });
+  });
+
   it("reconciles by_flow to the same total as every other breakdown", () => {
     const journals: readonly CostReportSessionJournal[] = [
       {

--- a/cli/tests/e2e/telemetry-flow-axis.e2e.test.ts
+++ b/cli/tests/e2e/telemetry-flow-axis.e2e.test.ts
@@ -13,6 +13,10 @@ import { createTestEnv, gitInit, runCli } from "./helpers.js";
  */
 const RUN_ID = "01ARZ3NDEKTSV4RRFFQ69G5FBY";
 const VENDOR_ID = "66666666-6666-4666-8666-666666666666";
+// A second session with no run journal on disk at all - the shape a session resumed after
+// its context was compacted leaves behind: nothing is invoked again, so no `step_start`
+// hook fires, while the transcript goes on stating the step on every record it produces.
+const NO_JOURNAL_VENDOR_ID = "77777777-7777-4777-8777-777777777777";
 const PROJECT_ID = "acme/widgets";
 const PERIOD = ["--from", "2026-03-01", "--to", "2026-03-31"];
 
@@ -71,10 +75,28 @@ const RECORDS = [
   }),
   // Inside the second, distinct sdlc run.
   record({ turn_id: "second-run", event_timestamp: "2026-03-10T10:10:00Z", cost_usd: 4 }),
+  // A session whose journal opened no flow, whose own tool named the orchestrating skill.
+  record({
+    vendor_id: NO_JOURNAL_VENDOR_ID,
+    turn_id: "stated-one",
+    event_timestamp: "2026-03-11T09:00:00Z",
+    cost_usd: 6,
+    step_attribution: "tool-stated",
+    step: "aidd-orchestrator:01-sdlc",
+  }),
+  record({
+    vendor_id: NO_JOURNAL_VENDOR_ID,
+    turn_id: "stated-two",
+    event_timestamp: "2026-03-11T10:00:00Z",
+    cost_usd: 7,
+    step_attribution: "tool-stated",
+    step: "aidd-orchestrator:01-sdlc",
+  }),
 ];
 
 interface FlowRow {
   readonly flow?: string;
+  readonly attribution: string;
   readonly started_at?: string;
   readonly totals: { readonly requests: number; readonly cost_micro_usd?: number };
 }
@@ -128,7 +150,11 @@ describe("aidd telemetry report — by_flow through the real adapter, on real di
     expect(result.exitCode, result.stderr).toBe(0);
     const envelope = JSON.parse(result.stdout) as Envelope;
 
-    const sdlcRuns = envelope.by_flow.filter((row) => row.flow === "aidd-orchestrator:01-sdlc");
+    // Only the runs the journal itself witnessed: the row a second session's own tool named
+    // shares the skill's name and is a different claim, told apart by `attribution`.
+    const sdlcRuns = envelope.by_flow.filter(
+      (row) => row.flow === "aidd-orchestrator:01-sdlc" && row.attribution === "journal-interval"
+    );
     expect(sdlcRuns).toHaveLength(2);
     expect(new Set(sdlcRuns.map((row) => row.started_at)).size).toBe(2);
     // The first run holds both the orchestrator's own record and the hand-run skill's -
@@ -176,7 +202,8 @@ describe("aidd telemetry report — by_flow through the real adapter, on real di
 
     const sum = envelope.by_flow.reduce((total, row) => total + row.totals.requests, 0);
     expect(sum).toBe(envelope.totals.requests);
-    expect(envelope.by_flow).toHaveLength(3); // outside-flow row + two distinct sdlc runs
+    // outside-flow row + two distinct sdlc runs + the run only the tool named
+    expect(envelope.by_flow).toHaveLength(4);
   });
 
   it("prints the flow axis through --axis, naming both runs and the outside-flow row", async () => {
@@ -192,5 +219,41 @@ describe("aidd telemetry report — by_flow through the real adapter, on real di
     expect(result.stdout).toContain("axis: by flow");
     expect(result.stdout).toContain("aidd-orchestrator:01-sdlc");
     expect(result.stdout).toContain("outside any flow");
+    // The table's own shape, not only the names in it: this artefact exists to be pasted,
+    // so a column added or dropped is a break for whatever reads the paste.
+    expect(result.stdout).toContain("| Flow | Attribution | Opened at | Total |");
+    // A tool-stated row prints its attribution and an em dash where a run would name its
+    // opening moment.
+    expect(result.stdout).toContain("| aidd-orchestrator:01-sdlc | stated by the tool | — |");
+  });
+
+  it("states the limit that belongs to each kind of flow row, and no other", async () => {
+    const { projectDir, fakeHome } = await seed();
+
+    const result = await runCli(
+      ["telemetry", "report", ...PERIOD, "--axis", "flow"],
+      projectDir,
+      fakeHome
+    );
+
+    // This period holds both kinds, so both sets of limits apply.
+    expect(result.stdout).toContain("a skill run by hand while a flow was open");
+    expect(result.stdout).toContain("is every run of that skill at once");
+  });
+
+  it("names the flow a session's own tool stated, where its journal opened none", async () => {
+    const { projectDir, fakeHome } = await seed();
+
+    const result = await runCli(["telemetry", "report", ...PERIOD, "--json"], projectDir, fakeHome);
+    const envelope = JSON.parse(result.stdout) as Envelope;
+
+    const stated = envelope.by_flow.find((row) => row.attribution === "tool-stated");
+    expect(stated?.flow).toBe("aidd-orchestrator:01-sdlc");
+    expect(stated?.totals.cost_micro_usd).toBe(13_000_000); // 6 + 7
+    // A name is not a run: the row is a bucket drawn from however many runs the tool named.
+    expect(stated?.started_at).toBeUndefined();
+    // And it never swallows the runs the journal did witness.
+    const witnessed = envelope.by_flow.filter((row) => row.attribution === "journal-interval");
+    expect(witnessed).toHaveLength(2);
   });
 });

--- a/cli/tests/fixtures/cli-owns-read/expected-envelope.json
+++ b/cli/tests/fixtures/cli-owns-read/expected-envelope.json
@@ -60,6 +60,7 @@
   ],
   "by_flow": [
     {
+      "attribution": "unattributed",
       "totals": {
         "requests": 4,
         "input_tokens": 935,

--- a/plugins/aidd-telemetry/skills/01-cost/actions/03-report.md
+++ b/plugins/aidd-telemetry/skills/01-cost/actions/03-report.md
@@ -146,11 +146,15 @@ A breakdown the object leaves empty is a section left out, never a table of zero
      item - "issue #661 cost X", never "this task cost X". Two tasks declaring the same
      item are already merged into one row; nothing here re-merges anything.
    - `by_flow` answers "what did this orchestrated run cost" - unrelated to task or
-     backlog, and read from the journal's own step sequence with nothing new captured for
-     it. Two runs of the *same* orchestrating skill in one session are two rows, told apart
-     by when each opened - never merge them by name. A skill a person ran by hand while a
-     flow was open is counted inside it, since the journal cannot tell it from one the
-     orchestrator itself invoked - say so if it changes how a figure reads.
+     backlog, and read with nothing new captured for it. Two runs of the *same*
+     orchestrating skill in one session are two rows, told apart by when each opened -
+     never merge them by name. Read `attribution` before comparing two rows:
+     `journal-interval` is a run the journal opened and closed, `tool-stated` is every run
+     of that skill only the record's own tool named, in a session whose journal opened no
+     flow at all - it names no opening moment, because a name is not a run. A skill a
+     person ran by hand while a flow was open is counted inside it, since the journal
+     cannot tell it from one the orchestrator itself invoked - say so if it changes how a
+     figure reads.
 5. **Read `capability` before explaining an absent figure.** A tool that cannot supply a number and a session that consumed nothing look identical in the numbers.
 
    | False field | Means |


### PR DESCRIPTION
## What

`by_flow` decided a record's flow from journal intervals and nothing else (`cost-report.ts`'s `flowKeyOf`). A record whose own transcript states the orchestrating skill it ran under was reported in the unnamed row, however plainly it said so.

Measured on this machine's sink, `--days 30`, 30,222 requests, on the binary built from `9fc819ef`:

| Axis | `aidd-orchestrator:01-sdlc` | Attribution |
| --- | --- | --- |
| `by_step` | 2,220 | `tool-stated` |
| `by_step` | 1 | `journal-interval` |
| `by_flow` | 1,052 | journal interval, the only source it had |

The two axes were not disagreeing about one flow. They were looking at two sessions: the 1,052 come from the session holding the corpus's only orchestrating `step_start`; the 2,220 come from a second session whose journal has **six `step_end` lines and no `step_start` at all**.

## Why a session states a step its journal never opened

`step_start` is written by a hook when a skill is invoked. A session resumed after its context was compacted carries its skills forward in the restored context, so nothing is invoked again and no hook fires — while the transcript goes on stating the step on every record it produces. That journal shows exactly this: ends without starts.

Not an error to repair at the write path. It is a capture the journal cannot make, and a second source that already made it.

## Change

`flowKeyOf` gains one fallback. A record no interval covers, whose own `step_attribution` is `tool-stated` and whose `step` names an orchestrating skill, joins a row for that skill.

| Row | Keyed on | `attribution` | `started_at` |
| --- | --- | --- | --- |
| a flow the journal witnessed | the `FlowInterval` object, by reference | `journal-interval` | the interval's own start |
| a flow only the tool named | the skill name | `tool-stated` | absent |

Keeping them apart preserves what `buildFlowIntervals` argues for: two orchestrated runs of one skill in one session are two rows, because two intervals are two objects. A name is not a run, so the tool-stated row cannot make that distinction and does not pretend to.

**An interval wins over a tool-stated step, and the reason is granularity, not strength.** `withStepBackfill` prefers a tool-stated step over a journal-interval one; this preference runs the other way, and the two are not in conflict. There the question is *which skill* — the tool naming its own beats an inference from a moment. Here it is *which run* — and only an interval can say.

## Proof, two binaries against one sink

| `by_flow` row | `9fc819ef` | this branch |
| --- | --- | --- |
| `aidd-orchestrator:01-sdlc`, `journal-interval` | 1,052 | 1,052 |
| `aidd-orchestrator:01-sdlc`, `tool-stated` | — | **2,208** |
| no flow | 29,170 | 26,962 |

The unnamed row drops by exactly 2,208, and all eleven breakdowns sum to 30,222 on both. **2,208, not 2,220**: the twelve missing are tool-stated records that fall inside the journal's own interval — the precedence rule visible in real data, staying on the interval's row rather than being moved or double-counted.

## Guards

| Guard | Mutation that killed it |
| --- | --- |
| a tool-stated orchestrating record with no interval joins a row named for its skill | drop the fallback — 2 unit, 4 e2e |
| a record inside an interval stays on the interval's row | let the fallback run first — 1 |
| a tool-stated step naming no orchestrating skill joins no flow row | drop the `ORCHESTRATING_SKILLS` check — 1 |
| an orchestrating step the reader merely inferred opens no flow | accept any attribution — 1 |
| `by_flow` still sums to the period total | fold the row into nothing — 2 |
| the `--axis flow` table's own four-column shape | put the three-column header back — 1 e2e |
| the journal's two limits print only where a journal row does | restore the old `flow !== undefined` gate — 1 |
| the tool-stated limit prints only where such a row does | — (paired with the above) |

## The limits each row kind states

`flowLimits` used to gate on "a named row exists". A `tool-stated` row has a name, so both of the journal's own limits would have printed for a period whose only flow came from a record's own tool — describing a walk that never ran. They are now gated on a `journal-interval` row, and a `tool-stated` row states the limit that is actually its own: it is every run of that skill at once, so its total is not one orchestration's.

## Envelope

No bump. The flow row gains `attribution`, a field a consumer may ignore, and no existing field changes meaning — the rule stated at `cost-report-envelope.ts`. Every consumer updated in the same commit: the envelope type and mapper, the `--axis flow` artefact (which gains an Attribution column, the same third column `stepArtefact` already carries and for the same reason), the contract, and the cost skill's own reading instructions. The terminal display renders no flow axis.

The contract also carried a stale sentence from #763 — a flow closing at "the next orchestrating `step_start` or a `turn_end`". Corrected here, in the section this PR rewrites.

## Not in scope

`by_prompt`'s doc comment calls it "the one breakdown that is complete by construction". Measured the same day on the same sink: 843 of 30,714 records carry no `prompt_id`. Recorded in this PR's plan with its evidence; it is a different axis and its own argument.

Bundle is at 592.9 KB against a 593 KB budget — 0.1 KB of headroom. Not raised here; the next change to touch the bundle will have to.

Gates: 3443 tests / 308 files, `tsc`, `biome ci` (2 pre-existing warnings, 0 new), knip, jscpd, bundle within budget, 369 repository script tests, 0 broken links, cli layering clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWNxk63AGKkqE8HRqHLjGp
