### PR TITLE
fix(cli): telemetry off keeps the person's own commit hook executable

### DIFF
--- a/cli/src/runtime/git/git-adapter.ts
+++ b/cli/src/runtime/git/git-adapter.ts
@@ -112,7 +112,9 @@ export class GitAdapter implements VersionControl {
     if (!content.includes(line)) return false;
 
     const kept = content.split("\n").filter((entry) => entry.trim() !== line);
+    const executable = await this.fs.isExecutable(hookPath);
     await this.fs.writeFile(hookPath, kept.join("\n"));
+    if (executable) await this.fs.chmodExecutable(hookPath);
     return true;
   }
 

--- a/cli/tests/runtime/git/git-adapter.integration.test.ts
+++ b/cli/tests/runtime/git/git-adapter.integration.test.ts
@@ -1,0 +1,83 @@
+import { spawnSync } from "node:child_process";
+import { chmod, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { sessionTrailerHookLine } from "../../../src/contexts/telemetry/domain/formats/commit-session-trailer.js";
+import { FileAdapter } from "../../../src/runtime/filesystem/file-adapter.js";
+import { HasherAdapter } from "../../../src/runtime/filesystem/hasher-adapter.js";
+import { GitAdapter } from "../../../src/runtime/git/git-adapter.js";
+import { environmentWithoutGitVariables } from "../../../src/runtime/git/git-environment.js";
+
+const DELEGATE = "aidd-session-trailer.sh";
+const SCRIPT = "#!/bin/sh\necho delegate\n";
+
+function git(cwd: string, ...args: string[]): string {
+  const result = spawnSync(
+    "git",
+    ["-c", "user.name=t", "-c", "user.email=t@t", "-c", "commit.gpgsign=false", ...args],
+    { cwd, encoding: "utf8", env: environmentWithoutGitVariables() }
+  );
+  if (result.status !== 0) throw new Error(`git ${args.join(" ")} failed: ${result.stderr}`);
+  return result.stdout.trim();
+}
+
+describe("GitAdapter", () => {
+  let root: string;
+  let hooksDir: string;
+  let adapter: GitAdapter;
+
+  beforeEach(async () => {
+    root = await realpath(await mkdtemp(join(tmpdir(), "aidd-git-adapter-")));
+    git(root, "init", "-q");
+    hooksDir = join(root, ".git", "hooks");
+    adapter = new GitAdapter(new FileAdapter(new HasherAdapter()));
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  describe("removeCommitMessageDelegate", () => {
+    it("drops the one line and deletes the delegate, leaving the rest of the hook", async () => {
+      await mkdir(hooksDir, { recursive: true });
+      await writeFile(join(hooksDir, "prepare-commit-msg"), "#!/bin/sh\necho mine\n");
+      await adapter.installCommitMessageDelegate(root, DELEGATE, SCRIPT);
+
+      const result = await adapter.removeCommitMessageDelegate(root, DELEGATE);
+
+      expect(result).toStrictEqual({ removed: true });
+      expect(await readFile(join(hooksDir, "prepare-commit-msg"), "utf8")).toBe(
+        "#!/bin/sh\necho mine\n"
+      );
+      expect(await adapter.readCommitTrailerSetup(root, DELEGATE, "X", 1)).toStrictEqual({
+        delegate: "absent",
+        hookExecutable: true,
+        callSite: "missing",
+        hookHasOtherContent: true,
+        hooksDir,
+      });
+    });
+
+    // A mode bit is POSIX: on Windows `access(X_OK)` answers like `F_OK`.
+    it.skipIf(process.platform === "win32")(
+      "leaves a hook that was not executable as it found it",
+      async () => {
+        await mkdir(hooksDir, { recursive: true });
+        await adapter.installCommitMessageDelegate(root, DELEGATE, SCRIPT);
+        const hookPath = join(hooksDir, "prepare-commit-msg");
+        await writeFile(
+          hookPath,
+          `#!/bin/sh\n${sessionTrailerHookLine(join(hooksDir, DELEGATE))}\n`
+        );
+        await chmod(hookPath, 0o644);
+
+        await adapter.removeCommitMessageDelegate(root, DELEGATE);
+
+        expect((await adapter.readCommitTrailerSetup(root, DELEGATE, "X", 1)).hookExecutable).toBe(
+          false
+        );
+      }
+    );
+  });
+});


### PR DESCRIPTION
## 🎯 What & why

`aidd telemetry off` removes the commit-trailer delegate's line from the project's `prepare-commit-msg` hook. It rewrote that hook through the atomic temp-file-and-rename write, which does not keep the file's mode. An executable hook came back without its executable bit. Git skips a non-executable hook without saying so, so the rest of the person's own hook stopped running. This shipped in cli 5.3.0.

## 🛠️ How it works

`GitAdapter.stopCallingDelegate` reads `isExecutable` before the write and calls `chmodExecutable` after it, only when the bit was set. Two lines. A hook that was not executable is left as it was.

## 🧪 How to verify

```sh
cd cli && pnpm vitest run --project integration tests/runtime/git/git-adapter.integration.test.ts
```

| Run | Result |
|---|---|
| Without the fix | "drops the one line and deletes the delegate, leaving the rest of the hook" is red: `hookExecutable` is false |
| With the fix | both tests pass |
| Restore made unconditional (`if (true)`) | "leaves a hook that was not executable as it found it" is red: expected true to be false |

Runtime and telemetry suites: 81 files, 1084 tests passed. Typecheck, lint, test:arch, knip and type honesty are clean.

## ⚠️ Heads-up

- The second test skips on Windows. There `access(X_OK)` answers like `F_OK`, so a mode bit cannot be observed, and git does not need one.
- The runtime mutation lot of #799 found this defect and will rebase onto this branch.

## 🔗 Linked issue

Fixes #817

## ✅ I certify

- [x] I have read the contributing guide and followed the PR template.
- [x] The tests were red before the fix and every gate listed above passed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011x4ms5qcGuZgYhCxfdHMUb
