### PR TITLE
feat(plugins): every skill says when its own work is done

### DIFF
--- a/plugins/aidd-context/skills/00-onboard/SKILL.md
+++ b/plugins/aidd-context/skills/00-onboard/SKILL.md
@@ -30,3 +30,17 @@ Run the actions in that order, looping. Read an action's file in `actions/` befo
 - Never test a plugin version against a registry.
 - Never trust a stale status.
 - Wait for an explicit reply before running anything.
+
+## Say when this skill's work is done
+
+Once this skill has produced what it was called for, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-context:00-onboard"
+```
+
+No host reports when a skill's work finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that
+never hears this ends the step where the next one begins — or, where none follows, at the
+journal's own last witnessed moment, which credits this skill with everything the session
+did afterwards.

--- a/plugins/aidd-context/skills/01-bootstrap/SKILL.md
+++ b/plugins/aidd-context/skills/01-bootstrap/SKILL.md
@@ -37,3 +37,17 @@ Before running an action, read its file in `actions/`, not only the table or ass
 
 - `assets/checklist.md` - the 24-item checklist (4 blocks)
 - `assets/install-template.md` - the `INSTALL.md` skeleton
+
+## Say when this skill's work is done
+
+Once this skill has produced what it was called for, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-context:01-bootstrap"
+```
+
+No host reports when a skill's work finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that
+never hears this ends the step where the next one begins — or, where none follows, at the
+journal's own last witnessed moment, which credits this skill with everything the session
+did afterwards.

--- a/plugins/aidd-context/skills/02-project-memory/SKILL.md
+++ b/plugins/aidd-context/skills/02-project-memory/SKILL.md
@@ -31,3 +31,17 @@ Run the flow above, reading only the next action file.
 - Ask before anything ambiguous. Never default silently.
 - A bank that already exists changes only through what the user approved, file by file and line by line.
 - End with a short report of what changed.
+
+## Say when this skill's work is done
+
+Once this skill has produced what it was called for, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-context:02-project-memory"
+```
+
+No host reports when a skill's work finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that
+never hears this ends the step where the next one begins — or, where none follows, at the
+journal's own last witnessed moment, which credits this skill with everything the session
+did afterwards.

--- a/plugins/aidd-context/skills/03-context-generate/SKILL.md
+++ b/plugins/aidd-context/skills/03-context-generate/SKILL.md
@@ -19,3 +19,17 @@ Routes a generation request to the dedicated generator for the artifact kind. Ho
 | hook     | `aidd-context:08-hook-generate`  |
 
 Identify the artifact kind from the request, then hand off to the matching generator. If the kind is unclear, ask which one. To survey or list existing artifacts, use the explore skill instead.
+
+## Say when this skill's work is done
+
+Once this skill has produced what it was called for, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-context:03-context-generate"
+```
+
+No host reports when a skill's work finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that
+never hears this ends the step where the next one begins — or, where none follows, at the
+journal's own last witnessed moment, which credits this skill with everything the session
+did afterwards.

--- a/plugins/aidd-context/skills/04-skill-generate/SKILL.md
+++ b/plugins/aidd-context/skills/04-skill-generate/SKILL.md
@@ -29,3 +29,17 @@ Run the flow above. Read only the next action file.
 - If a cited reference cannot be read, stop and report the missing file.
 - Confirm every target and name with the user.
 - Never write silently.
+
+## Say when this skill's work is done
+
+Once this skill has produced what it was called for, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-context:04-skill-generate"
+```
+
+No host reports when a skill's work finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that
+never hears this ends the step where the next one begins — or, where none follows, at the
+journal's own last witnessed moment, which credits this skill with everything the session
+did afterwards.

--- a/plugins/aidd-context/skills/05-rule-generate/SKILL.md
+++ b/plugins/aidd-context/skills/05-rule-generate/SKILL.md
@@ -27,3 +27,17 @@ Before running an action, read its file in `actions/`, not only the table or ass
 ## Assets
 
 - `assets/rule-template.md`: rule file scaffold.
+
+## Say when this skill's work is done
+
+Once this skill has produced what it was called for, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-context:05-rule-generate"
+```
+
+No host reports when a skill's work finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that
+never hears this ends the step where the next one begins — or, where none follows, at the
+journal's own last witnessed moment, which credits this skill with everything the session
+did afterwards.

--- a/plugins/aidd-context/skills/06-agent-generate/SKILL.md
+++ b/plugins/aidd-context/skills/06-agent-generate/SKILL.md
@@ -27,3 +27,17 @@ Before running an action, read its file in `actions/`, not only the table or ass
 ## Assets
 
 - `assets/agent-template.md`: agent file scaffold.
