### PR TITLE
docs(telemetry): a prompt axis says what it cannot name

### DIFF
--- a/aidd_docs/product/cost-report-contract.md
+++ b/aidd_docs/product/cost-report-contract.md
@@ -195,12 +195,13 @@ consumer that switched exhaustively on the three previous reasons must add this 
 row's `totals` still reconciles to the period total exactly as before.
 
 Bumped from `12` when **`by_prompt`** joined the top-level breakdowns. It is the only
-breakdown complete by construction: every other one depends on a capture that may not have
+breakdown no host limit can empty: every other one depends on a capture that may not have
 happened — a run journal, an identity file, a task declaration, a host that names the skill
-it is running — while this one depends on a field the transcript reader already resolves for
-every usage line by walking `parentUuid` back to the turn that caused it. Measured 2026-09-04
-on the built binary against one real session: 1073 of 1073 records carried a `prompt_id`, its
-972 subagent records included, across 12 distinct prompts. Nothing new is captured for it.
+it is running — while this one depends on a field the transcript reader resolves for itself,
+by walking `parentUuid` back to the turn that caused the work. That is not the same as
+complete: measured 2026-09-05 on one machine's sink, 845 of 30,714 records carry no
+`prompt_id`, and all but one of them were stored by a reader that predates the resolution —
+see **`by_prompt`** below. Nothing new is captured for it.
 A row carries `started_at`, the earliest moment in that prompt, because a prompt id alone is
 opaque — it is what a person greps for in their own transcript. The row for records that
 named no prompt carries neither `prompt` nor `started_at`, is placed last rather than ranked
@@ -477,7 +478,16 @@ turn that caused the work.
 | Row | Means |
 | --- | --- |
 | `prompt` and `started_at` | one prompt, and the earliest moment measured inside it |
-| neither field | every record whose tool cannot say which prompt caused it |
+| neither field | every record no prompt could be resolved for |
+
+**Read the second row as a real quantity, not a rounding error.** A sink accumulates across
+reader versions, and a record's fields are fixed the first time its turn is stored: a record
+written before this resolution shipped never gains a `prompt_id`, however often the sink is
+read again. Measured 2026-09-05 on one machine's sink of 30,714 records: 845 carry none —
+34 written before the CLI stamped a version, 810 by one session's reader before the
+resolution shipped, and exactly one by the current reader, an assistant line whose
+`parentUuid` chain reaches no line naming a prompt. Re-reading recovers little of it: 720 of
+those requests name no line any transcript on disk still holds.
 
 Ordered largest first, like every breakdown but `by_day`; the remainder row is placed last
 rather than ranked, because a bucket drawn from many turns has no size comparable to a single

