### PR TITLE
fix(telemetry): an agent row says who could be named

### DIFF
--- a/aidd_docs/product/cost-report-contract.md
+++ b/aidd_docs/product/cost-report-contract.md
@@ -61,7 +61,7 @@ up, by what each task's folder declares. `by_flow` is a ninth, also with no filt
 own — see **`by_flow`** below — grouping by which orchestrated run the journal's own step
 sequence names, never a second capture. `by_agent` is a tenth, also with no filter of its
 own — see **`by_agent`** below — grouping by which agent ran, the main thread carrying its
-own row rather than an absence. `by_prompt` is an eleventh, also with no filter of its own —
+own row rather than an absence, and a tool that names no agent at all carrying a third. `by_prompt` is an eleventh, also with no filter of its own —
 see **`by_prompt`** below — grouping by the prompt that caused the work, the one breakdown
 no host limit can leave empty. `aidd telemetry report` also takes
 `--axis <name>` (`total`, `day`, `step`, `model`, `agent`, `prompt`, `task`, `backlog`,
@@ -214,9 +214,12 @@ is where the spend is: measured on a live session, ten subagent transcripts held
 subagent tokens) where almost none names a skill (2.7%). That is why `by_step` can read a
 few percent while a session's real cost sits elsewhere — the host names a skill on the main
 thread alone, and no reader can invent one. `by_agent` needs no new capture: `agent_name` was
-already on the record. A row with no `agent` is the main thread's own, never "no agent" — a
-session starts there. On every tool but Claude Code the field is never set at all, so that
-one row carries the whole period, which is the truth for a route that names no subagents.
+already on the record. Every row carries `attribution`, and it is what tells the two rows
+that name no agent apart: `main-thread` is a tool that names agents saying this record
+belongs to none of them — a session starts there, and it is never "no agent" — while
+`not-stated` is a tool whose route never names one. Only Claude Code's route does today, so
+on Codex, Copilot and OpenCode every record joins the `not-stated` row. It used to join the
+main thread's, which asserted of those tools a fact nothing observed.
 
 Bumped from `8` to `9` when `attribution` gained a fourth value, `prompt-matched`.
 
@@ -276,7 +279,7 @@ one. Adding a field you may ignore is not a bump; changing what an existing fiel
   "active_time_s": 2820,                        // absent when no record carried it
   "by_step":    [{ "step": "aidd-dev:02-implement", "attribution": "journal-interval", "totals": {} }],
   "by_model":   [{ "model": "gpt-5.6-sol", "totals": {} }],  // a row with no "model" names none known
-  "by_agent":   [{ "agent": "aidd-dev:executor", "totals": {} }, { "totals": {} }],  // a row with no "agent" is the main thread's own, never "no agent"
+  "by_agent":   [{ "agent": "aidd-dev:executor", "attribution": "tool-stated", "totals": {} }, { "attribution": "main-thread", "totals": {} }, { "attribution": "not-stated", "totals": {} }],  // "main-thread" is a tool that names agents saying this is none of them; "not-stated" is a tool whose route never names one
   "by_prompt":  [{ "prompt": "a-prompt-id", "started_at": "2026-07-01T09:00:00Z", "totals": {} }, { "totals": {} }],  // one row per prompt, largest first; the last row, undated, is every record that named none
   "by_tool":    [{ "tool": "codex", "coverage": "covered", "reason": "…", "capability": {}, "totals": {}, "session_totals": {} }],  // session_totals absent unless the tool has one (Copilot, today)
   "by_project": [{ "project": "acme/widgets", "totals": {} }],   // a row with no `project` names none known