+
+## Say when this skill's work is done
+
+Once this skill has produced what it was called for, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-context:06-agent-generate"
+```
+
+No host reports when a skill's work finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that
+never hears this ends the step where the next one begins — or, where none follows, at the
+journal's own last witnessed moment, which credits this skill with everything the session
+did afterwards.

--- a/plugins/aidd-context/skills/07-command-generate/SKILL.md
+++ b/plugins/aidd-context/skills/07-command-generate/SKILL.md
@@ -27,3 +27,17 @@ Before running an action, read its file in `actions/`, not only the table or ass
 ## Assets
 
 - `assets/command-template.md`: command file scaffold.
+
+## Say when this skill's work is done
+
+Once this skill has produced what it was called for, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-context:07-command-generate"
+```
+
+No host reports when a skill's work finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that
+never hears this ends the step where the next one begins — or, where none follows, at the
+journal's own last witnessed moment, which credits this skill with everything the session
+did afterwards.

--- a/plugins/aidd-context/skills/08-hook-generate/SKILL.md
+++ b/plugins/aidd-context/skills/08-hook-generate/SKILL.md
@@ -28,3 +28,17 @@ Before running an action, read its file in `actions/`, not only the table or ass
 
 - `assets/hook-template.json`: the entry scaffold.
 - `assets/hook-script-template.sh`: the backing-script scaffold.
+
+## Say when this skill's work is done
+
+Once this skill has produced what it was called for, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-context:08-hook-generate"
+```
+
+No host reports when a skill's work finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that
+never hears this ends the step where the next one begins — or, where none follows, at the
+journal's own last witnessed moment, which credits this skill with everything the session
+did afterwards.

--- a/plugins/aidd-context/skills/09-mermaid/SKILL.md
+++ b/plugins/aidd-context/skills/09-mermaid/SKILL.md
@@ -27,3 +27,17 @@ Before running an action, read its file in `actions/`, not only the table or ass
 ## References
 
 - `references/mermaid-conventions.md`: the conventions and defaults every generated diagram follows.
+
+## Say when this skill's work is done
+
+Once this skill has produced what it was called for, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-context:09-mermaid"
+```
+
+No host reports when a skill's work finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that
+never hears this ends the step where the next one begins — or, where none follows, at the
+journal's own last witnessed moment, which credits this skill with everything the session
+did afterwards.

--- a/plugins/aidd-context/skills/10-learn/SKILL.md
+++ b/plugins/aidd-context/skills/10-learn/SKILL.md
@@ -33,3 +33,17 @@ Run the flow above. Read only the next action file.
 - Write only the user-approved plan.
 - Preserve user edits and touch affected files only.
 - Write project files only, never personal or global memory.
+
+## Say when this skill's work is done
+
+Once this skill has produced what it was called for, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-context:10-learn"
+```
+
+No host reports when a skill's work finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that
+never hears this ends the step where the next one begins — or, where none follows, at the
+journal's own last witnessed moment, which credits this skill with everything the session
+did afterwards.

--- a/plugins/aidd-context/skills/11-explore/SKILL.md
+++ b/plugins/aidd-context/skills/11-explore/SKILL.md
@@ -37,3 +37,17 @@ Before running an action, read its file in `actions/`, not only the table or ass
 ## References
 
 - `references/ai-mapping.md`: the per-tool signals, scan paths, and formats for the Tooling and Context axes.
+
+## Say when this skill's work is done
+
+Once this skill has produced what it was called for, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-context:11-explore"
+```
+
+No host reports when a skill's work finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that
+never hears this ends the step where the next one begins — or, where none follows, at the
+journal's own last witnessed moment, which credits this skill with everything the session
+did afterwards.

--- a/plugins/aidd-context/skills/12-cook/SKILL.md
+++ b/plugins/aidd-context/skills/12-cook/SKILL.md
@@ -29,3 +29,17 @@ Before running an action, read its file in `actions/`, not only the table or ass
 
 - `assets/recipe-template.md`: the canonical recipe scaffold `upsert` renders from, and the shape `list` parses.
 - `assets/recipes/`: bundled recipes shipped with this skill.
+
+## Say when this skill's work is done
+
+Once this skill has produced what it was called for, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-context:12-cook"
+```
+
+No host reports when a skill's work finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that
+never hears this ends the step where the next one begins — or, where none follows, at the
+journal's own last witnessed moment, which credits this skill with everything the session
+did afterwards.

--- a/plugins/aidd-dev/skills/02-implement/SKILL.md
+++ b/plugins/aidd-dev/skills/02-implement/SKILL.md
@@ -27,3 +27,17 @@ Before running an action, read its file in `actions/`, not only the table or ass
 ## References
 
 - `references/blocked.md`: the conditions that make a plan `blocked` and need a human.
+
+## Say when this skill's work is done
+
+Once this skill has produced what it was called for, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-dev:02-implement"
+```
+
+No host reports when a skill's work finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that
+never hears this ends the step where the next one begins — or, where none follows, at the
+journal's own last witnessed moment, which credits this skill with everything the session
+did afterwards.

