### PR TITLE
fix(plugins): a skill links only inside itself

### DIFF
--- a/aidd_docs/tasks/2026_09/2026_09_05_a-skill-links-only-inside-itself/plan.md
+++ b/aidd_docs/tasks/2026_09/2026_09_05_a-skill-links-only-inside-itself/plan.md
@@ -1,0 +1,57 @@
+---
+status: done
+---
+
+# A skill links only inside itself
+
+## The defect
+
+`architecture.md` has stated the rule since the per-tool distributions landed:
+
+> A skill never links outside itself: the tree ships both flat and as a marketplace, so no
+> relative path survives both.
+
+Nothing enforced it, and the one checker that looks at links cannot:
+`check-markdown-links.js` resolves every path against this repository, where the target does
+exist. A link reaching out of a skill is green there and dead in every installed copy.
+
+Five had accumulated:
+
+| File | Link |
+| --- | --- |
+| `aidd-dev/skills/01-plan/SKILL.md` | `../../../../aidd_docs/runs/README.md` |
+| `aidd-telemetry/skills/01-cost/actions/03-report.md` | `../../../../../aidd_docs/product/cost-report-contract.md` × 3 |
+| `aidd-telemetry/skills/01-cost/actions/03-report.md` | `../../../README.md` |
+
+Three of them point at `aidd_docs/product/cost-report-contract.md`, which no plugin ships at
+all — the reader of an installed `aidd-telemetry` is sent to a file that was never in the
+package.
+
+**The boundary is the skill, not the plugin.** `../../../README.md` stays inside
+`plugins/aidd-telemetry/`, and is still wrong: a tool installs a skill somewhere of its own
+choosing, and the plugin's README is no more reachable from there than the repository is.
+
+## The change
+
+Every one of the five becomes a name in prose. A reader can search for a name; a name cannot
+rot into a broken link.
+
+## The guard
+
+`scripts/__tests__/a-skill-links-only-inside-itself.test.js`. Every markdown file under
+`plugins/<plugin>/skills/<skill>/` is read, every relative link resolved, and one that lands
+outside that skill's own directory fails.
+
+It ships with a second test that puts an escaping link in front of it and requires it to be
+seen — without that, a boundary check that never trips reads exactly like a clean tree, which
+is the state `check-markdown-links.js` was already reporting.
+
+| Guard | Mutation that killed it |
+| --- | --- |
+| no link leaves its own skill | make the boundary check never trip — 1 |
+| the boundary is the skill, not the plugin | widen it to `plugins/<plugin>` — 1 |
+
+Both were killed by the probe test, which is the point of it.
+
+CI runs it: `cli CI` filters on `scripts/__tests__/**` and executes
+`node --test "scripts/__tests__/*.test.js"`, as does lefthook's pre-commit.

--- a/plugins/aidd-dev/skills/01-plan/SKILL.md
+++ b/plugins/aidd-dev/skills/01-plan/SKILL.md
@@ -29,8 +29,8 @@ echo "aidd:step-end aidd-dev:01-plan"
 This is the one thing about a step nothing else can supply. No host reports when a skill's
 work finished — a skill call's own result comes back in a tenth of a second, which is the
 dispatch, not the completion — so a measurement that never hears this ends the step at the
-next pause and credits planning with one turn out of however many it took. See
-[`aidd_docs/runs/README.md`](../../../../aidd_docs/runs/README.md).
+next pause and credits planning with one turn out of however many it took. The framework
+repository documents the run journal this writes into, in `aidd_docs/runs/README.md`.
 
 ## References
 

--- a/plugins/aidd-telemetry/skills/01-cost/actions/03-report.md
+++ b/plugins/aidd-telemetry/skills/01-cost/actions/03-report.md
@@ -91,7 +91,7 @@ A breakdown the object leaves empty is a section left out, never a table of zero
    than that.
 2. **Ask, as one axis or as the whole object.**
    - One axis: `aidd telemetry report --axis <axis> --from 2026-08-01 --to 2026-08-31`.
-   - Everything: `aidd telemetry report --from 2026-08-01 --to 2026-08-31 --json`, reading the shape from [cost-report-contract.md](../../../../../aidd_docs/product/cost-report-contract.md).
+   - Everything: `aidd telemetry report --from 2026-08-01 --to 2026-08-31 --json`, reading the shape from the report contract, `aidd_docs/product/cost-report-contract.md` in the framework repository.
    - The figure will be kept or compared: give `--from` and `--to`, since `--days` resolves against today and two identical calls on two days cover two different periods.
 3. **Refuse an unknown shape.** `cost_report_version` is `15` today, read from the `--json`
    path - the `--axis` path prints text the script already built from that same object, so