@@ -596,7 +599,7 @@ supply an amount and a session that cost nothing look identical in the numbers.
 
 ```jsonc
 "capability": {
-  "local_read": { "token_counters": true, "amount": false, "tool_stated_step": false },
+  "local_read": { "token_counters": true, "amount": false, "tool_stated_step": false, "agent_name": false },
   "export": null,
   "journal_attributable": true,
   "task_attributable": false
@@ -610,6 +613,7 @@ supply an amount and a session that cost nothing look identical in the numbers.
 | `token_counters` | That route yields the four counters. |
 | `amount` | That route yields a figure denominated in currency. Never a credit or a premium request. |
 | `tool_stated_step` | The tool names the running step itself. A journal interval is not this. |
+| `agent_name` | The route names the agent a record belongs to, and so also says when one is the main thread's own. Without it, `by_agent` reads this tool's records as `not-stated`, never as the main thread. |
 | `journal_attributable` | The run journal names this tool's sessions. **False means two things:** no step can come from an interval, *and* a read that sweeps the journal never reaches one of its sessions — so the tool can be perfectly readable and still report nothing until someone names a session by hand. |
 | `task_attributable` | A session on this tool can be traced to the task it worked on — declared, inferred, or both. False only where the journal hook never reaches a tool call for this host at all, since a declaration needs a tool call's own arguments to read; true for every declared host today, OpenCode included as of 2026-08-31 (`registry-conformance.unit.test.ts` keeps this tied to the journal hook's own dispatch rather than typed in twice by hand). |
 

--- a/aidd_docs/tasks/2026_09/2026_09_05_an-agent-row-says-who-could-be-named/plan.md
+++ b/aidd_docs/tasks/2026_09/2026_09_05_an-agent-row-says-who-could-be-named/plan.md
@@ -1,0 +1,91 @@
+---
+status: done
+---
+
+# An agent row says who could be named
+
+## The defect
+
+`agentKeyOf` read `agent_name === undefined` as the main thread, whatever the tool:
+
+```ts
+return record.agent_name === undefined ? NO_AGENT : record.agent_name;
+```
+
+Only Claude Code's reader ever sets that field. `claude-code-transcript.ts` derives it from
+`isSidechain` and `attributionAgent`; the Codex, Copilot and OpenCode readers set it nowhere,
+and their route declarations say so — `toolStatedStep: false` was already there, an agent
+flag was not.
+
+So on those three tools every record was reported as the main thread. Not a small error: it
+is **100% of the axis**, asserted on no evidence at all. The contract said so out loud and
+called it correct: *"On every tool but Claude Code the field is never set at all, so that one
+row carries the whole period, which is the truth for a route that names no subagents."*
+
+The same file already states the right rule twelve lines below, for `step`: *"its absence
+here yields no `step` at all … rather than asserting 'no skill ran'."*
+
+## The change
+
+A record with no agent name joins one of two rows, and only the tool's own declaration says
+which.
+
+| Row | `attribution` | Means |
+| --- | --- | --- |
+| named | `tool-stated` | the tool named the agent |
+| no name | `main-thread` | a tool that names agents said this belongs to none of them |
+| no name | `not-stated` | a tool whose route never names one |
+
+`TelemetryRouteSupply` gains `agentName`, declared per route beside `toolStatedStep`, and
+checked against real captures by the same honesty guard: `telemetry-route-supply.unit.test.ts`
+observes what each capture actually yields, so a route claiming an agent name its reader
+never sets fails there.
+
+The declaration is read rather than the record because the record cannot carry the absence:
+a tool that never names an agent writes exactly what a main-thread line writes.
+
+`accumulate`'s per-record parameters became a `RecordContext` in the same commit — nine
+positional arguments in a fixed order is a call nobody checks by eye, and the linter's own
+function-length rule made the point at the ninth.
+
+## What this does not fix
+
+A line marked as a subagent's that carries no agent name still reads as the main thread.
+Measured 2026-09-05 across 1,852 transcripts: **157 of 122,637 subagent lines name no agent,
+0.07%**. Closing it needs a new field on the record, which no record already stored could
+ever gain (`storeNewCandidates` freezes a record's field set at first sight — see
+`2026_09_05_a-prompt-axis-says-what-it-cannot-name`). Stated on `CostReportAgentRow` rather
+than captured.
+
+## Guards
+
+| Guard | Mutation that killed it |
+| --- | --- |
+| a tool that names agents gets a `main-thread` row | always answer `not-stated` — 3 |
+| a tool whose route never names one gets `not-stated` | always answer `main-thread`, the old reading — 3 |
+| a *declared* route that names no agent reads the same as no route at all | accept any declared route — 1 |
+| the two silences are two rows, never merged | (covered by the two above) |
+| every agent row still sums to the period total | (reconciliation test, 3 rows) |
+| a route may not claim an agent name its reader never sets | make codex declare `agentName: true` — 1 |
+| both renderings name which silence a row is | collapse the label to "the main thread" — 1 display, 1 artefact |
+
+## Proof
+
+Two binaries against one copy of the sink, `--days 30`, 30,222 requests on both. This corpus
+is almost entirely Claude Code, so it can barely show the fault:
+
+| `by_agent` row | `aee5721b` | this branch |
+| --- | --- | --- |
+| the main thread | 9,002 | 9,001 |
+| a tool that names no agent | — | **1** |
+
+That one record is the sink's only Codex request. The magnitude is not in this corpus — for
+a Codex-only reader the same change moves the whole axis — so the guards are the proof and
+the one record is the demonstration that the path runs end to end. All eleven breakdowns
+reconcile to 30,222 on both.
+
+## Bundle
+
+593.8 KB against a 593 KB budget. Raised to 596, the same 2.2 KB headroom the `by_prompt`
+raise left. The comment in `check-bundle-size.mjs` records the raise and its measurement, as
+the two before it do.

--- a/cli/package.json
+++ b/cli/package.json
@@ -44,7 +44,7 @@
       "qs": ">=6.15.2"
     }
   },
-  "bundleBudgetKB": 593,
+  "bundleBudgetKB": 596,
   "scripts": {
     "build": "tsup && node scripts/check-bundle-size.mjs",
     "build:check-size": "node scripts/check-bundle-size.mjs",

--- a/cli/scripts/check-bundle-size.mjs
+++ b/cli/scripts/check-bundle-size.mjs
@@ -12,7 +12,10 @@ const pkg = JSON.parse(readFileSync(resolve(root, "package.json"), "utf8"));
 // the bundle to 567.7 KB - tighter headroom than the 560 raise left, on
 // purpose, rather than padding past what was actually measured.
 // 593 was set when `by_prompt` joined the breakdowns: measured 588.4 -> 590.6 KB,
-// +2.2 KB for the axis that is complete by construction. Same tight headroom.
+// +2.2 KB for the axis no host limit can empty. Same tight headroom.
+// 596 was set when `by_agent` learned to tell a main thread from a tool that never
+// names an agent: measured 592.0 -> 593.8 KB across two changes, the flow axis's own
+// tool-stated row included. Same 2.2 KB headroom the raise before it left.
 const budgetKB = pkg.bundleBudgetKB ?? 500;
 const budgetBytes = budgetKB * 1024;
 

--- a/cli/src/application/display/cost-report-artefact.ts
+++ b/cli/src/application/display/cost-report-artefact.ts
@@ -57,6 +57,10 @@ const NO_KNOWN_PROJECT = "no known project";
 const NO_KNOWN_MODEL = "no known model";
 // Not "no agent": the main thread is where a session starts, not an absence.
 const MAIN_THREAD = "the main thread";
+// A tool that never names an agent has said nothing about which one ran. Labelling that row
+// "the main thread" would state a fact nothing observed - the reading this axis used to give
+// every Codex, Copilot and OpenCode record.
+const AGENT_NOT_STATED = "the tool names no agent";
 // Distinct on purpose, per the contract's own three-way shape: an unresolved row names an
 // identity that is real but unplaced, and repeats once per such identity since each is its
 // own row; the no-identity row is singular and says nobody opted in at all. Neither label
@@ -359,7 +363,8 @@ function agentArtefact(envelope: CostReportEnvelope): string {
     "by agent",
     "Agent",
     envelope.by_agent.map(
-      (row) => `| ${row.agent ?? MAIN_THREAD} | ${figure(row.totals, envelope)} |`
+      (row) =>
+        `| ${row.agent ?? (row.attribution === "main-thread" ? MAIN_THREAD : AGENT_NOT_STATED)} | ${figure(row.totals, envelope)} |`
     )
   );
 }

--- a/cli/src/application/display/cost-report-display.ts
+++ b/cli/src/application/display/cost-report-display.ts
@@ -95,6 +95,15 @@ const NO_KNOWN_PROJECT = "no known project";
 const NO_KNOWN_MODEL = "no known model";
 // Not "no agent": the main thread is where a session starts, not an absence.
 const MAIN_THREAD = "the main thread";
+// And not the main thread either: a tool that never names an agent has said nothing about
+// which one ran, so a row labelled "the main thread" would state a fact nothing observed.
+const AGENT_NOT_STATED = "the tool names no agent";
+
+/** What a row that names no agent is called, by which of the two silences it is. */
+export function agentRowLabel(row: CostReport["byAgents"][number]): string {
+  if (row.agent !== undefined) return row.agent;
+  return row.attribution === "main-thread" ? MAIN_THREAD : AGENT_NOT_STATED;
+}
 
 // A prompt id is a uuid, wider than `LABEL_WIDTH`, and `padTo` never truncates - so the
 // column is its own width rather than colliding with the one every named label shares.
@@ -398,7 +407,7 @@ function printAgents(output: CLIOutput, report: CostReport, basis: Basis): void 
   output.print("");
   output.print(`  by agent    ${basis.label}`);
   for (const row of report.byAgents) {
-    const name = row.agent ?? MAIN_THREAD;
+    const name = agentRowLabel(row);
     const share = shareOf(row.totals, basis.of, basis.useCost);
     output.print(
       `    ${padTo(name, LABEL_WIDTH)}${share}   ${figureFor(row.totals, basis.useCost)}`

--- a/cli/src/domain/capabilities/telemetry-capability.ts
+++ b/cli/src/domain/capabilities/telemetry-capability.ts
@@ -18,6 +18,12 @@ export interface TelemetryRouteSupply {
   /** The tool names the running step itself, on the record. An interval derived from the
    * run journal is not this — that is the framework's inference, not the tool's statement. */
   readonly toolStatedStep: boolean;
+  /** The tool names the agent a record belongs to, and so also says when a record is the
+   * main thread's own. Without it a record carrying no agent states nothing: `by_agent`
+   * cannot read it as the main thread, because the tool never had a main thread to
+   * distinguish. Only Claude Code's reader sets it today (`isSidechain` and
+   * `attributionAgent`, see `claude-code-transcript.ts`). */
+  readonly agentName: boolean;
 }
 
 /** Where a tool's own transcript files live, and how to recognise the one file (or files)

--- a/cli/src/domain/models/cost-report-envelope.ts
+++ b/cli/src/domain/models/cost-report-envelope.ts
@@ -1,5 +1,6 @@
 import type { TelemetryRouteSupply } from "../capabilities/telemetry-capability.js";
 import type {
+  AgentAttributionSource,
   CostReport,
   CostReportEmptySelection,
   CostReportFilters,
@@ -136,6 +137,10 @@ export interface CostReportEnvelopeRouteSupply {
   readonly token_counters: boolean;
   readonly amount: boolean;
   readonly tool_stated_step: boolean;
+  /** The route names the agent a record belongs to, and so also says when one is the main
+   * thread's own. Without it `by_agent` reads this tool's records as stating no agent, never
+   * as the main thread. */
+  readonly agent_name: boolean;
 }
 
 export interface CostReportEnvelopeCapability {
@@ -204,12 +209,14 @@ export interface CostReportEnvelopeBacklogRow {
   readonly totals: CostReportEnvelopeTotals;
 }
 
-/** One orchestrated run's figures — see `CostReportFlowRow`. `flow` names the orchestrating
- * skill and `startedAt` when it opened, together telling apart two rows that share a name:
- * the same skill run twice in one session is two rows, never merged into one. Both are
- * absent on the one row for work that fell in no flow interval at all. */
+/** One agent's figures — see `CostReportAgentRow`. `agent` names it and is present exactly
+ * when `attribution` is `tool-stated`. The two rows that name none are different facts and
+ * never merged: `main-thread` is a tool that names agents saying this record belongs to
+ * none of them, `not-stated` is a tool whose route never names one, where reading a main
+ * thread would assert something nothing observed. */
 export interface CostReportEnvelopeAgentRow {
   readonly agent?: string;
+  readonly attribution: AgentAttributionSource;
   readonly totals: CostReportEnvelopeTotals;
 }
 
@@ -330,6 +337,7 @@ function supply(from: TelemetryRouteSupply | null): CostReportEnvelopeRouteSuppl
         token_counters: from.tokenCounters,
         amount: from.amount,
         tool_stated_step: from.toolStatedStep,
+        agent_name: from.agentName,
       };
 }
 
@@ -407,7 +415,11 @@ function backlogRow(row: CostReport["byBacklog"][number]): CostReportEnvelopeBac
 }
 
 function agentRow(row: CostReport["byAgents"][number]): CostReportEnvelopeAgentRow {
-  return { ...(row.agent === undefined ? {} : { agent: row.agent }), totals: totals(row.totals) };
+  return {
+    ...(row.agent === undefined ? {} : { agent: row.agent }),
+    attribution: row.attribution,
+    totals: totals(row.totals),
+  };
 }
 
 function promptRow(row: CostReport["byPrompts"][number]): CostReportEnvelopePromptRow {

--- a/cli/src/domain/models/cost-report.ts
+++ b/cli/src/domain/models/cost-report.ts
@@ -78,14 +78,28 @@ export interface CostReportModelRow {
   readonly totals: CostTotals;
 }
 
-/** One agent's own share of a period, `agent` absent for the main thread.
+/** How a record's agent came to be known, so a row that names none says which of the two
+ * silences it is. `main-thread` is a measurement — the tool names agents and said this
+ * record belongs to none of them; `not-stated` is the absence of one, from a tool whose
+ * route never names an agent at all, and reading it as a main thread would assert a fact
+ * nothing observed. */
+export type AgentAttributionSource = "tool-stated" | "main-thread" | "not-stated";
+
+/** One agent's own share of a period, `agent` absent unless `attribution` is `tool-stated`.
  *
  * Where the spend actually is: measured on a live session, ten subagent files held 432M of
  * its 466M tokens, and every one of their lines names its agent where almost none names a
  * skill (100% against 2.7%). `by_step` reads a few percent not because the reader drops
- * anything but because the host names a skill on the main thread alone. */
+ * anything but because the host names a skill on the main thread alone.
+ *
+ * **The limit this axis still lives with.** A line marked as a subagent's that carries no
+ * agent name reads as the main thread, because nothing on the stored record separates the
+ * two. Measured 2026-09-05 across 1,852 transcripts: 157 of 122,637 subagent lines name no
+ * agent, 0.07%. Closing it means a new field on the record, which no record already stored
+ * could ever gain (see `storeNewCandidates`), so it is stated rather than captured. */
 export interface CostReportAgentRow {
   readonly agent?: string;
+  readonly attribution: AgentAttributionSource;
   readonly totals: CostTotals;
 }
 
@@ -625,13 +639,42 @@ function projectKeyOf(record: TelemetrySinkRecord): ProjectKey {
 const NO_KNOWN_MODEL = Symbol("no known model");
 type ModelKey = string | typeof NO_KNOWN_MODEL;
 
-// The main thread's own row. A symbol for the same reason `NO_KNOWN_MODEL` is one: an agent
-// really can be named anything, so no string is safe to reserve.
-const NO_AGENT = Symbol("the main thread");
-type AgentKey = string | typeof NO_AGENT;
+// The main thread's own row, and the row for a tool that could never have named one. Symbols
+// for the same reason `NO_KNOWN_MODEL` is one: an agent really can be named anything, so no
+// string is safe to reserve.
+const MAIN_THREAD = Symbol("the main thread");
+const AGENT_NOT_STATED = Symbol("a tool whose route never names an agent");
+type AgentKey = string | typeof MAIN_THREAD | typeof AGENT_NOT_STATED;
 
-function agentKeyOf(record: TelemetrySinkRecord): AgentKey {
-  return record.agent_name === undefined ? NO_AGENT : record.agent_name;
+/** Which of the three rows a record joins. `agent_name` present is the tool's own statement
+ * and needs nothing else; absent means one of two different things, and only the tool's
+ * declaration tells them apart.
+ *
+ * This axis used to answer `NO_AGENT` for every record with no `agent_name`, whatever the
+ * tool. Only Claude Code's reader ever sets the field, so on Codex, Copilot and OpenCode
+ * every record was reported as the main thread — 100% of the axis, on no evidence. The
+ * declaration is read rather than the record because the record cannot carry the absence:
+ * a tool that never names an agent writes exactly what a main-thread line writes. */
+function agentKeyOf(
+  record: TelemetrySinkRecord,
+  namesAgents: (tool: AiToolId) => boolean
+): AgentKey {
+  if (record.agent_name !== undefined) return record.agent_name;
+  return namesAgents(record.tool) ? MAIN_THREAD : AGENT_NOT_STATED;
+}
+
+/** Whether a tool's own declared route names agents, answered from `declaredTools` alone.
+ * A tool with no declared local read supplies nothing, so it names no agent either — the
+ * same reading `NO_CAPABILITY` gives every other supply. */
+function agentNamingTools(
+  declaredTools: readonly CostReportToolDeclaration[]
+): (tool: AiToolId) => boolean {
+  const naming = new Set(
+    declaredTools
+      .filter((declaration) => declaration.capability.localRead?.agentName === true)
+      .map((declaration) => declaration.tool)
+  );
+  return (tool) => naming.has(tool);
 }
 
 // The row for what named no prompt. A symbol for the same reason `NO_AGENT` is one: a prompt
@@ -1290,33 +1333,50 @@ function accumulateSessionRecord(groups: Groups, record: TelemetrySinkRecord): v
   }
 }
 
+/** Everything one record needs to be placed on every axis, resolved once per report rather
+ * than once per record. Gathered into a shape because the list had grown past what a
+ * positional signature reads as: nine parameters in a fixed order is a call nobody can check
+ * by eye, and every one of them is the same for every record in the run. */
+interface RecordContext {
+  readonly membership: TaskMembership | null;
+  readonly taskIntervalsByVendorId: ReadonlyMap<string, readonly TaskInterval[]>;
+  readonly flowIntervalsByVendorId: ReadonlyMap<string, readonly FlowInterval[]>;
+  readonly journalsByVendorId: ReadonlyMap<string, CostReportSessionJournal>;
+  readonly identity: PersonIdentity | null;
+  readonly taskBacklogDeclarations: ReadonlyMap<TaskIdentity, TaskBacklogDeclaration> | undefined;
+  readonly namesAgents: (tool: AiToolId) => boolean;
+}
+
 function accumulateRequestRecord(
   groups: Groups,
   record: TelemetrySinkRecord,
-  membership: TaskMembership | null,
-  taskIntervalsByVendorId: ReadonlyMap<string, readonly TaskInterval[]>,
-  flowIntervalsByVendorId: ReadonlyMap<string, readonly FlowInterval[]>,
-  journalsByVendorId: ReadonlyMap<string, CostReportSessionJournal>,
-  identity: PersonIdentity | null,
-  taskBacklogDeclarations: ReadonlyMap<TaskIdentity, TaskBacklogDeclaration> | undefined
+  context: RecordContext
 ): void {
   groups.totals.add(record);
   addToStepGroup(groups.steps, record);
   accumulateInto(groups.attributions, record.step_attribution, record);
   accumulateInto(groups.tools, record.tool, record);
   accumulateInto(groups.models, modelKeyOf(record), record);
-  accumulateInto(groups.agents, agentKeyOf(record), record);
+  accumulateInto(groups.agents, agentKeyOf(record, context.namesAgents), record);
   addToPromptGroup(groups.prompts, record);
   accumulateInto(groups.projects, projectKeyOf(record), record);
-  const taskRow = taskRowOf(record, taskIntervalsByVendorId, journalsByVendorId);
+  const taskRow = taskRowOf(record, context.taskIntervalsByVendorId, context.journalsByVendorId);
   addToTaskGroup(groups.tasks, taskRow, record);
-  accumulateInto(groups.backlog, backlogKeyOf(taskRow, taskBacklogDeclarations), record);
-  accumulateInto(groups.flows, flowKeyOf(record, flowIntervalsByVendorId), record);
-  addToPersonGroup(groups.people, record, resolvePerson(identity, personRawIdOf(record)));
-  const day = telemetrySinkRecordDayKey(record);
-  if (day !== undefined && groups.days.has(day)) groups.days.get(day)?.add(record);
+  accumulateInto(groups.backlog, backlogKeyOf(taskRow, context.taskBacklogDeclarations), record);
+  accumulateInto(groups.flows, flowKeyOf(record, context.flowIntervalsByVendorId), record);
+  addToPersonGroup(groups.people, record, resolvePerson(context.identity, personRawIdOf(record)));
+  addToDayGroup(groups.days, record);
+  const { membership } = context;
   const attribution = membership === null ? undefined : taskAttributionOf(record, membership);
   if (attribution !== undefined) accumulateInto(groups.taskAttributions, attribution, record);
+}
+
+/** Only a day the period itself spans: `emptyGroups` seeded every one of them, so a record
+ * dated outside the period joins nothing rather than adding a day the report never claimed
+ * to cover. */
+function addToDayGroup(days: Map<string, TotalsAccumulator>, record: TelemetrySinkRecord): void {
+  const day = telemetrySinkRecordDayKey(record);
+  if (day !== undefined && days.has(day)) days.get(day)?.add(record);
 }
 
 function accumulate(
@@ -1326,27 +1386,22 @@ function accumulate(
   membership: TaskMembership | null,
   journals: readonly CostReportSessionJournal[],
   identity: PersonIdentity | null,
-  taskBacklogDeclarations: ReadonlyMap<TaskIdentity, TaskBacklogDeclaration> | undefined
+  taskBacklogDeclarations: ReadonlyMap<TaskIdentity, TaskBacklogDeclaration> | undefined,
+  declaredTools: readonly CostReportToolDeclaration[]
 ): Groups {
   const groups = emptyGroups(fromDay, toDay);
-  const taskIntervalsByVendorId = allTaskIntervalsByVendorId(journals);
-  const flowIntervalsByVendorId = allFlowIntervalsByVendorId(journals);
-  const journalsByVendorId = new Map(journals.map((journal) => [journal.vendorId, journal]));
+  const context: RecordContext = {
+    membership,
+    taskIntervalsByVendorId: allTaskIntervalsByVendorId(journals),
+    flowIntervalsByVendorId: allFlowIntervalsByVendorId(journals),
+    journalsByVendorId: new Map(journals.map((journal) => [journal.vendorId, journal])),
+    identity,
+    taskBacklogDeclarations,
+    namesAgents: agentNamingTools(declaredTools),
+  };
   for (const record of records) {
-    if (record.kind === "session") {
-      accumulateSessionRecord(groups, record);
-      continue;
-    }
-    accumulateRequestRecord(
-      groups,
-      record,
-      membership,
-      taskIntervalsByVendorId,
-      flowIntervalsByVendorId,
-      journalsByVendorId,
-      identity,
-      taskBacklogDeclarations
-    );
+    if (record.kind === "session") accumulateSessionRecord(groups, record);
+    else accumulateRequestRecord(groups, record, context);
   }
   return groups;
 }
@@ -1557,14 +1612,15 @@ function dayRows(days: ReadonlyMap<string, TotalsAccumulator>): readonly CostRep
 function agentRows(
   agents: ReadonlyMap<AgentKey, TotalsAccumulator>
 ): readonly CostReportAgentRow[] {
-  const rows: CostReportAgentRow[] = [...agents].map(([key, accumulator]) => ({
-    ...(key === NO_AGENT ? {} : { agent: key }),
-    totals: accumulator.build(),
-  }));
+  const rows: CostReportAgentRow[] = [...agents].map(([key, accumulator]) => {
+    if (key === MAIN_THREAD) return { attribution: "main-thread", totals: accumulator.build() };
+    if (key === AGENT_NOT_STATED) return { attribution: "not-stated", totals: accumulator.build() };
+    return { agent: key, attribution: "tool-stated", totals: accumulator.build() };
+  });
   return bySize(
     rows,
     (row) => row.totals,
-    (row) => row.agent ?? ""
+    (row) => `${row.agent ?? ""}@${row.attribution}`
   );
 }
 
@@ -1989,7 +2045,8 @@ export function buildCostReport(input: CostReportInput): CostReport {
     membership,
     input.journals,
     identity,
-    input.taskBacklogDeclarations
+    input.taskBacklogDeclarations,
+    input.declaredTools
   );
 
   return assembleCostReport(input, inScope, groups, membership, emptySelection);

--- a/cli/src/domain/tools/ai/claude.ts
+++ b/cli/src/domain/tools/ai/claude.ts
@@ -132,7 +132,7 @@ export const claude: AiTool<HasAgents & HasSkills & HasCommands & HasRules & Has
       transcript: CLAUDE_CODE_TRANSCRIPT_LOCATION,
       // The mirror image of the export: the transcript names the running skill exactly, on
       // the same line as the counters, and carries no amount at all.
-      supplies: { tokenCounters: true, amount: false, toolStatedStep: true },
+      supplies: { tokenCounters: true, amount: false, toolStatedStep: true, agentName: true },
     },
     telemetryTaskAttributable: true,
     telemetryJournalHost: "claude-code",

--- a/cli/src/domain/tools/ai/codex.ts
+++ b/cli/src/domain/tools/ai/codex.ts
@@ -271,7 +271,7 @@ export const codex: AiTool<
     transcript: CODEX_ROLLOUT_LOCATION,
     // Complete counters per turn, no currency anywhere in a rollout, and no field naming a
     // running skill - so a step here can only ever come from a run journal interval.
-    supplies: { tokenCounters: true, amount: false, toolStatedStep: false },
+    supplies: { tokenCounters: true, amount: false, toolStatedStep: false, agentName: false },
   },
   // Codex's payload carries no write-path field for any tool (writes go through
   // apply_patch), but a declaration never needed one - it reads the same Bash command text

--- a/cli/src/domain/tools/ai/copilot.ts
+++ b/cli/src/domain/tools/ai/copilot.ts
@@ -355,7 +355,7 @@ export const copilot: AiTool<
   // copilot-events.ts for the reader and the arithmetic that settles it.
   telemetryLocalRead: {
     kind: "declared",
-    supplies: { tokenCounters: true, amount: false, toolStatedStep: false },
+    supplies: { tokenCounters: true, amount: false, toolStatedStep: false, agentName: false },
     // The exclusivity of `input` against `cache_read` is NOT established. The only capture
     // this repository holds (tests/fixtures/local-cost/.copilot/.../events.jsonl) reports
     // `cache_read: 0`, so "input excludes the cached prompt" and "input already includes it"

--- a/cli/src/domain/tools/ai/opencode.ts
+++ b/cli/src/domain/tools/ai/opencode.ts
@@ -177,7 +177,7 @@ export const opencode: AiTool<
     // Counters per message, and no amount: `info.cost` is `0` in every message captured
     // and its denomination was never established, so it is deliberately never read. No
     // field names a running skill either.
-    supplies: { tokenCounters: true, amount: false, toolStatedStep: false },
+    supplies: { tokenCounters: true, amount: false, toolStatedStep: false, agentName: false },
     // Measured 2026-08-20: `input` is exclusive of `cache.read` for providerID "anthropic",
     // matching that API's own documented behaviour. A second provider was probed 2026-08-24
     // (providerID "opencode") and reconciled the same way, but never exercised its cache

--- a/cli/tests/application/display/cost-report-artefact.unit.test.ts
+++ b/cli/tests/application/display/cost-report-artefact.unit.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import "../../../src/domain/tools/ai/claude.js";
+import "../../../src/domain/tools/ai/codex.js";
 import {
   ARTEFACT_AXES,
   buildCostReportArtefact,
@@ -310,6 +311,62 @@ describe("buildCostReportArtefact — by step, two rows sharing one name", () =>
     expect(journalIntervalRow).toContain("500 tokens");
     // 1,500 total input tokens across the two records - never printed as one row by either
     // renderer, but recoverable from the two rows a reader is given.
+  });
+});
+
+describe("buildCostReportArtefact — the agent axis names which silence a row is", () => {
+  const NAMES_AGENTS = {
+    localRead: { tokenCounters: true, amount: false, toolStatedStep: false, agentName: true },
+    export: null,
+    journalAttributable: false,
+    taskAttributable: false,
+  } as const;
+
+  // Two rows carry no agent name and mean opposite things. A table that printed "the main
+  // thread" for both would state, of a tool that never names an agent, a fact nothing
+  // observed — the reading this axis gave every Codex, Copilot and OpenCode record.
+  it("prints the main thread and a tool that names no agent as different rows", () => {
+    const envelope = envelopeOf({
+      declaredTools: [
+        { tool: "claude", coverage: "covered", capability: NAMES_AGENTS },
+        { tool: "codex", coverage: "covered", capability: NO_CAPABILITY },
+      ],
+      records: [
+        request({ input_tokens: 10 }),
+        request({ tool: "codex", vendor_id: "s-codex", input_tokens: 10 }),
+      ],
+    });
+
+    const artefact = buildCostReportArtefact(envelope, "agent");
+
+    expect(artefact).toContain("| the main thread |");
+    expect(artefact).toContain("| the tool names no agent |");
+  });
+
+  it("prints the same two labels in the terminal rendering", () => {
+    const report = buildCostReport({
+      fromDay: "2026-08-17",
+      toDay: "2026-08-21",
+      journals: [],
+      undatedRecords: 0,
+      unreadableLines: 0,
+      measurementEnabled: true,
+      declaredTools: [
+        { tool: "claude", coverage: "covered", capability: NAMES_AGENTS },
+        { tool: "codex", coverage: "covered", capability: NO_CAPABILITY },
+      ],
+      records: [
+        request({ input_tokens: 10 }),
+        request({ tool: "codex", vendor_id: "s-codex", input_tokens: 10 }),
+      ],
+    });
+    const output = new CapturingOutput();
+
+    printCostReport(output, report);
+
+    const printed = output.lines.join("\n");
+    expect(printed).toContain("the main thread");
+    expect(printed).toContain("the tool names no agent");
   });
 });
 

--- a/cli/tests/application/display/cost-report-display.unit.test.ts
+++ b/cli/tests/application/display/cost-report-display.unit.test.ts
@@ -215,8 +215,8 @@ describe("printCostReport", () => {
   it("prints a session total on its own tool row, not 'nothing in this period' (#697)", () => {
     const output = new CapturingOutput();
     const COPILOT_CAPABILITY = {
-      localRead: { tokenCounters: true, amount: false, toolStatedStep: false },
-      export: { tokenCounters: false, amount: false, toolStatedStep: false },
+      localRead: { tokenCounters: true, amount: false, toolStatedStep: false, agentName: false },
+      export: { tokenCounters: false, amount: false, toolStatedStep: false, agentName: false },
       journalAttributable: true,
       taskAttributable: false,
     } as const;

--- a/cli/tests/application/use-cases/telemetry/read-local-cost-use-case.unit.test.ts
+++ b/cli/tests/application/use-cases/telemetry/read-local-cost-use-case.unit.test.ts
@@ -127,7 +127,12 @@ describe("ReadLocalCostUseCase", () => {
 
   // What this stub route supplies is not what this file is about; it declares the minimum
   // the type requires so the use case's own orchestration is what gets tested.
-  const SUPPLIES_NOTHING = { tokenCounters: false, amount: false, toolStatedStep: false } as const;
+  const SUPPLIES_NOTHING = {
+    tokenCounters: false,
+    amount: false,
+    toolStatedStep: false,
+    agentName: false,
+  } as const;
 
   function declareClaudeReadable(): void {
     registerTool({
@@ -1520,7 +1525,12 @@ describe("a refusal holds on the one writer left", () => {
  */
 describe("which readers a session reaches", () => {
   const SPIED_SESSION = "spied-session";
-  const SUPPLIES = { tokenCounters: true, amount: false, toolStatedStep: false } as const;
+  const SUPPLIES = {
+    tokenCounters: true,
+    amount: false,
+    toolStatedStep: false,
+    agentName: false,
+  } as const;
 
   let claudeConfig: AiTool<unknown>;
   let codexConfig: AiTool<unknown>;

--- a/cli/tests/domain/models/cost-report-envelope.unit.test.ts
+++ b/cli/tests/domain/models/cost-report-envelope.unit.test.ts
@@ -24,8 +24,8 @@ const DECLARED: readonly CostReportToolDeclaration[] = [
     tool: "claude",
     coverage: "covered",
     capability: {
-      localRead: { tokenCounters: true, amount: false, toolStatedStep: true },
-      export: { tokenCounters: true, amount: true, toolStatedStep: false },
+      localRead: { tokenCounters: true, amount: false, toolStatedStep: true, agentName: true },
+      export: { tokenCounters: true, amount: true, toolStatedStep: false, agentName: false },
       journalAttributable: true,
       taskAttributable: true,
     },
@@ -48,8 +48,8 @@ const DECLARED: readonly CostReportToolDeclaration[] = [
       "Its own file names outputTokens per turn, but session.shutdown carries all four " +
       "counters for the whole session — a session total, never a sum of requests.",
     capability: {
-      localRead: { tokenCounters: true, amount: false, toolStatedStep: false },
-      export: { tokenCounters: false, amount: false, toolStatedStep: false },
+      localRead: { tokenCounters: true, amount: false, toolStatedStep: false, agentName: false },
+      export: { tokenCounters: false, amount: false, toolStatedStep: false, agentName: false },
       journalAttributable: true,
       taskAttributable: false,
     },
@@ -149,8 +149,18 @@ describe("toCostReportEnvelope", () => {
     );
 
     expect(byTool.claude).toEqual({
-      local_read: { token_counters: true, amount: false, tool_stated_step: true },
-      export: { token_counters: true, amount: true, tool_stated_step: false },
+      local_read: {
+        token_counters: true,
+        amount: false,
+        tool_stated_step: true,
+        agent_name: true,
+      },
+      export: {
+        token_counters: true,
+        amount: true,
+        tool_stated_step: false,
+        agent_name: false,
+      },
       journal_attributable: true,
       task_attributable: true,
     });

--- a/cli/tests/domain/models/cost-report.unit.test.ts
+++ b/cli/tests/domain/models/cost-report.unit.test.ts
@@ -42,6 +42,30 @@ const NO_CAPABILITY = {
   taskAttributable: false,
 } as const;
 
+/** A tool whose local read does name the agent that ran - what tells "the main thread" apart
+ * from "a tool that could never have said". Only a declaration says which; `NO_CAPABILITY`
+ * declares no route at all, so a record of that tool can support neither reading. */
+const NAMES_AGENTS = {
+  localRead: { tokenCounters: true, amount: false, toolStatedStep: false, agentName: true },
+  export: null,
+  journalAttributable: false,
+  taskAttributable: false,
+} as const;
+
+/** Codex's real shape: a declared local read that supplies token counters and names no
+ * agent. Distinct from `NO_CAPABILITY`, which declares no route at all - the reading must
+ * be the same for both, and only a route that says `agentName` can support a main thread. */
+const READS_BUT_NAMES_NO_AGENT = {
+  localRead: { tokenCounters: true, amount: false, toolStatedStep: false, agentName: false },
+  export: null,
+  journalAttributable: false,
+  taskAttributable: false,
+} as const;
+
+const TOOL_THAT_NAMES_AGENTS = [
+  { tool: "claude" as const, coverage: "covered" as const, capability: NAMES_AGENTS },
+];
+
 function report(overrides: Partial<CostReportInput> = {}) {
   return buildCostReport({
     fromDay: "2026-08-17",
@@ -390,8 +414,8 @@ describe("buildCostReport — a still-open local-read turn is superseded, never 
 
 describe("buildCostReport — a local-read session total, the first kind: 'session' report figure (#697)", () => {
   const COPILOT_CAPABILITY = {
-    localRead: { tokenCounters: true, amount: false, toolStatedStep: false },
-    export: { tokenCounters: false, amount: false, toolStatedStep: false },
+    localRead: { tokenCounters: true, amount: false, toolStatedStep: false, agentName: false },
+    export: { tokenCounters: false, amount: false, toolStatedStep: false, agentName: false },
     journalAttributable: true,
     taskAttributable: false,
   } as const;
@@ -562,6 +586,7 @@ describe("buildCostReport — every breakdown reconciles", () => {
   // `agent_name` — 924 of 1018 stored records hold one — and nothing exposed it.
   it("breaks the period down by the agent that ran, main thread included as its own row", () => {
     const built = report({
+      declaredTools: TOOL_THAT_NAMES_AGENTS,
       records: [
         request({ agent_name: "aidd-dev:executor", input_tokens: 100 }),
         request({ agent_name: "aidd-dev:executor", input_tokens: 50 }),
@@ -570,15 +595,83 @@ describe("buildCostReport — every breakdown reconciles", () => {
       ],
     });
 
-    expect(built.byAgents.map((row) => [row.agent, row.totals.requests])).toEqual([
-      ["aidd-dev:executor", 2],
-      ["Explore", 1],
-      [undefined, 1],
+    expect(built.byAgents.map((row) => [row.agent, row.attribution, row.totals.requests])).toEqual([
+      ["aidd-dev:executor", "tool-stated", 2],
+      ["Explore", "tool-stated", 1],
+      [undefined, "main-thread", 1],
     ]);
+  });
+
+  // The reading this axis used to give every tool: `agent_name` absent was read as the main
+  // thread, whatever the tool was. Only Claude Code's reader ever sets the field - Codex,
+  // Copilot and OpenCode never do - so on those tools every record was reported as the main
+  // thread on no evidence at all. An unknown is never a zero, and it is never a main thread
+  // either.
+  it("claims no main thread for a tool whose route never names an agent", () => {
+    const built = report({
+      declaredTools: [{ tool: "codex", coverage: "covered", capability: NO_CAPABILITY }],
+      records: [request({ tool: "codex", input_tokens: 4 })],
+    });
+
+    expect(built.byAgents.map((row) => [row.agent, row.attribution])).toEqual([
+      [undefined, "not-stated"],
+    ]);
+  });
+
+  // A declared route is not the same as a route that names agents. Codex reads token
+  // counters from its own rollout files and names no agent anywhere in them, so its records
+  // must read exactly as a tool with no declared route at all does.
+  it("claims no main thread for a route that is declared and still names no agent", () => {
+    const built = report({
+      declaredTools: [{ tool: "codex", coverage: "covered", capability: READS_BUT_NAMES_NO_AGENT }],
+      records: [request({ tool: "codex", input_tokens: 4 })],
+    });
+
+    expect(built.byAgents.map((row) => row.attribution)).toEqual(["not-stated"]);
+  });
+
+  // Two records that named no agent, from two tools, are two rows and not one: merging them
+  // would put work nobody could attribute in the same row as work a tool measured as its own
+  // main thread.
+  it("keeps a main thread apart from a tool that could never have named one", () => {
+    const built = report({
+      declaredTools: [
+        ...TOOL_THAT_NAMES_AGENTS,
+        { tool: "codex", coverage: "covered", capability: NO_CAPABILITY },
+      ],
+      records: [
+        request({ input_tokens: 5 }),
+        request({ tool: "codex", input_tokens: 5, vendor_id: "v-codex" }),
+      ],
+    });
+
+    expect(built.byAgents.map((row) => row.attribution).sort()).toEqual([
+      "main-thread",
+      "not-stated",
+    ]);
+  });
+
+  it("reconciles the agent breakdown when a named, a main-thread and an unstated row all exist", () => {
+    const built = report({
+      declaredTools: [
+        ...TOOL_THAT_NAMES_AGENTS,
+        { tool: "codex", coverage: "covered", capability: NO_CAPABILITY },
+      ],
+      records: [
+        request({ agent_name: "aidd-dev:checker", input_tokens: 7 }),
+        request({ input_tokens: 3 }),
+        request({ tool: "codex", input_tokens: 11, vendor_id: "v-codex" }),
+      ],
+    });
+
+    expect(built.byAgents).toHaveLength(3);
+    const summed = built.byAgents.reduce((total, row) => total + (row.totals.inputTokens ?? 0), 0);
+    expect(summed).toBe(built.totals.inputTokens);
   });
 
   it("reconciles the agent breakdown to the same total as every other axis", () => {
     const built = report({
+      declaredTools: TOOL_THAT_NAMES_AGENTS,
       records: [
         request({ agent_name: "aidd-dev:checker", input_tokens: 7 }),
         request({ input_tokens: 3 }),

--- a/cli/tests/domain/tools/telemetry-route-supply.unit.test.ts
+++ b/cli/tests/domain/tools/telemetry-route-supply.unit.test.ts
@@ -33,7 +33,7 @@ const CLAUDE_SESSION = "22222222-2222-4222-8222-222222222222";
 const CODEX_SESSION = "019fae6f-2009-7cd3-86b2-b8f83481b160";
 const COPILOT_SESSION = "33333333-3333-4333-8333-333333333333";
 
-/** Whatever a capture yields, reduced to the three facts a route declares. */
+/** Whatever a capture yields, reduced to the four facts a route declares. */
 function observe(records: readonly Partial<TelemetrySinkRecord>[]): TelemetryRouteSupply {
   const some = (has: (record: Partial<TelemetrySinkRecord>) => boolean) => records.some(has);
   return {
@@ -46,6 +46,7 @@ function observe(records: readonly Partial<TelemetrySinkRecord>[]): TelemetryRou
     ),
     amount: some((record) => record.cost_usd !== undefined),
     toolStatedStep: some((record) => record.step !== undefined),
+    agentName: some((record) => record.agent_name !== undefined),
   };
 }
 
@@ -121,6 +122,7 @@ describe("what a route declares it supplies, against what its reader actually pr
           tokenCounters: false,
           amount: false,
           toolStatedStep: false,
+          agentName: false,
         });
       });
       continue;

--- a/cli/tests/fixtures/cli-owns-read/expected-envelope.json
+++ b/cli/tests/fixtures/cli-owns-read/expected-envelope.json
@@ -72,12 +72,23 @@
   ],
   "by_agent": [
     {
+      "attribution": "main-thread",
       "totals": {
-        "requests": 4,
-        "input_tokens": 935,
-        "output_tokens": 590,
-        "cache_read_tokens": 14100,
+        "requests": 3,
+        "input_tokens": 35,
+        "output_tokens": 550,
+        "cache_read_tokens": 12100,
         "cache_creation_tokens": 1000
+      }
+    },
+    {
+      "attribution": "not-stated",
+      "totals": {
+        "requests": 1,
+        "input_tokens": 900,
+        "output_tokens": 40,
+        "cache_read_tokens": 2000,
+        "cache_creation_tokens": 0
       }
     }
   ],
@@ -122,7 +133,8 @@
         "local_read": {
           "token_counters": true,
           "amount": false,
-          "tool_stated_step": true
+          "tool_stated_step": true,
+          "agent_name": true
         },
         "export": null,
         "journal_attributable": true,
@@ -158,7 +170,8 @@
         "local_read": {
           "token_counters": true,
           "amount": false,
-          "tool_stated_step": false
+          "tool_stated_step": false,
+          "agent_name": false
         },
         "export": null,
         "journal_attributable": true,
@@ -183,7 +196,8 @@
         "local_read": {
           "token_counters": true,
           "amount": false,
-          "tool_stated_step": false
+          "tool_stated_step": false,
+          "agent_name": false
         },
         "export": null,
         "journal_attributable": true,
@@ -200,7 +214,8 @@
         "local_read": {
           "token_counters": true,
           "amount": false,
-          "tool_stated_step": false
+          "tool_stated_step": false,
+          "agent_name": false
         },
         "export": null,
         "journal_attributable": true,

--- a/plugins/aidd-telemetry/skills/01-cost/actions/03-report.md
+++ b/plugins/aidd-telemetry/skills/01-cost/actions/03-report.md
@@ -115,7 +115,11 @@ A breakdown the object leaves empty is a section left out, never a table of zero
    gained a fourth, `"no-journal"`, which says no usable run journal reached that record's
    session - a fact about the read, never the claim that the session declared no task. The
    bump from `9` to `10` added `by_agent` to the top-level breakdowns: which agent ran,
-   which on Claude Code is where most of the spend is. The bump from `8` to `9` added a
+   which on Claude Code is where most of the spend is. Read its `attribution` before
+   reading a row that names no agent: `main-thread` is a tool that names agents saying this
+   record belongs to none of them, `not-stated` is a tool whose route never names one -
+   every Codex, Copilot and OpenCode record - and calling the second a main thread would
+   state a fact nothing observed. The bump from `8` to `9` added a
    fourth value to `attribution`, `prompt-matched`. The bump from `7` to `8` added `by_flow`
    to the top-level breakdowns: which orchestrated run the journal's own step sequence
    already names (see [cost-report-contract.md](../../../../../aidd_docs/product/cost-report-contract.md)),


### PR DESCRIPTION
## What

`agentKeyOf` read `agent_name === undefined` as the main thread, whatever the tool:

```ts
return record.agent_name === undefined ? NO_AGENT : record.agent_name;
```

Only Claude Code's reader ever sets that field (`isSidechain` + `attributionAgent`, `claude-code-transcript.ts`). The Codex, Copilot and OpenCode readers set it nowhere. So on those three tools **every record was reported as the main thread — 100% of the axis, on no evidence at all.**

The contract said so out loud and called it correct:

> On every tool but Claude Code the field is never set at all, so that one row carries the whole period, which is the truth for a route that names no subagents.

The same source file already states the right rule twelve lines below, for `step`: *"its absence here yields no `step` at all … rather than asserting 'no skill ran'."*

## Change

A record with no agent name joins one of two rows, and only the tool's own declaration says which.

| Row | `attribution` | Means |
| --- | --- | --- |
| named | `tool-stated` | the tool named the agent |
| no name | `main-thread` | a tool that names agents said this belongs to none of them |
| no name | `not-stated` | a tool whose route never names one |

`TelemetryRouteSupply` gains `agentName`, declared per route beside `toolStatedStep` and checked against real captures by the existing honesty guard — `telemetry-route-supply.unit.test.ts` observes what each capture actually yields, so a route claiming an agent name its reader never sets fails there.

**The declaration is read rather than the record** because the record cannot carry the absence: a tool that never names an agent writes exactly what a main-thread line writes.

## What this does not fix

A line marked as a subagent's that carries no agent name still reads as the main thread. Measured 2026-09-05 across 1,852 transcripts: **157 of 122,637 subagent lines name no agent, 0.07%.** Closing it needs a new field on the record, which no record already stored could ever gain (`storeNewCandidates` freezes a record's field set at first sight, #769). Stated on `CostReportAgentRow` rather than captured.

## Proof

Two binaries against one copy of the sink, `--days 30`, 30,222 requests on both. This corpus is almost entirely Claude Code, so it can barely show the fault:

| `by_agent` row | `aee5721b` | this branch |
| --- | --- | --- |
| the main thread | 9,002 | 9,001 |
| a tool that names no agent | — | **1** |

That one record is the sink's only Codex request. The magnitude is not in this corpus — for a Codex-only reader the same change moves the whole axis — so the guards are the proof and the record is the demonstration the path runs end to end. All eleven breakdowns reconcile to 30,222 on both.

## Guards

| Guard | Mutation that killed it |
| --- | --- |
| a tool that names agents gets a `main-thread` row | always answer `not-stated` — 3 |
| a tool whose route never names one gets `not-stated` | always answer `main-thread`, the old reading — 3 |
| a *declared* route that names no agent reads the same as no route at all | accept any declared route — 1 |
| a route may not claim an agent name its reader never sets | make codex declare `agentName: true` — 1 |
| both renderings name which silence a row is | collapse the label to "the main thread" — 1 display, 1 artefact |

Reconciliation is covered by a three-row case: named + main thread + not stated must still sum to the period total.

## Envelope

No bump. The agent row gains `attribution` and the route supply gains `agent_name` — fields a consumer may ignore, no existing field changing meaning, the rule at `cost-report-envelope.ts`. A consumer that read `by_agent` as "one row per agent plus one for the main thread" now sees a third row; that is the same reasoning #768 applied to `by_flow` and CI accepted, stated here rather than implied.

Consumers updated in the same commit: the envelope type and mapper, the route-supply envelope shape, the `--axis agent` table, the terminal rendering, the contract, and the cost skill's reading instructions.

## Also in this commit

- `accumulate`'s per-record parameters became a `RecordContext`. Nine positional arguments in a fixed order is a call nobody checks by eye, and `biome`'s function-length rule made the point at the ninth.
- Bundle budget raised `593` → `596` KB, measured 593.8 — the same 2.2 KB headroom the `by_prompt` raise left, recorded in `check-bundle-size.mjs` beside the two raises before it.

Gates: 3449 tests / 308 files, `tsc`, `biome ci` (2 pre-existing warnings, 0 errors), knip, jscpd, bundle within budget, 369 repository script tests, 0 broken links, cli layering clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWNxk63AGKkqE8HRqHLjGp