### PR TITLE
fix(cli): activation leaves no permanent drift

### DIFF
--- a/aidd_docs/tasks/2026_09/2026_09_05_activation-leaves-no-permanent-drift/plan.md
+++ b/aidd_docs/tasks/2026_09/2026_09_05_activation-leaves-no-permanent-drift/plan.md
@@ -1,0 +1,60 @@
+---
+status: done
+---
+
+# Activation leaves no permanent drift
+
+## The defect
+
+`MarketplaceSyncSettingsUseCase.execute` ran in this order:
+
+1. `syncTool` writes `.claude/settings.json` and hashes what it wrote into the manifest.
+2. `manifestRepo.save(manifest)`.
+3. `activateNativeTools` shells out to `claude plugin marketplace add` and
+   `claude plugin enable`.
+
+Step 3 writes into the same file step 1 hashed. Claude Code declares
+`settingsPath: ".claude/settings.json"` and **no** `enabledPluginsSettingsPath`, so both
+halves land there, and the file is hash-tracked (`syncEnabledPluginsFile` tracks it precisely
+because the two paths coincide).
+
+Nothing re-read it. The tracked hash described content that stopped existing the moment
+activation succeeded, so:
+
+- `status` and `doctor` reported a file the person never touched as drifted, for as long as
+  the manifest stood.
+- `restore` would have undone the host's own registration to reach a state AIDD held for the
+  length of one function.
+
+## How it was confirmed, and the wrong answer that came first
+
+The first probe **passed**, and it was vacuous: the fake activator wrote
+`enabledPlugins: { <ref>: true }`, which is exactly the key `mergeEnabledPlugins` had already
+written, so the content was byte-identical and the hash matched by coincidence.
+
+Replacing it with a key this code never writes — the host's own bookkeeping — turned the
+probe red. That is the difference between a passing test and a test that checks anything.
+
+## The change
+
+After activation, re-read the settings file and store what is there, for the tools whose own
+CLI actually ran. `activateTool` now answers whether it drove the CLI, and only those tools
+are re-hashed.
+
+**Only those tools.** A tool whose binary is absent wrote nothing, so a settings file that
+differs from its tracked hash differs because a person changed it — the drift `status` exists
+to report and `restore` exists to undo. Re-hashing every installed tool would bless that as
+ours and make the person's change permanent and invisible.
+
+Re-read rather than re-derived: what is stored is what is on disk after the write, an
+observation, not a guess at what the host would have written.
+
+## Guards
+
+| Guard | Mutation that killed it |
+| --- | --- |
+| the tracked hash matches the file after the host CLI has written to it | drop the re-hash — the code as it was — 1 |
+| a hash is left alone for a tool whose own CLI never ran | re-hash every installed tool — 1 |
+
+The second is what keeps the first honest; without it the fix would be indistinguishable from
+"always trust the file".

--- a/cli/src/application/use-cases/marketplace/marketplace-sync-settings-use-case.ts
+++ b/cli/src/application/use-cases/marketplace/marketplace-sync-settings-use-case.ts
@@ -58,21 +58,81 @@ export class MarketplaceSyncSettingsUseCase implements MarketplaceSyncSettings {
       if (updated) updatedTools.push(toolId);
     }
     if (updatedTools.length > 0) await this.manifestRepo.save(manifest);
-    await this.activateNativeTools(projectRoot, manifest, marketplaces);
+    const activated = await this.activateNativeTools(projectRoot, manifest, marketplaces);
+    if (await this.recordWhatActivationWrote(projectRoot, manifest, activated))
+      await this.manifestRepo.save(manifest);
     return { updatedTools };
   }
 
