### PR TITLE
test(cli): a smoke case checks what it broke

### DIFF
--- a/aidd_docs/tasks/2026_09/2026_09_05_a-smoke-case-checks-what-it-broke/plan.md
+++ b/aidd_docs/tasks/2026_09/2026_09_05_a-smoke-case-checks-what-it-broke/plan.md
@@ -1,0 +1,59 @@
+---
+status: done
+---
+
+# A smoke case checks what it broke
+
+## The defect
+
+Four cases in `smoke-tools.sh` damaged a file and then proved nothing about it.
+
+**They did not know which file they damaged.** Four places picked one with
+`find … | head -1`. `find` answers in directory order — not sorted, and not the same on two
+filesystems — so each run corrupted whichever file happened to come back first. A case that
+cannot name the file it broke is a case nobody can debug, and four of them shared the
+pattern:
+
+```sh
+cache_catalog() { find "$1/.aidd/cache/marketplaces" -path "*marketplace.json" … | head -1; }
+tgt=$(find "$BASE/.claude" -name "*.md" | head -1)
+d=$(find "$BASE/.cursor" -name "*.md" 2>/dev/null | head -1)
+i=$(find "$BASE/.vscode" -type f | head -1)
+```
+
+**And the three restore cases never checked the repair.** Each appended drift, ran
+`restore --force`, and asserted exit `0`:
+
+```sh
+if [[ -n "$tgt" ]]; then printf '\nDRIFT\n' >> "$tgt"; fi
+run "restore --force" 0 "" "$BASE" -- restore --force
+```
+
+A `restore --force` that exits 0 having restored nothing is precisely the failure #762 fixed
+inside the command. The smoke case meant to cover it would have passed throughout.
+
+The `ide` case was worse still: its drift was a bare newline, which `grep` cannot see, so no
+check on that file was possible at all.
+
+## The change
+
+- `first_file` replaces every `head -1`: `LC_ALL=C sort | head -1`, so the same file is
+  chosen on every machine and every run.
+- One named marker, `SMOKE_DRIFT`, is what the three cases append — a mark a check can look
+  for, unlike a blank line.
+- `repaired "<case>" "<file>"` runs after each restore and fails when the mark is still
+  there, or when nothing was drifted to repair in the first place.
+
+## Guards
+
+The harness is not run by CI (`pnpm smoke` is manual), so the guards read its text, the way
+`smoke-harness-isolation.unit.test.ts` already guards the home sandbox.
+
+| Guard | Mutation that killed it |
+| --- | --- |
+| no `find … \| head` survives anywhere in the harness | put one back — 1 |
+| every `restore --force` case is followed by a `repaired` check | drop one of the three — 1 |
+| the drift carries a name a check can grep for | rename the mark to `X` — 1 |
+
+Each was written first and failed for the reason it names. `bash -n` and
+`shellcheck -S error` both clean.