--- a/plugins/aidd-dev/skills/03-assert/SKILL.md
+++ b/plugins/aidd-dev/skills/03-assert/SKILL.md
@@ -29,3 +29,17 @@ Before running an action, read its file in `actions/`, not only the table or ass
 ## Assets
 
 - `assets/task-template.md`: the tracking file the frontend facet fills across its fix loop.
+
+## Say when this skill's work is done
+
+Once this skill has produced what it was called for, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-dev:03-assert"
+```
+
+No host reports when a skill's work finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that
+never hears this ends the step where the next one begins — or, where none follows, at the
+journal's own last witnessed moment, which credits this skill with everything the session
+did afterwards.

--- a/plugins/aidd-dev/skills/04-audit/SKILL.md
+++ b/plugins/aidd-dev/skills/04-audit/SKILL.md
@@ -35,3 +35,17 @@ Before running an action, read its file in `actions/`, not only the table or ass
 ## Assets
 
 - `assets/audit-template.md`: the report structure both run modes fill.
+
+## Say when this skill's work is done
+
+Once this skill has produced what it was called for, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-dev:04-audit"
+```
+
+No host reports when a skill's work finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that
+never hears this ends the step where the next one begins — or, where none follows, at the
+journal's own last witnessed moment, which credits this skill with everything the session
+did afterwards.

--- a/plugins/aidd-dev/skills/05-review/SKILL.md
+++ b/plugins/aidd-dev/skills/05-review/SKILL.md
@@ -38,3 +38,17 @@ Run all three by default, composing one report. Run a single axis only when the 
 
 - `assets/review-template.md`: the single report the three axes fill.
 - `assets/review-validator.yml`: the closed set of report sections.
+
+## Say when this skill's work is done
+
+Once this skill has produced what it was called for, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-dev:05-review"
+```
+
+No host reports when a skill's work finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that
+never hears this ends the step where the next one begins — or, where none follows, at the
+journal's own last witnessed moment, which credits this skill with everything the session
+did afterwards.

--- a/plugins/aidd-dev/skills/06-test/SKILL.md
+++ b/plugins/aidd-dev/skills/06-test/SKILL.md
@@ -24,3 +24,17 @@ Before running an action, read its file in `actions/`, not only the table or ass
 - One action per run: follow only the matching action file.
 - Functional behavior only: never couple a test to implementation details.
 - Never compromise quality for speed.
+
+## Say when this skill's work is done
+
+Once this skill has produced what it was called for, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-dev:06-test"
+```
+
+No host reports when a skill's work finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that
+never hears this ends the step where the next one begins — or, where none follows, at the
+journal's own last witnessed moment, which credits this skill with everything the session
+did afterwards.

--- a/plugins/aidd-dev/skills/07-refactor/SKILL.md
+++ b/plugins/aidd-dev/skills/07-refactor/SKILL.md
@@ -27,3 +27,17 @@ Before running an action, read its file in `actions/`, not only the table or ass
 - Audit-fed, optional: when the caller pushes an audit report (a path under `aidd_docs/tasks/audits/` or pasted findings), take its findings for this axis as the fix list and skip the scan. The bridge is the report artifact; this skill never loads or calls another skill. The audit `code-quality` pillar feeds the `cleanup` axis; the other axes map by name.
 - Severity uses the shared 3-level scale: 🔴 critical, 🟡 warning, 🟢 minor.
 - Stay inside the axis: dependency upgrades and UI redesign are out of scope. Add tests only as a regression for a security fix, never otherwise.
+
+## Say when this skill's work is done
+
+Once this skill has produced what it was called for, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-dev:07-refactor"
+```
+
+No host reports when a skill's work finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that
+never hears this ends the step where the next one begins — or, where none follows, at the
+journal's own last witnessed moment, which credits this skill with everything the session
+did afterwards.

--- a/plugins/aidd-dev/skills/08-debug/SKILL.md
+++ b/plugins/aidd-dev/skills/08-debug/SKILL.md
@@ -32,3 +32,17 @@ Pick the one action matching the intent; never default to `01`. Triggers like "r
 ## References
 
 - `references/mermaid-conventions.md`: the project's Mermaid conventions for the action-path flowchart.
+
+## Say when this skill's work is done
+
+Once this skill has produced what it was called for, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-dev:08-debug"
+```
+
+No host reports when a skill's work finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that
+never hears this ends the step where the next one begins — or, where none follows, at the
+journal's own last witnessed moment, which credits this skill with everything the session
+did afterwards.