@@ -123,10 +123,10 @@ A breakdown the object leaves empty is a section left out, never a table of zero
    state a fact nothing observed. The bump from `8` to `9` added a
    fourth value to `attribution`, `prompt-matched`. The bump from `7` to `8` added `by_flow`
    to the top-level breakdowns: which orchestrated run the journal's own step sequence
-   already names (see [cost-report-contract.md](../../../../../aidd_docs/product/cost-report-contract.md)),
+   already names (see the report contract, `aidd_docs/product/cost-report-contract.md`),
    nothing newly captured for it. The bump from `6` to `7` added `by_backlog`
    to the top-level breakdowns: every task's records regrouped by what its own folder
-   declares (see [cost-report-contract.md](../../../../../aidd_docs/product/cost-report-contract.md)),
+   declares (see the report contract, `aidd_docs/product/cost-report-contract.md`),
    never a second notion of which task a record belongs to. The bump from `5` to `6` did
    not add a breakdown: what `by_task` gives for a record that fell in no declared
    interval can now be more than one row, each carrying `reason` - naming which distinct
@@ -170,7 +170,7 @@ A breakdown the object leaves empty is a section left out, never a table of zero
    | `task_attributable` | a session on this tool cannot be traced to a task, so it is absent from a task report without having done nothing |
 
 6. **Keep `unattributed` as itself.** Nothing measured supports reading it as no step having run, and it is never a residual.
-7. **Say when the answer is partial.** A non-zero `read.undated_records` or `read.unreadable_lines` means the total is incomplete, and the reasons are in [the plugin README](../../../README.md). The `--axis` path already carries this in its own last lines; the `--json` path carries it in `read`.
+7. **Say when the answer is partial.** A non-zero `read.undated_records` or `read.unreadable_lines` means the total is incomplete, and the reasons are in this plugin's own README. The `--axis` path already carries this in its own last lines; the `--json` path carries it in `read`.
 8. **Say when this project's own switch is off.** `measurement_enabled: false` on the `--json` path (a "switch is off" line in the `--axis` header) means these figures are not scoped to this project — the sink they come from is scoped to this person, across every project they ever measured. Relay both facts together: the switch is off here, and the figures shown are real, from wherever they were measured. Never read `false` as "these numbers are made up" or drop them for it.
 
 ## Test