--- a/cli/scripts/smoke-tools.sh
+++ b/cli/scripts/smoke-tools.sh
@@ -92,7 +92,26 @@ run() {
 new_project() { local p; p=$(mktemp -d "$TMPROOT/proj.XXXXXX"); (cd "$p" && git init -q); echo "$p"; }
 # Only the marketplaces catalog — NOT the per-target built-marketplace cache
 # (.aidd/cache/built/.../marketplace.json), which also matches a bare *marketplace.json glob.
-cache_catalog() { find "$1/.aidd/cache/marketplaces" -path "*marketplace.json" 2>/dev/null | head -1; }
+# `find` answers in directory order, which is neither sorted nor the same on two machines.
+# Every case below damages the file this returns, so an unsorted pick runs a different case
+# on every run - and a case nobody can name is a case nobody can debug.
+first_file() { LC_ALL=C sort | head -1; }
+
+cache_catalog() { find "$1/.aidd/cache/marketplaces" -path "*marketplace.json" 2>/dev/null | first_file; }
+
+# The drift every restore case writes, and the string its check looks for again afterwards.
+# A marker rather than a bare newline: a blank line is invisible to `grep`, so a case that
+# appended one could only ever assert an exit code.
+DRIFT_MARK="SMOKE_DRIFT"
+
+# A restore that exits 0 having restored nothing is the exact failure #762 fixed in the
+# command. The exit code is checked by `run`; this is what checks the repair.
+repaired() {
+  local name="$1" file="$2"
+  if [[ -z "$file" ]]; then bad "$name (nothing was drifted to repair)"; return 1; fi
+  if grep -qF -- "$DRIFT_MARK" "$file"; then bad "$name (drift still in $file)"; return 1; fi
+  ok "$name repaired the file it drifted"
+}
 
 # ── build ───────────────────────────────────────────────────────
 echo "Building dist…"
@@ -188,17 +207,20 @@ else
   run "update" 0 "" "$BASE" -- update
 
   section "global restore"
-  tgt=$(find "$BASE/.claude" -name "*.md" | head -1)
-  if [[ -n "$tgt" ]]; then printf '\nDRIFT\n' >> "$tgt"; fi
+  tgt=$(find "$BASE/.claude" -name "*.md" | first_file)
+  if [[ -n "$tgt" ]]; then printf '\n%s\n' "$DRIFT_MARK" >> "$tgt"; fi
   run "restore --force" 0 "" "$BASE" -- restore --force
+  repaired "restore --force" "$tgt"
 
   section "ai per-tool commands × all 5 tools"
   run "ai list" 0 "" "$BASE" -- ai list
   run "ai status" 0 "" "$BASE" -- ai status
   run "ai doctor" "0|1" "" "$BASE" -- ai doctor
   run "ai update (all)" 0 "" "$BASE" -- ai update
-  d=$(find "$BASE/.cursor" -name "*.md" 2>/dev/null | head -1); [[ -n "$d" ]] && printf '\nX\n' >> "$d"
+  d=$(find "$BASE/.cursor" -name "*.md" 2>/dev/null | first_file)
+  [[ -n "$d" ]] && printf '\n%s\n' "$DRIFT_MARK" >> "$d"
   run "ai restore --force" 0 "" "$BASE" -- ai restore --force
+  repaired "ai restore --force" "$d"
   for t in "${AI_TOOLS[@]}"; do
     run "ai update $t" 0 "" "$BASE" -- ai update "$t"
   done
@@ -215,8 +237,12 @@ else
   run "ide status" 0 "" "$BASE" -- ide status
   run "ide doctor" 0 "" "$BASE" -- ide doctor
   run "ide update" 0 "" "$BASE" -- ide update vscode
-  i=$(find "$BASE/.vscode" -type f | head -1); [[ -n "$i" ]] && printf '\n' >> "$i"
+  # A blank line was the drift here, and `grep` cannot see one - so this case could only ever
+  # assert an exit code. The same mark as the other two, for the same reason.
+  i=$(find "$BASE/.vscode" -type f | first_file)
+  [[ -n "$i" ]] && printf '\n%s\n' "$DRIFT_MARK" >> "$i"
   run "ide restore --force" 0 "" "$BASE" -- ide restore --force
+  repaired "ide restore --force" "$i"
   P_IDE=$(new_project)
   (cd "$P_IDE" && node "$CLI" setup --source remote --ide vscode --plugins none --yes >/dev/null 2>&1)
   run "ide uninstall vscode" 0 "" "$P_IDE" -- ide uninstall vscode

--- a/cli/tests/infrastructure/smoke-harness-isolation.unit.test.ts
+++ b/cli/tests/infrastructure/smoke-harness-isolation.unit.test.ts
@@ -27,6 +27,17 @@ describe("the smoke harness never runs against the real user home", () => {
     expect(harness).toMatch(/export CODEX_HOME="\$TMPROOT\/[^"]+"/u);
   });
 
+  // A case that damages a file it picked at random, then asserts only an exit code, proves
+  // nothing twice over: it does not know which file it broke, and it never looks at whether
+  // the command repaired it. `find` returns directory order, which is neither sorted nor
+  // stable across filesystems, so `find … | head -1` on a tree of several files runs a
+  // different case on every machine.
+  it("picks the file a case damages in a fixed order, never whatever find returns first", () => {
+    const unsorted = [...harness.matchAll(/find [^\n|]*\|[ \t]*head\b/gu)].map((m) => m[0]);
+
+    expect(unsorted).toEqual([]);
+  });
+
   // Ordering is the whole guard: the token is resolved through `gh`, which reads the real
   // home. Exporting the sandbox before that line makes every authenticated case silently
   // unauthenticated, so the sandbox must come after it and before the first case that runs.
@@ -38,5 +49,24 @@ describe("the smoke harness never runs against the real user home", () => {
     expect(token).toBeGreaterThan(-1);
     expect(home).toBeGreaterThan(token);
     expect(home).toBeLessThan(firstCase);
+  });
+});
+
+/** A `restore --force` that returns 0 having restored nothing is exactly the failure #762
+ * fixed in the command itself, and the smoke case that was supposed to cover it asserted the
+ * exit code alone. An exit code is not a repair. */
+describe("a smoke case that damages a file checks the damage was undone", () => {
+  it("marks the drift it writes, so the check can name what it is looking for", () => {
+    expect(harness).toContain("SMOKE_DRIFT");
+  });
+
+  it("looks for that mark again after every restore it runs", () => {
+    const restores = [...harness.matchAll(/run "((?:ai |ide )?restore --force)"/gu)].map(
+      (match) => match[1]
+    );
+    const checks = [...harness.matchAll(/repaired "([^"]+)"/gu)].map((match) => match[1]);
+
+    expect(restores.length).toBeGreaterThan(0);
+    expect(checks.sort()).toEqual(restores.sort());
   });
 });