--- a/aidd_docs/tasks/2026_09/2026_09_05_a-prompt-axis-says-what-it-cannot-name/plan.md
+++ b/aidd_docs/tasks/2026_09/2026_09_05_a-prompt-axis-says-what-it-cannot-name/plan.md
@@ -1,0 +1,84 @@
+---
+status: done
+---
+
+# A prompt axis says what it cannot name
+
+## The false claim
+
+Four places called `by_prompt` *"the one breakdown that is complete by construction"*, and
+three of them backed it with one measurement: *"measured 2026-09-04 on the built binary,
+1073 of 1073 records of one real session carried a `prompt_id`"*.
+
+Measured on this machine's own sink the following day, 30,714 records:
+
+| | Records | Why |
+| --- | --- | --- |
+| carry a `prompt_id` | 29,869 | |
+| carry none | **845** (2.75%) | |
+| — of which, stored before the CLI stamped a version | 34 | an older reader |
+| — of which, one session under `5.2.2` | 810 | stored before this resolution shipped |
+| — of which, written by the current reader | **1** | a `parentUuid` chain reaching no line that names a prompt |
+
+Every one of the nine sessions in the sink has at least one record with no prompt.
+
+The measurement behind the claim is also no longer reproducible. That session's transcript
+holds 230 assistant lines today where 1,073 records were read from it, so a fresh read
+yields nothing like 1,073 — the figure describes a file state that no longer exists.
+
+## What is true, and now written instead
+
+`by_prompt` is **the one breakdown no host limit can empty**: every other depends on a
+capture that may not have happened — a run journal, an identity file, a task declaration, a
+host that names the skill it is running — while this one depends on a field the transcript
+reader resolves for itself, walking `parentUuid` back to the line that named the prompt.
+
+That is not the same as complete, and the difference has a mechanism worth naming.
+
+## Why 844 of them can never be named
+
+`storeNewCandidates` treats a candidate whose turn is already stored as a correction only
+when it carries a **larger counter**. A field the stored record lacks is not a correction, so
+a reader that later learns to resolve something an earlier one could not names nothing
+already stored: the turn matches, the counters have not grown, the candidate is dropped. A
+record's field set is fixed the first time its turn is seen.
+
+## Why that is left as it is
+
+Re-reading is not the repair. Of the 811 records whose sessions were measured against the
+transcripts on disk:
+
+| | Records |
+| --- | --- |
+| the request is still in a transcript and a prompt resolves today | **90** |
+| the request is still in a transcript, the chain reaches no prompt | 1 |
+| the request is in no transcript on disk at all | 720 |
+
+Roughly 90 records in 30,714 is the whole prize. Enriching would mean appending a line whose
+counters equal one already stored, which `collapseSupersededTurns` picks between by counter
+weight and then by serialized content — so the merge would have to learn a preference it does
+not have, for 0.3%. Stated as a limit at `storeNewCandidates`, with the arithmetic, and the
+condition under which to revisit it: a reader learning a field that matters more than a
+prompt id.
+
+## The change
+
+Prose only. No behaviour moves, no envelope field, no version.
+
+| File | Was |
+| --- | --- |
+| `cost-report.ts`, `CostReportPromptRow` | "complete by construction", the 1073 of 1073 measurement |
+| `cost-report-envelope.ts`, the version-13 paragraph | the same claim, the same measurement |
+| `cost-report-contract.md`, twice | the same claim; the remainder row described as a host limitation only |
+| `03-report.md` | "since every record the reader stores already carries the turn it came from" |
+| `cost-report.unit.test.ts`, `aidd-telemetry-cost-skill.test.js` | the claim repeated in two comments |
+| `read-local-cost-use-case.ts`, `storeNewCandidates` | the frozen field set undocumented |
+
+## No new guard, and why
+
+The behaviour is already guarded, and correctly. `claude-code-transcript.unit.test.ts`
+covers a chain that reaches no prompt, a parent the transcript does not hold, and a chain
+that points back at itself; `cost-report.unit.test.ts` covers the unnamed row staying
+undated, placed last, and reconciling to the period total on every counter. Nothing here
+changes what any of them assert — the defect was in what the code claimed about itself, not
+in what it did.