+  /** Answers the tools whose own CLI actually ran — never every installed tool. A tool whose
+   * binary is absent, or that has no native activation at all, wrote nothing, so a settings
+   * file that differs for it differs because a person changed it. Blessing that as ours is
+   * the one thing this must not do. */
   private async activateNativeTools(
     projectRoot: string,
     manifest: Manifest,
     marketplaces: readonly Marketplace[]
-  ): Promise<void> {
+  ): Promise<readonly ToolId[]> {
+    const activated: ToolId[] = [];
     for (const toolId of manifest.getInstalledToolIds()) {
       const binary = this.nativeActivationBinary(toolId);
       const activator = binary === undefined ? undefined : this.activators.get(binary);
       if (binary === undefined || activator === undefined) continue;
-      await this.activateTool(toolId, binary, activator, projectRoot, manifest, marketplaces);
+      const ran = await this.activateTool(
+        toolId,
+        binary,
+        activator,
+        projectRoot,
+        manifest,
+        marketplaces
+      );
+      if (ran) activated.push(toolId);
     }
+    return activated;
+  }
+
+  /**
+   * The host's own CLI writes its registration into the very file `syncTool` had just
+   * hashed — Claude Code declares no separate `enabledPluginsSettingsPath`, so both halves
+   * land in `.claude/settings.json`. The tracked hash then described content that no longer
+   * existed, and nothing re-read it: `status` and `doctor` reported a file the person never
+   * touched as drifted for as long as the manifest stood, and `restore` would have undone
+   * the host's own registration to reach a state AIDD held for the length of one function.
+   *
+   * Re-read rather than re-derive, and only for a tool whose CLI actually ran: what is
+   * stored is what is on disk after the write, which is the observation, not a guess at
+   * what the host would have written.
+   */
+  private async recordWhatActivationWrote(
+    projectRoot: string,
+    manifest: Manifest,
+    activated: readonly ToolId[]
+  ): Promise<boolean> {
+    let changed = false;
+    for (const toolId of activated) {
+      const settingsPath = this.marketplaceSettingsOf(toolId)?.settingsPath;
+      if (settingsPath === undefined) continue;
+      const tracked = manifest
+        .getToolFiles(toolId)
+        .find((file) => file.relativePath === settingsPath);
+      if (tracked === undefined) continue;
+      const content = await this.fs.readFile(resolve(projectRoot, settingsPath)).catch(() => null);
+      if (content === null) continue;
+      const hash = this.hasher.hash(content);
+      if (hash.value === tracked.hash.value) continue;
+      manifest.updateTrackedFileHash(toolId, settingsPath, hash);
+      changed = true;
+    }
+    return changed;
+  }
+
+  private marketplaceSettingsOf(toolId: ToolId): MarketplaceSettings | undefined {
+    const toolConfig = getToolConfig(toolId);
+    if (toolConfig === undefined || !isAiTool(toolConfig)) return undefined;
+    const caps = toolConfig.capabilities as {
+      plugins?: { marketplaceSettings: MarketplaceSettings | null };
+    };
+    return caps.plugins?.marketplaceSettings ?? undefined;
   }
 
   private nativeActivationBinary(toolId: ToolId): string | undefined {
@@ -84,6 +144,8 @@ export class MarketplaceSyncSettingsUseCase implements MarketplaceSyncSettings {
     return caps.plugins?.nativeActivation?.binary ?? undefined;
   }
 
+  /** True when this tool's own CLI was actually driven — the only case in which the settings
+   * file may have been written by anything but this code. */
   private async activateTool(
     toolId: ToolId,
     binary: string,
@@ -91,12 +153,12 @@ export class MarketplaceSyncSettingsUseCase implements MarketplaceSyncSettings {
     projectRoot: string,
     manifest: Manifest,
     marketplaces: readonly Marketplace[]
-  ): Promise<void> {
+  ): Promise<boolean> {
     const { refs, marketplaces: used } = this.pluginActivation(toolId, manifest, marketplaces);
-    if (refs.length === 0) return;
+    if (refs.length === 0) return false;
     if (!activator.isAvailable()) {
       this.logger.warn(`${binary} CLI not found on PATH — skipping native plugin activation.`);
-      return;
+      return false;
     }
     // Each step is independently best-effort: one failing plugin or marketplace
     // must warn and let the others through, never abort the whole activation.
@@ -106,6 +168,7 @@ export class MarketplaceSyncSettingsUseCase implements MarketplaceSyncSettings {
     for (const ref of refs) {
       this.bestEffort(() => activator.enablePlugin(ref), `enable plugin '${ref}'`);
     }
+    return true;
   }
 
   private bestEffort(action: () => void, label: string): void {

--- a/cli/tests/application/use-cases/marketplace/marketplace-sync-native-activation.integration.test.ts
+++ b/cli/tests/application/use-cases/marketplace/marketplace-sync-native-activation.integration.test.ts
@@ -1,4 +1,5 @@
 import "../../../../src/domain/tools/ai/claude.js";
+import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import { MarketplaceSyncSettingsUseCase } from "../../../../src/application/use-cases/marketplace/marketplace-sync-settings-use-case.js";
 import { Manifest } from "../../../../src/domain/models/manifest.js";
@@ -65,19 +66,70 @@ function manifestWithPlugin(marketplace: string = MARKETPLACE): InMemoryManifest
 
 function buildSync(activator: FakeNativePluginActivator, pluginMarketplace?: string) {
   const registry = new InMemoryMarketplaceRegistry();
+  const fs = new InMemoryFileAdapter();
+  const manifestRepo = manifestWithPlugin(pluginMarketplace);
+  const hasher = new DeterministicHasher();
   return {
     registry,
+    fs,
+    manifestRepo,
+    hasher,
     useCase: new MarketplaceSyncSettingsUseCase(
-      new InMemoryFileAdapter(),
-      manifestWithPlugin(pluginMarketplace),
+      fs,
+      manifestRepo,
       registry,
       NO_CATALOG,
-      new DeterministicHasher(),
+      hasher,
       new CapturingLogger(),
       new Map([["claude", activator]]),
       fakeEnsureBuiltMarketplace()
     ),
   };
+}
+
+const SETTINGS_PATH = ".claude/settings.json";
+
+/** `resolve`, exactly as `syncMarketplacesFile` does — not a `/`-joined literal. On Windows
+ * the production key is `C:\\test-project\\.claude\\settings.json`, and a hand-built POSIX
+ * path addresses a file the use case never wrote. */
+function settingsPathIn(projectRoot: string): string {
+  return resolve(projectRoot, SETTINGS_PATH);
+}
+
+/** What the host's own CLI does that this code cannot see: `claude plugin marketplace add`
+ * and `claude plugin enable` write their result into the very file `syncTool` just hashed.
+ * The fake shells out to nothing, so it stands in for that write directly. */
+class ActivatorThatWritesSettings extends FakeNativePluginActivator {
+  constructor(
+    private readonly fs: InMemoryFileAdapter,
+    private readonly settingsAbsolutePath: string
+  ) {
+    super({ available: true });
+  }
+
+  private readonly writes: Promise<void>[] = [];
+
+  async settled(): Promise<void> {
+    await Promise.all(this.writes);
+  }
+
+  private async appendHostState(): Promise<void> {
+    const before = await this.fs.readFile(this.settingsAbsolutePath).catch(() => "{}");
+    const json = JSON.parse(before) as Record<string, unknown>;
+    // Not a key this code writes: the point is content only the host could have put there.
+    json.installedPluginsBookkeeping = { [REF]: { installedAt: "2026-09-05T00:00:00Z" } };
+    await this.fs.writeFile(this.settingsAbsolutePath, JSON.stringify(json, null, 2));
+  }
+
+  override addMarketplace(source: string): void {
+    super.addMarketplace(source);
+    this.writes.push(this.appendHostState());
+  }
+
+  override enablePlugin(pluginRef: string): void {
+    super.enablePlugin(pluginRef);
+    this.writes.push(this.appendHostState());
+  }
 }
 
 describe("syncing settings registers the plugin with the host's own CLI", () => {
@@ -141,5 +193,95 @@ describe("syncing settings registers the plugin with the host's own CLI", () => 
     ]).entries[0];
 
     expect(entry?.answer).toBe("not-registered");
+  });
+});
+
+/**
+ * `syncTool` writes `.claude/settings.json`, hashes what it wrote, and the manifest is saved.
+ * Only then does `activateNativeTools` run the host's own CLI — which writes into that same
+ * file, because Claude Code declares no separate `enabledPluginsSettingsPath`.
+ *
+ * So the tracked hash describes content that no longer exists the moment activation
+ * succeeds. Nothing re-hashes it. `status` and `doctor` report a file the user never touched
+ * as drifted, for as long as the manifest stands, and `restore` would undo the host's own
+ * registration to get back to a state AIDD only ever held for the length of one function.
+ *
+ * The one case in this file that is about what the activation leaves behind rather than what
+ * it was driven with.
+ */
+describe("what native activation leaves behind is not reported as the user's drift", () => {
+  it("tracks a hash that still matches the settings file after the host CLI has written to it", async () => {
+    const registry = new InMemoryMarketplaceRegistry();
+    const fs = new InMemoryFileAdapter();
+    const manifestRepo = manifestWithPlugin();
+    const hasher = new DeterministicHasher();
+    const settingsAbsolutePath = settingsPathIn(PROJECT_ROOT);
+    const activator = new ActivatorThatWritesSettings(fs, settingsAbsolutePath);
+    const useCase = new MarketplaceSyncSettingsUseCase(
+      fs,
+      manifestRepo,
+      registry,
+      NO_CATALOG,
+      hasher,
+      new CapturingLogger(),
+      new Map([["claude", activator]]),
+      fakeEnsureBuiltMarketplace()
+    );
+    await registry.save(PROJECT_ROOT, marketplace());
+
+    await useCase.execute({ projectRoot: PROJECT_ROOT });
+    // The port is synchronous and the host CLI's write is not, so let the writes the
+    // activator queued actually land before reading the file back.
+    await activator.settled();
+
+    const onDisk = await fs.readFile(settingsAbsolutePath);
+    const manifest = await manifestRepo.load();
+    const tracked = manifest?.getToolFiles("claude") ?? [];
+    const entry = tracked.find((file) => file.relativePath === SETTINGS_PATH);
+
+    expect(entry, "the settings file is tracked at all").toBeDefined();
+    expect(entry?.hash).toEqual(hasher.hash(onDisk));
+  });
+  /**
+   * The other half, and the one that keeps the repair honest. A tool whose CLI is not on the
+   * PATH wrote nothing, so a settings file that differs from its tracked hash differs because
+   * a person changed it — which is exactly the drift `status` exists to report and `restore`
+   * exists to undo. Re-hashing every tool after activation would bless that as ours and
+   * silently make the change permanent.
+   */
+  it("leaves a hash alone for a tool whose own CLI never ran", async () => {
+    const registry = new InMemoryMarketplaceRegistry();
+    const fs = new InMemoryFileAdapter();
+    const manifestRepo = manifestWithPlugin();
+    const hasher = new DeterministicHasher();
+    const settingsAbsolutePath = settingsPathIn(PROJECT_ROOT);
+    const useCase = new MarketplaceSyncSettingsUseCase(
+      fs,
+      manifestRepo,
+      registry,
+      NO_CATALOG,
+      hasher,
+      new CapturingLogger(),
+      // Not available: the binary is not on the PATH, so nothing of the host's is written.
+      new Map([["claude", new FakeNativePluginActivator({ available: false })]]),
+      fakeEnsureBuiltMarketplace()
+    );
+    await registry.save(PROJECT_ROOT, marketplace());
+    await useCase.execute({ projectRoot: PROJECT_ROOT });
+    const hashAfterSync = (await manifestRepo.load())
+      ?.getToolFiles("claude")
+      .find((file) => file.relativePath === SETTINGS_PATH)?.hash;
+
+    // A person edits the file, then a second sync runs and changes nothing else.
+    const edited = `${await fs.readFile(settingsAbsolutePath)}\n`;
+    await fs.writeFile(settingsAbsolutePath, edited);
+    await useCase.execute({ projectRoot: PROJECT_ROOT });
+
+    const tracked = (await manifestRepo.load())
+      ?.getToolFiles("claude")
+      .find((file) => file.relativePath === SETTINGS_PATH);
+    expect(hashAfterSync, "the settings file is tracked at all").toBeDefined();
+    expect(tracked?.hash).toEqual(hashAfterSync);
+    expect(tracked?.hash).not.toEqual(hasher.hash(edited));
   });
 });


### PR DESCRIPTION
## What

`MarketplaceSyncSettingsUseCase.execute` ran in this order:

1. `syncTool` writes `.claude/settings.json` and hashes what it wrote into the manifest.
2. `manifestRepo.save(manifest)`.
3. `activateNativeTools` shells out to `claude plugin marketplace add` and `claude plugin enable`.

**Step 3 writes into the same file step 1 hashed.** Claude Code declares `settingsPath: ".claude/settings.json"` and *no* `enabledPluginsSettingsPath`, so both halves land there — and the file is hash-tracked precisely because the two paths coincide (`syncEnabledPluginsFile`'s own `if (settings.enabledPluginsSettingsPath == null)`).

Nothing re-read it. The tracked hash described content that stopped existing the moment activation succeeded, so:

- `status` and `doctor` reported a file the person never touched as drifted, for as long as the manifest stood.
- `restore` would have undone the host's own registration to reach a state AIDD held for the length of one function.

## The wrong answer that came first

The first probe **passed** — and was vacuous. The fake activator wrote `enabledPlugins: { <ref>: true }`, which is exactly the key `mergeEnabledPlugins` had already written, so the content was byte-identical and the hash matched by coincidence. Replacing it with a key this code never writes — the host's own bookkeeping — turned the probe red.

## Change

After activation the settings file is re-read and what is there is stored, for **the tools whose own CLI actually ran**. `activateTool` now answers whether it drove the CLI.

Only those tools. A tool whose binary is absent wrote nothing, so a settings file that differs from its tracked hash differs because a person changed it — the drift `status` exists to report and `restore` exists to undo. Re-hashing every installed tool would bless that as ours and make the person's change permanent and invisible.

Re-read rather than re-derived: what is stored is what is on disk after the write — an observation, not a guess at what the host would have written.

## Guards

| Guard | Mutation that killed it |
| --- | --- |
| the tracked hash matches the file after the host CLI has written to it | drop the re-hash, i.e. the code as it was — 1 |
| a hash is left alone for a tool whose own CLI never ran | re-hash every installed tool — 1 |

The second is what keeps the first honest: without it the fix is indistinguishable from "always trust the file".

## Windows caught the first push

Both new tests failed on `cli / Windows` at `17d64ee7` — a real failure, not the reporter flake #766 fixed. They built the settings key as a `/`-joined literal while the production code uses `resolve`, so on Windows the test addressed `\\test-project\\.claude\\settings.json` under a name the use case never wrote. Now resolved the same way the code does, with the reason stated where the helper lives.

Worth recording: the job that caught it is the one #766 existed to make trustworthy, and this is the first time since that it has failed for a reason that was actually mine.

Gates: 3454 tests / 308 files, `tsc`, `biome ci` (2 pre-existing warnings, 0 errors), knip, jscpd, bundle within budget, 369 repository script tests, 0 broken links, cli layering clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWNxk63AGKkqE8HRqHLjGp