--- a/plugins/aidd-dev/skills/09-for-sure/SKILL.md
+++ b/plugins/aidd-dev/skills/09-for-sure/SKILL.md
@@ -35,3 +35,17 @@ Before running an action, read its file in `actions/`, not only the table or ass
 ## References
 
 - `references/autonomous-loop-log-format.md`: the Log entry format the loop appends per attempt.
+
+## Say when this skill's work is done
+
+Once this skill has produced what it was called for, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-dev:09-for-sure"
+```
+
+No host reports when a skill's work finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that
+never hears this ends the step where the next one begins — or, where none follows, at the
+journal's own last witnessed moment, which credits this skill with everything the session
+did afterwards.

--- a/plugins/aidd-dev/skills/10-todo/SKILL.md
+++ b/plugins/aidd-dev/skills/10-todo/SKILL.md
@@ -15,3 +15,17 @@ actions/01-todo.md
 ```
 
 Before running an action, read its file in `actions/`, not only the table or assets.
+
+## Say when this skill's work is done
+
+Once this skill has produced what it was called for, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-dev:10-todo"
+```
+
+No host reports when a skill's work finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that
+never hears this ends the step where the next one begins — or, where none follows, at the
+journal's own last witnessed moment, which credits this skill with everything the session
+did afterwards.

--- a/plugins/aidd-dev/skills/11-browser-qa/SKILL.md
+++ b/plugins/aidd-dev/skills/11-browser-qa/SKILL.md
@@ -27,3 +27,17 @@ Read only the next action's file before running it.
 - Run against a reviewed change and never patch the application.
 - Never spawn agents. Batch independent reads and tool checks, but keep state-changing browser work sequential.
 - Do not narrate action transitions, searches, fixtures, selectors, or successful checks. Report only a blocker, a required decision, or the final verdict and paths.
+
+## Say when this skill's work is done
+
+Once this skill has produced what it was called for, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-dev:11-browser-qa"
+```
+
+No host reports when a skill's work finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that
+never hears this ends the step where the next one begins — or, where none follows, at the
+journal's own last witnessed moment, which credits this skill with everything the session
+did afterwards.

--- a/plugins/aidd-pm/skills/01-ticket-info/SKILL.md
+++ b/plugins/aidd-pm/skills/01-ticket-info/SKILL.md
@@ -18,3 +18,17 @@ Run the flow above. Read only the next action file.
 | Action        | Does                                                     |
 | ------------- | --------------------------------------------------------- |
 | ticket-info   | resolve ticket id, query configured tool, display fields |
+
+## Say when this skill's work is done
+
+Once this skill has produced what it was called for, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-pm:01-ticket-info"
+```
+
+No host reports when a skill's work finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that
+never hears this ends the step where the next one begins — or, where none follows, at the
+journal's own last witnessed moment, which credits this skill with everything the session
+did afterwards.

--- a/plugins/aidd-pm/skills/02-user-stories/SKILL.md
+++ b/plugins/aidd-pm/skills/02-user-stories/SKILL.md
@@ -39,3 +39,17 @@ Run the flow above. Read only the next action file.
 - Ask natural questions; never expose actions, references, or unchanged state.
 - Require explicit approval or caller-provided bounded authority before any write.
 - Draft only after actor, need, and outcome are explicit in the source or confirmed.
+
+## Say when this skill's work is done
+
+Once this skill has produced what it was called for, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-pm:02-user-stories"
+```
+
+No host reports when a skill's work finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that
+never hears this ends the step where the next one begins — or, where none follows, at the
+journal's own last witnessed moment, which credits this skill with everything the session
+did afterwards.

--- a/plugins/aidd-pm/skills/03-prd/SKILL.md
+++ b/plugins/aidd-pm/skills/03-prd/SKILL.md
@@ -28,3 +28,17 @@ Run the flow above. Read only the next action file.
 - Ask natural questions; never expose actions, references, or unchanged state.
 - Require explicit approval or caller-provided bounded authority before any write.
 - State what and why; never a technical plan or user stories.
+
+## Say when this skill's work is done
+
+Once this skill has produced what it was called for, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-pm:03-prd"
+```
+
+No host reports when a skill's work finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that
+never hears this ends the step where the next one begins — or, where none follows, at the
+journal's own last witnessed moment, which credits this skill with everything the session
+did afterwards.

--- a/plugins/aidd-pm/skills/04-spec/SKILL.md
+++ b/plugins/aidd-pm/skills/04-spec/SKILL.md
@@ -28,3 +28,17 @@ Run the flow above. Read only the next action file.
 - Hold intent, never implementation: solution-agnostic, no how, few acceptance criteria.
 - Keep it readable: clear headers, bulleted criteria, explicit non-goals.
 - Immutable once validated: never rewrite a locked spec.
+
+## Say when this skill's work is done
+
+Once this skill has produced what it was called for, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-pm:04-spec"
+```
+
+No host reports when a skill's work finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that
+never hears this ends the step where the next one begins — or, where none follows, at the
+journal's own last witnessed moment, which credits this skill with everything the session
+did afterwards.