--- a/scripts/__tests__/a-skill-links-only-inside-itself.test.js
+++ b/scripts/__tests__/a-skill-links-only-inside-itself.test.js
@@ -1,0 +1,94 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { describe, it } = require("node:test");
+
+const ROOT = path.resolve(__dirname, "../..");
+
+/**
+ * A skill ships two ways and a relative path survives only one of them.
+ *
+ * `architecture.md` has stated the rule since the per-tool distributions landed — "a skill
+ * never links outside itself: the tree ships both flat and as a marketplace, so no relative
+ * path survives both" — and nothing enforced it. `check-markdown-links.js` resolves every
+ * link against this repository, where the target does exist, so a link reaching out of a
+ * skill passes there and is dead in every installed copy.
+ *
+ * Five had accumulated, three of them into `aidd_docs/product/cost-report-contract.md`,
+ * which no plugin ships at all.
+ *
+ * The skill's own directory is the boundary, not the plugin's: `plugins/<plugin>/skills/
+ * <skill>/`. A link to a sibling skill, to the plugin's README, or to anything in the
+ * repository is equally unreachable once a tool has installed the skill somewhere of its
+ * own choosing. Name the file in prose instead — a reader can search for it, and a name
+ * cannot rot into a broken link.
+ */
+
+const SKILL_ROOT = /^plugins\/[^/]+\/skills\/[^/]+$/u;
+
+/** Markdown link targets that are relative paths — not anchors, not URLs, not mail. */
+const RELATIVE_LINK = /\]\((\.[^)\s]*)\)/gu;
+
+function everyMarkdownUnderPlugins(directory, into) {
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const full = path.join(directory, entry.name);
+    if (entry.isDirectory()) everyMarkdownUnderPlugins(full, into);
+    else if (entry.name.endsWith(".md")) into.push(full);
+  }
+  return into;
+}
+
+/** The skill directory a file belongs to, or `null` for a file outside every skill —
+ * a plugin's own README, an agent, a command, which ship by different rules. */
+function skillRootOf(relativePath) {
+  const segments = relativePath.split("/");
+  const root = segments.slice(0, 4).join("/");
+  return SKILL_ROOT.test(root) ? root : null;
+}
+
+function linksLeavingTheirSkill() {
+  const escaping = [];
+  for (const file of everyMarkdownUnderPlugins(path.join(ROOT, "plugins"), [])) {
+    const relative = path.relative(ROOT, file).split(path.sep).join("/");
+    const root = skillRootOf(relative);
+    if (root === null) continue;
+    const text = fs.readFileSync(file, "utf8");
+    for (const [, target] of text.matchAll(RELATIVE_LINK)) {
+      const resolved = path
+        .normalize(path.join(path.dirname(relative), target.split("#")[0]))
+        .split(path.sep)
+        .join("/");
+      if (resolved !== root && !resolved.startsWith(`${root}/`)) {
+        escaping.push(`${relative} -> ${target}`);
+      }
+    }
+  }
+  return escaping;
+}
+
+describe("a skill links only inside itself", () => {
+  it("has no markdown link reaching out of the skill that ships it", () => {
+    assert.deepEqual(
+      linksLeavingTheirSkill(),
+      [],
+      "a relative link out of a skill is dead in every installed copy — name the file in prose instead",
+    );
+  });
+
+  // The guard has to be able to see one. A checker that resolves every path against this
+  // repository, the way `check-markdown-links.js` does, reports nothing here at all.
+  it("sees an escaping link when one is put in front of it", () => {
+    const root = path.join(ROOT, "plugins", "aidd-dev", "skills", "01-plan");
+    const probe = path.join(root, "escaping-link-probe.md");
+    fs.writeFileSync(probe, "[out](../../../../README.md)\n", "utf8");
+    try {
+      const found = linksLeavingTheirSkill();
+      assert.ok(
+        found.some((entry) => entry.includes("escaping-link-probe.md")),
+        `the probe was not detected; found: ${JSON.stringify(found)}`,
+      );
+    } finally {
+      fs.rmSync(probe);
+    }
+  });
+});


### PR DESCRIPTION
## What

`architecture.md` has stated the rule since the per-tool distributions landed:

> A skill never links outside itself: the tree ships both flat and as a marketplace, so no relative path survives both.

Nothing enforced it, **and the one checker that looks at links cannot**: `check-markdown-links.js` resolves every path against this repository, where the target does exist. A link reaching out of a skill is green there and dead in every installed copy.

Five had accumulated:

| File | Link |
| --- | --- |
| `aidd-dev/skills/01-plan/SKILL.md` | `../../../../aidd_docs/runs/README.md` |
| `aidd-telemetry/skills/01-cost/actions/03-report.md` | `../../../../../aidd_docs/product/cost-report-contract.md` × 3 |
| `aidd-telemetry/skills/01-cost/actions/03-report.md` | `../../../README.md` |

Three point at `aidd_docs/product/cost-report-contract.md`, which **no plugin ships at all** — a reader of an installed `aidd-telemetry` was sent to a file that was never in the package.

**The boundary is the skill, not the plugin.** `../../../README.md` stays inside `plugins/aidd-telemetry/` and is still wrong: a tool installs a skill somewhere of its own choosing, and the plugin's README is no more reachable from there than the repository is.

## Change

Every one of the five becomes a name in prose. A reader can search for a name; a name cannot rot into a broken link.

## The guard

`scripts/__tests__/a-skill-links-only-inside-itself.test.js` reads every markdown under `plugins/<plugin>/skills/<skill>/`, resolves each relative link, and fails on one landing outside that skill's own directory.

It ships with a second test that puts an escaping link in front of it and requires it to be seen. Without that, a boundary check that never trips reads exactly like a clean tree — which is the state `check-markdown-links.js` was already reporting.

| Guard | Mutation that killed it |
| --- | --- |
| no link leaves its own skill | make the boundary check never trip — 1 |
| the boundary is the skill, not the plugin | widen it to `plugins/<plugin>` — 1 |

Both were killed by the probe test, which is the point of it.

CI runs it: `cli CI` filters on `scripts/__tests__/**` and executes `node --test "scripts/__tests__/*.test.js"`, as does lefthook's pre-commit.

Gates: 371 repository script tests (369 + the two new), 0 broken links, `check-markdown-links.js` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWNxk63AGKkqE8HRqHLjGp