--- a/cli/src/application/use-cases/telemetry/read-local-cost-use-case.ts
+++ b/cli/src/application/use-cases/telemetry/read-local-cost-use-case.ts
@@ -519,7 +519,22 @@ export class ReadLocalCostUseCase {
    * same turn (`isLocalReadTurnCorrection`), the one case this match used to refuse
    * outright. The correction lands as a second line, never an edit: the sink is
    * append-only, and `cost-report.ts`'s `collapseSupersededTurns` is what later reconciles
-   * the two readings into one. */
+   * the two readings into one.
+   *
+   * **A correction is a larger counter, never a field the stored record lacks — so a
+   * record's field set is fixed the first time its turn is seen.** A reader that later
+   * learns to resolve something the earlier one could not names nothing already stored: the
+   * turn matches, the counters have not grown, and the candidate is dropped. Measured
+   * 2026-09-05 on a live sink: 844 records carry no `prompt_id` for exactly this reason,
+   * 2.75% of 30,714, and `CostReportPromptRow` states it where the figure is read.
+   *
+   * Left as it is, deliberately. Enriching would mean appending a line whose counters equal
+   * one already stored, which `collapseSupersededTurns` picks between by counter weight and
+   * then by serialized content — so the merge would have to learn a preference it does not
+   * have, to close a gap re-reading could barely close anyway: of the 811 measured, 720
+   * name a request no transcript on disk still holds. Roughly 90 records in 30,714 is the
+   * whole prize. Revisit this the day a reader learns a field that matters more than a
+   * prompt id, and that arithmetic changes. */
   private async storeNewCandidates(
     tool: AiToolId,
     sessionId: string,

--- a/cli/src/domain/models/cost-report-envelope.ts
+++ b/cli/src/domain/models/cost-report-envelope.ts
@@ -20,11 +20,11 @@ import type { AiToolId } from "./tool-ids.js";
  *
  * Bumped to 13: `by_prompt` is a new top-level breakdown, and a consumer summing every
  * breakdown's `requests` against `totals.requests` to check nothing was dropped now has one
- * more to include. It is the only breakdown complete by construction: every other depends on
- * a capture that may not have happened, this one on a field the transcript reader already
- * resolves for every usage line. Measured 2026-09-04 on the built binary - 1073 of 1073
- * records of one real session carried a `prompt_id`, its 972 subagent records included,
- * across 12 distinct prompts.
+ * more to include. It is the only breakdown no host limit can empty: every other depends on
+ * a capture that may not have happened, this one on a field the transcript reader resolves
+ * for itself. That is not the same as complete, and `CostReportPromptRow` carries the
+ * measurement — 845 of 30,714 records of this machine's own sink carry no `prompt_id`, all
+ * but one of them stored by a reader that predates the resolution.
  *
  * Bumped to 12: `by_task`'s `attribution` stops being always `"declared"`. A record no
  * declaration covers, in a session whose journal witnessed it and that wrote into exactly

--- a/cli/src/domain/models/cost-report.ts
+++ b/cli/src/domain/models/cost-report.ts
@@ -91,12 +91,26 @@ export interface CostReportAgentRow {
 /** One prompt's own share of a period, `prompt` absent on the row for records that named
  * none.
  *
- * The one breakdown that is complete by construction. Every other depends on a capture that
- * may not have happened — a journal, an identity file, a declaration, a host that names a
- * skill. This one depends on a field the transcript reader already resolves for every usage
- * line by walking `parentUuid`: measured 2026-09-04 on the built binary, 1073 of 1073
- * records of one real session carried a `prompt_id`, its 972 subagent records included,
- * across 12 distinct prompts.
+ * The one breakdown no host limit can empty — never one that is complete. Every other
+ * depends on a capture that may not have happened — a journal, an identity file, a
+ * declaration, a host that names a skill. This one depends on a field the transcript reader
+ * resolves for itself, by walking `parentUuid` back to the line that named the prompt.
+ *
+ * The reader is very nearly complete and the sink it fills is not, and the difference is
+ * worth stating where the figure is read. Measured 2026-09-05 on this machine's own sink:
+ * 845 of 30,714 records carry no `prompt_id`, 2.75%. Exactly one of them was written by the
+ * current reader — an assistant line whose `parentUuid` chain reaches no line naming a
+ * prompt, out of 29,607 in that session. The other 844 were stored by earlier readers: 34
+ * before the CLI stamped a version at all, and 810 in one session before this resolution
+ * shipped.
+ *
+ * **Those 844 stay unnamed however often the sink is read again.** `storeNewCandidates`
+ * fixes a record's field set the first time it sees the turn, so a re-read that would now
+ * resolve the prompt stores nothing — the turn is already stored and its counters have not
+ * grown. Re-reading is not the repair either: of the 811 whose sessions were measured, 720
+ * name a request no transcript on disk still holds, so roughly 90 records in 30,714 are all
+ * a retroactive pass could ever recover. Which is why this states a limit rather than
+ * carrying machinery to close it.
  *
  * `startedAt` is the earliest moment in the group, and only a named prompt gets one: the
  * row for records that named no prompt is a bucket drawn from many turns, so a start moment

--- a/cli/tests/domain/models/cost-report.unit.test.ts
+++ b/cli/tests/domain/models/cost-report.unit.test.ts
@@ -589,11 +589,11 @@ describe("buildCostReport — every breakdown reconciles", () => {
     expect(summed).toBe(built.totals.inputTokens);
   });
 
-  // The one axis that is complete by construction. Measured 2026-09-04 on the built binary
-  // against a sandboxed copy of one real session: 1073 of 1073 records carried a
-  // `prompt_id`, its 972 subagent records included, across 12 distinct prompts. Every other
-  // breakdown depends on a capture that may not have happened; this one depends on a field
-  // the reader already resolves for every usage line by walking `parentUuid`.
+  // The one axis no host limit can empty — which is not the same as complete, and the
+  // difference is measured on `CostReportPromptRow`. Every other breakdown depends on a
+  // capture that may not have happened; this one depends on a field the reader resolves for
+  // itself by walking `parentUuid`, so what it cannot name is a chain it cannot walk or a
+  // record an older reader already stored without one.
   it("breaks the period down by the prompt that caused the work, largest first", () => {
     const built = report({
       records: [

--- a/plugins/aidd-telemetry/skills/01-cost/actions/03-report.md
+++ b/plugins/aidd-telemetry/skills/01-cost/actions/03-report.md
@@ -106,8 +106,9 @@ A breakdown the object leaves empty is a section left out, never a table of zero
    which a resumed transcript carries - never as the flow declaring its task late. The bump
    from `12` to `13` added `by_prompt`
    to the top-level breakdowns: the prompt that caused the work, the one breakdown no host
-   limit can leave empty, since every record the reader stores already carries the turn it
-   came from. The bump from `11` to `12` did not add a
+   limit can leave empty, since the reader resolves the turn for itself rather than waiting
+   on a capture. Not the same as complete - a record stored before that resolution shipped
+   never gains one, so the row naming no prompt is a real quantity to read, never noise. The bump from `11` to `12` did not add a
    breakdown either: `by_task`'s `attribution` stopped being always `declared`, so one task
    can now hold two rows - one for what a declaration covered, one for what only a written
    file names. The bump from `10` to `11` did not add a

--- a/scripts/__tests__/aidd-telemetry-cost-skill.test.js
+++ b/scripts/__tests__/aidd-telemetry-cost-skill.test.js
@@ -164,8 +164,8 @@ test("every field the cost skill names by name resolves on the object the script
   // while bringing the skill's own version paragraph up from `8` to `11` - it had gone three
   // bumps stale, so the paragraph named neither `by_agent` nor `prompt-matched` nor the
   // fourth no-task reason a row can now carry. 18 -> 19 when 03-report.md named `by_prompt`,
-  // the breakdown by the prompt that caused the work - the one axis complete by construction,
-  // since every record the reader stores already carries the turn it came from.
+  // the breakdown by the prompt that caused the work - the one axis no host limit can empty,
+  // since the reader resolves the turn for itself rather than waiting on a capture.
   assert.equal(claims.size, 19, "expected exactly nineteen field references in the cost skill");
 
   // Fields the envelope carries only under some condition, so a fixture cannot show them all


### PR DESCRIPTION
## What

Four places called `by_prompt` **"the one breakdown that is complete by construction"**, three of them backed by one measurement: *1073 of 1073 records of one real session carried a `prompt_id`*.

Measured the following day on this machine's own sink, 30,714 records:

| | Records | |
| --- | --- | --- |
| carry a `prompt_id` | 29,869 | |
| carry none | **845** (2.75%) | every one of the nine sessions has at least one |
| — stored before the CLI stamped a version | 34 | an older reader |
| — one session under `5.2.2` | 810 | stored before this resolution shipped |
| — written by the current reader | **1** | a `parentUuid` chain reaching no line that names a prompt |

The original measurement is also no longer reproducible: that session's transcript holds 230 assistant lines today where 1,073 records were read from it, so the figure describes a file state that no longer exists.

## What is written instead

`by_prompt` is **the one breakdown no host limit can empty** — it waits on no run journal, no identity file, no task declaration, no host naming the skill it is running. That is true, checkable, and not the same as complete.

## The mechanism, now stated where it lives

`storeNewCandidates` treats a candidate whose turn is already stored as a correction only when it carries a **larger counter**. A field the stored record lacks is not a correction, so a reader that later learns to resolve something an earlier one could not names nothing already stored: the turn matches, the counters have not grown, the candidate is dropped. **A record's field set is fixed the first time its turn is seen.**

## Why that is left as it is

| Of the 811 measured against the transcripts on disk | Records |
| --- | --- |
| still in a transcript, a prompt resolves today | **90** |
| still in a transcript, the chain reaches no prompt | 1 |
| in no transcript on disk at all | 720 |

Roughly 90 records in 30,714 is the whole prize. Enriching would mean appending a line whose counters equal one already stored, which `collapseSupersededTurns` picks between by counter weight and then by serialized content — a preference it would have to learn, for 0.3%. The limit is stated at `storeNewCandidates` with that arithmetic and the condition to revisit it: a reader learning a field that matters more than a prompt id.

## Files

| File | Was |
| --- | --- |
| `cost-report.ts`, `CostReportPromptRow` | the claim and the 1073 of 1073 measurement |
| `cost-report-envelope.ts`, version 13 | the same claim, the same measurement |
| `cost-report-contract.md`, twice | the same claim; the remainder row described as a host limitation only |
| `03-report.md` | "since every record the reader stores already carries the turn it came from" |
| `cost-report.unit.test.ts`, `aidd-telemetry-cost-skill.test.js` | the claim repeated in two comments |
| `read-local-cost-use-case.ts` | the frozen field set undocumented |

## No new guard, and why

The behaviour is already guarded in both directions and nothing here changes what any guard asserts — the defect was in what the code claimed about itself, not in what it did. `claude-code-transcript.unit.test.ts` covers a chain reaching no prompt, a parent the transcript does not hold, and a chain pointing back at itself; `cost-report.unit.test.ts` covers the unnamed row staying undated, placed last, and reconciling to the period total on every counter.

Prose only: no behaviour moves, no envelope field, no version.

Gates: 3434 tests / 308 files, `tsc`, `biome ci` (2 pre-existing warnings, 0 new), knip, jscpd, bundle 592.0 KB within budget, 369 repository script tests, 0 broken links, cli layering clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWNxk63AGKkqE8HRqHLjGp