--- a/plugins/aidd-pm/skills/05-spike/SKILL.md
+++ b/plugins/aidd-pm/skills/05-spike/SKILL.md
@@ -34,3 +34,17 @@ Run the flow above. Read only the next action file.
 - Ask natural questions; never expose actions, references, or unchanged state.
 - Require explicit approval or caller-provided bounded authority before any write.
 - Bound the question; never answer beyond its stop condition.
+
+## Say when this skill's work is done
+
+Once this skill has produced what it was called for, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-pm:05-spike"
+```
+
+No host reports when a skill's work finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that
+never hears this ends the step where the next one begins — or, where none follows, at the
+journal's own last witnessed moment, which credits this skill with everything the session
+did afterwards.

--- a/plugins/aidd-pm/skills/06-product-brief/SKILL.md
+++ b/plugins/aidd-pm/skills/06-product-brief/SKILL.md
@@ -41,3 +41,17 @@ Run the flow above. Read only the next action file.
 - Ask natural questions; never expose actions, references, or unchanged state.
 - Require explicit approval or caller-provided bounded authority before any write.
 - Frame the opportunity; never write requirements.
+
+## Say when this skill's work is done
+
+Once this skill has produced what it was called for, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-pm:06-product-brief"
+```
+
+No host reports when a skill's work finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that
+never hears this ends the step where the next one begins — or, where none follows, at the
+journal's own last witnessed moment, which credits this skill with everything the session
+did afterwards.

--- a/plugins/aidd-pm/skills/07-epic/SKILL.md
+++ b/plugins/aidd-pm/skills/07-epic/SKILL.md
@@ -33,3 +33,17 @@ Run the flow above. Read only the next action file.
 - Ask natural questions; never expose actions, references, or unchanged state.
 - Require explicit approval or caller-provided bounded authority before any write.
 - Stay at outcome level; do not propose child slices or implementation.
+
+## Say when this skill's work is done
+
+Once this skill has produced what it was called for, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-pm:07-epic"
+```
+
+No host reports when a skill's work finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that
+never hears this ends the step where the next one begins — or, where none follows, at the
+journal's own last witnessed moment, which credits this skill with everything the session
+did afterwards.

--- a/plugins/aidd-pm/skills/08-three-amigos/SKILL.md
+++ b/plugins/aidd-pm/skills/08-three-amigos/SKILL.md
@@ -28,3 +28,17 @@ Run the flow above. Read only the next action file.
 - Treat roles as analytical lenses, not human authorities.
 - Ground every finding and question in cited evidence; never invent a decision.
 - Return proposals only; the caller decides what to do with them.
+
+## Say when this skill's work is done
+
+Once this skill has produced what it was called for, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-pm:08-three-amigos"
+```
+
+No host reports when a skill's work finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that
+never hears this ends the step where the next one begins — or, where none follows, at the
+journal's own last witnessed moment, which credits this skill with everything the session
+did afterwards.

--- a/plugins/aidd-pm/skills/09-defect/SKILL.md
+++ b/plugins/aidd-pm/skills/09-defect/SKILL.md
@@ -33,3 +33,17 @@ Run the flow above. Read only the next action file.
 - Ask natural questions; never expose actions, references, or unchanged state.
 - Require explicit approval or caller-provided bounded authority before any write.
 - Record the mismatch; never diagnose or implement its fix.
+
+## Say when this skill's work is done
+
+Once this skill has produced what it was called for, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-pm:09-defect"
+```
+
+No host reports when a skill's work finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that
+never hears this ends the step where the next one begins — or, where none follows, at the
+journal's own last witnessed moment, which credits this skill with everything the session
+did afterwards.

--- a/plugins/aidd-pm/skills/10-task/SKILL.md
+++ b/plugins/aidd-pm/skills/10-task/SKILL.md
@@ -33,3 +33,17 @@ Run the flow above. Read only the next action file.
 - Ask natural questions; never expose actions, references, or unchanged state.
 - Require explicit approval or caller-provided bounded authority before any write.
 - Record delivery work; never plan or implement it.
+
+## Say when this skill's work is done
+
+Once this skill has produced what it was called for, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-pm:10-task"
+```
+
+No host reports when a skill's work finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that
+never hears this ends the step where the next one begins — or, where none follows, at the
+journal's own last witnessed moment, which credits this skill with everything the session
+did afterwards.