### PR DESCRIPTION
## What

Four cases in `smoke-tools.sh` damaged a file and then proved nothing about it.

**They did not know which file they damaged.** Four places picked one with `find … | head -1`. `find` answers in directory order — not sorted, not the same on two filesystems — so each run corrupted whichever file came back first:

```sh
cache_catalog() { find "$1/.aidd/cache/marketplaces" -path "*marketplace.json" … | head -1; }
tgt=$(find "$BASE/.claude"  -name "*.md" | head -1)
d=$(find   "$BASE/.cursor"  -name "*.md" 2>/dev/null | head -1)
i=$(find   "$BASE/.vscode"  -type f | head -1)
```

**And the three restore cases never checked the repair:**

```sh
if [[ -n "$tgt" ]]; then printf '\nDRIFT\n' >> "$tgt"; fi
run "restore --force" 0 "" "$BASE" -- restore --force
```

Exit `0` and nothing else. A `restore --force` that exits 0 having restored nothing is precisely the failure #762 fixed inside the command — the smoke case meant to cover it would have passed throughout.

The `ide` case was worse still: its drift was a bare newline, which `grep` cannot see, so no check on that file was possible at all.

## Change

| | |
| --- | --- |
| `first_file` | `LC_ALL=C sort \| head -1` — the same file on every machine and every run |
| `SMOKE_DRIFT` | one named marker the three cases append, so a check has something to look for |
| `repaired "<case>" "<file>"` | fails when the mark is still there after the restore, or when nothing was drifted to repair |

## Guards

The harness is not run by CI (`pnpm smoke` is manual), so the guards read its text — the way `smoke-harness-isolation.unit.test.ts` already guards the home sandbox.

| Guard | Mutation that killed it |
| --- | --- |
| no `find … \| head` survives anywhere in the harness | put one back — 1 |
| every `restore --force` case is followed by a `repaired` check | drop one of the three — 1 |
| the drift carries a name a check can grep for | rename the mark to `X` — 1 |

Each guard was written first and failed for the reason it names.

Gates: 3446 tests / 308 files, `tsc`, `biome ci` (2 pre-existing warnings, 0 errors), knip, jscpd, bundle within budget, 369 repository script tests, 0 broken links, `bash -n` and `shellcheck -S error` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWNxk63AGKkqE8HRqHLjGp