--- a/plugins/aidd-refine/skills/01-brainstorm/SKILL.md
+++ b/plugins/aidd-refine/skills/01-brainstorm/SKILL.md
@@ -32,3 +32,17 @@ Run the flow above. Read only the next action's file before running it.
 - State a leaning and its tradeoff when facts already point one way.
 - Hide process words: no density, coverage, nodes, completeness, matrix, or frame unless the user asks for an audit.
 - Wait after questions, approval, and persistence choices.
+
+## Say when this skill's work is done
+
+Once this skill has produced what it was called for, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-refine:01-brainstorm"
+```
+
+No host reports when a skill's work finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that
+never hears this ends the step where the next one begins — or, where none follows, at the
+journal's own last witnessed moment, which credits this skill with everything the session
+did afterwards.

--- a/plugins/aidd-refine/skills/02-challenge/SKILL.md
+++ b/plugins/aidd-refine/skills/02-challenge/SKILL.md
@@ -29,3 +29,17 @@ Before running an action, read its file in `actions/`, not only the table or ass
 ## Assets
 
 - `assets/report-template.md`: findings report skeleton, filled per run.
+
+## Say when this skill's work is done
+
+Once this skill has produced what it was called for, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-refine:02-challenge"
+```
+
+No host reports when a skill's work finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that
+never hears this ends the step where the next one begins — or, where none follows, at the
+journal's own last witnessed moment, which credits this skill with everything the session
+did afterwards.

--- a/plugins/aidd-refine/skills/03-shadow-areas/SKILL.md
+++ b/plugins/aidd-refine/skills/03-shadow-areas/SKILL.md
@@ -38,3 +38,17 @@ Before running an action, read its file in `actions/`, not only the table or ass
 ## Assets
 
 - `assets/report-template.md`: report skeleton with header, per-category sections, and `status: clean` block.
+
+## Say when this skill's work is done
+
+Once this skill has produced what it was called for, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-refine:03-shadow-areas"
+```
+
+No host reports when a skill's work finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that
+never hears this ends the step where the next one begins — or, where none follows, at the
+journal's own last witnessed moment, which credits this skill with everything the session
+did afterwards.

--- a/plugins/aidd-refine/skills/04-fact-check/SKILL.md
+++ b/plugins/aidd-refine/skills/04-fact-check/SKILL.md
@@ -39,3 +39,17 @@ Before running an action, read its file in `actions/`, not only the table or ass
 ## Assets
 
 - `assets/report-template.md`: rewritten-answer skeleton with the `## Sources` footnote block.
+
+## Say when this skill's work is done
+
+Once this skill has produced what it was called for, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-refine:04-fact-check"
+```
+
+No host reports when a skill's work finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that
+never hears this ends the step where the next one begins — or, where none follows, at the
+journal's own last witnessed moment, which credits this skill with everything the session
+did afterwards.

--- a/plugins/aidd-telemetry/skills/00-init/SKILL.md
+++ b/plugins/aidd-telemetry/skills/00-init/SKILL.md
@@ -55,3 +55,17 @@ Run the flow above. Read only the next action file.
 - Removing what was measured is irreversible, and reaches further than one project: this machine's stored records span every project ever measured on it, not only the one being discussed. Never presented as reversible, and never presented as scoped to one project when it is not.
 - What history keeps is relayed exactly as `aidd telemetry forget` states it — a journal already committed as certainly held, one merely staged but never committed as not yet held, one not tracked at all as possibly held — and is never presented as removable. No command in this skill rewrites git history.
 - The `aidd` command cannot be found: say so and change nothing.
+
+## Say when this skill's work is done
+
+Once this skill has produced what it was called for, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-telemetry:00-init"
+```
+
+No host reports when a skill's work finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that
+never hears this ends the step where the next one begins — or, where none follows, at the
+journal's own last witnessed moment, which credits this skill with everything the session
+did afterwards.

--- a/plugins/aidd-telemetry/skills/01-cost/SKILL.md
+++ b/plugins/aidd-telemetry/skills/01-cost/SKILL.md
@@ -50,3 +50,17 @@ menu and ask them to pick.
 - An absent number is not a zero. Say the figure is unknown and give what is known instead.
 - Turning measurement on belongs elsewhere. Stop and say so rather than doing it here.
 - The script cannot be found or fails: say so and show no figure.
+
+## Say when this skill's work is done
+
+Once this skill has produced what it was called for, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-telemetry:01-cost"
+```
+
+No host reports when a skill's work finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that
+never hears this ends the step where the next one begins — or, where none follows, at the
+journal's own last witnessed moment, which credits this skill with everything the session
+did afterwards.

--- a/plugins/aidd-telemetry/skills/02-check/SKILL.md
+++ b/plugins/aidd-telemetry/skills/02-check/SKILL.md
@@ -33,3 +33,17 @@ Run the flow above. Read only the next action file.
 - `ok`, `FAIL` and `--` are three different answers. `--` means there was nothing to evaluate, not that the chain is healthy.
 - A declaration that the recorder is set up is not proof it fired. Relay it as what it is — a fact about configuration, never a promise about behaviour.
 - The `aidd` command cannot be found: say so and check nothing.
+
+## Say when this skill's work is done
+
+Once this skill has produced what it was called for, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-telemetry:02-check"
+```
+
+No host reports when a skill's work finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that
+never hears this ends the step where the next one begins — or, where none follows, at the
+journal's own last witnessed moment, which credits this skill with everything the session
+did afterwards.

--- a/plugins/aidd-ui/skills/01-hello/SKILL.md
+++ b/plugins/aidd-ui/skills/01-hello/SKILL.md
@@ -19,3 +19,17 @@ Before running an action, read its file in `actions/`, not only the table or ass
 ## Prerequisites
 
 - The plugin loaded locally (`claude --plugin-dir plugins/aidd-ui`, or installed from the marketplace).
+
+## Say when this skill's work is done
+
+Once this skill has produced what it was called for, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-ui:01-hello"
+```
+
+No host reports when a skill's work finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that
+never hears this ends the step where the next one begins — or, where none follows, at the
+journal's own last witnessed moment, which credits this skill with everything the session
+did afterwards.

--- a/plugins/aidd-vcs/skills/00-repo-init/SKILL.md
+++ b/plugins/aidd-vcs/skills/00-repo-init/SKILL.md
@@ -34,3 +34,17 @@ Before running an action, read its file in `actions/`, not only the table or ass
 ## Assets
 
 - `assets/CONTRIBUTING.md`: the project-root `CONTRIBUTING.md` template.
+
+## Say when this skill's work is done
+
+Once this skill has produced what it was called for, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-vcs:00-repo-init"
+```
+
+No host reports when a skill's work finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that
+never hears this ends the step where the next one begins — or, where none follows, at the
+journal's own last witnessed moment, which credits this skill with everything the session
+did afterwards.

--- a/plugins/aidd-vcs/skills/01-commit/SKILL.md
+++ b/plugins/aidd-vcs/skills/01-commit/SKILL.md
@@ -32,3 +32,17 @@ Before running an action, read its file in `actions/`, not only the table or ass
 ## Assets
 
 - `assets/commit-template.md`: Conventional commit format reference.
+
+## Say when this skill's work is done
+
+Once this skill has produced what it was called for, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-vcs:01-commit"
+```
+
+No host reports when a skill's work finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that
+never hears this ends the step where the next one begins — or, where none follows, at the
+journal's own last witnessed moment, which credits this skill with everything the session
+did afterwards.

--- a/plugins/aidd-vcs/skills/02-pull-request/SKILL.md
+++ b/plugins/aidd-vcs/skills/02-pull-request/SKILL.md
@@ -31,3 +31,17 @@ Before running an action, read its file in `actions/`, not only the table or ass
 
 - `assets/pull_request.md`: Request body template.
 - `assets/branch.md`: Branch-naming convention, the fallback when project memory sets none.
+
+## Say when this skill's work is done
+
+Once this skill has produced what it was called for, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-vcs:02-pull-request"
+```
+
+No host reports when a skill's work finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that
+never hears this ends the step where the next one begins — or, where none follows, at the
+journal's own last witnessed moment, which credits this skill with everything the session
+did afterwards.

--- a/plugins/aidd-vcs/skills/03-release-tag/SKILL.md
+++ b/plugins/aidd-vcs/skills/03-release-tag/SKILL.md
@@ -28,3 +28,17 @@ Before running an action, read its file in `actions/`, not only the table or ass
 ## Assets
 
 - `assets/release-template.md`: Release notes template.
+
+## Say when this skill's work is done
+
+Once this skill has produced what it was called for, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-vcs:03-release-tag"
+```
+
+No host reports when a skill's work finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that
+never hears this ends the step where the next one begins — or, where none follows, at the
+journal's own last witnessed moment, which credits this skill with everything the session
+did afterwards.

--- a/plugins/aidd-vcs/skills/04-issue-create/SKILL.md
+++ b/plugins/aidd-vcs/skills/04-issue-create/SKILL.md
@@ -29,3 +29,17 @@ Before running an action, read its file in `actions/`, not only the table or ass
 
 - `assets/issue-template.md`: Issue / ticket body template.
 - `assets/CONTRIBUTING.md`: Contribution guidelines, including issue process.
+
+## Say when this skill's work is done
+
+Once this skill has produced what it was called for, and only then, run:
+
+```shell
+echo "aidd:step-end aidd-vcs:04-issue-create"
+```
+
+No host reports when a skill's work finished. A skill call's own result comes back in a
+tenth of a second, which is the dispatch and not the completion, so a measurement that
+never hears this ends the step where the next one begins — or, where none follows, at the
+journal's own last witnessed moment, which credits this skill with everything the session
+did afterwards.

--- a/scripts/__tests__/aidd-telemetry-step-end.test.js
+++ b/scripts/__tests__/aidd-telemetry-step-end.test.js
@@ -128,3 +128,44 @@ test("every skill that opens a flow also says when that flow is over", () => {
     assert.equal(read, skill, `${skill} declares no end the hook reads as its own`);
   }
 });
+
+// Every skill, not only the ones that opted in. A skill that never says it is done leaves an
+// interval nothing closes: it runs to the next `step_start` or, failing that, to the journal's
+// own last witnessed moment, and everything the session did afterwards reads as that skill's
+// work. Measured on the one orchestrated session captured, 2026-09-04, before the three
+// orchestrators declared theirs: `aidd-dev:01-plan` opened at 06:00:50, closed nothing, and
+// took every one of the 972 records written over the three and a half hours that followed.
+//
+// A sweep and not a list, for the reason the sweep above already gives: a skill added to this
+// tree is covered without this file being told.
+function everySkillFile() {
+  const found = [];
+  const walk = (dir) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.name === "SKILL.md") found.push(full);
+    }
+  };
+  walk(pluginsDir);
+  return found;
+}
+
+test("every skill says when its own work is done", () => {
+  const silent = [];
+
+  for (const full of everySkillFile()) {
+    const relative = path.relative(pluginsDir, full);
+    const [plugin, , skillDir] = relative.split(path.sep);
+    const read = declaredStepEnd({
+      tool_input: { command: fs.readFileSync(full, "utf8") },
+    });
+    if (read !== `${plugin}:${skillDir}`) silent.push(`${relative} declares ${read}`);
+  }
+
+  assert.deepEqual(
+    silent,
+    [],
+    `A skill that never declares its end leaves an interval nothing closes.\n${silent.join("\n")}`
+  );
+});


### PR DESCRIPTION
## Why

A step that nothing closes runs to wherever the next one begins or, failing that, to the journal's own last witnessed moment — and everything the session did afterwards reads as that skill's work.

Measured on the one orchestrated session captured, 2026-09-04: `aidd-dev:01-plan` opened at 06:00:50, closed nothing, and took every one of the **972 records** written over the three and a half hours that followed.

## Nothing any host can fix

The `tool_result` for a `Skill` call comes back in about a tenth of a second — the dispatch, not the completion. No skill-scoped end event exists in Claude Code, Codex, Cursor, Copilot or OpenCode; all five documentations were read. The only party that knows the work is over is the skill, and the only channel it has is a tool call it makes, which `step-ends.cjs` already reads out of the call's own free-form arguments.

## What changes

Four skills of fifty said so before this: `aidd-dev:01-plan`, plus the three orchestrators in the first commit. The remaining **46** now do too.

| Where it came from | Skills |
| --- | ---: |
| already declared before any of this | 1 |
| the three orchestrators, merged separately into `next` | 3 |
| **this PR** | **46** |
| **total on `next` once this lands** | **50 / 50** |

Rebased onto `next` after the orchestrator commit landed there on its own, so this PR now carries the 46 alone.

## The mechanism is measured, not assumed

In that same session `aidd-dev:01-plan` emitted the marker **4 times out of the 4 times it ran**, and all four closed their interval. The three orchestrators emitted none — because none carried the marker. That was absence, never unreliability, and it is what this PR removes.

## The guard sweeps, it does not list

`aidd-telemetry-step-end.test.js` already checked that a skill *declaring* an end declares it in the form the hook reads, and that every *orchestrating* skill declares one. It now also checks that **every** skill does — as a sweep, so a skill added to this tree is covered without the test being told.

Mutations run, both killed:

| Mutation | Red |
| --- | --- |
| a skill made silent again | 1 |
| a marker naming a different skill than its own | 2 |

## Two things worth flagging in review

- The block first quoted `step_start` in backticks, which `aidd-telemetry-cost-skill.test.js` counts as a field reference the cost skill names — nineteen expected, twenty found. Reworded to prose, which says the same and counts as nothing. Caught by the repository suite, not by review.
- No link out of a skill, deliberately. The tree ships flat and as a marketplace, so no relative path survives both. `aidd-dev:01-plan`'s own block carries one; this does not repeat it 46 times.

370 repository script tests pass, 0 broken links in 787 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWNxk63AGKkqE8HRqHLjGp

