### PR TITLE
test(cli): a real opencode session under smoke:real must write a journal line

### DIFF
--- a/cli/aidd_docs/memory/internal/smoke-real.md
+++ b/cli/aidd_docs/memory/internal/smoke-real.md
@@ -28,7 +28,7 @@
    Then each host's own inventory: `claude plugin details` lists the fixture's skills, hook events and MCP servers (never its agents: Claude counts none, measured 2026-09-09), `codex plugin list` marks it installed and enabled, `copilot plugin list` enabled. Cursor and opencode expose no inventory command.
 3. `doctor`.
 4. A host-side `claude plugin uninstall --scope local`, then the `sync --force` that repairs it.
-5. Opencode's bridge.
+5. Opencode's bridge, then a real `opencode run` under the repository's own `aidd-telemetry`: its run journal must hold a `session_start` from opencode. The bridge check alone passed while v5.10.0 journalled nothing (#812).
 6. Two `marketplace add` guards: a different catalog under one name, an alias diverging from the catalog's.
 7. `setup --scope user`: project clean per `git status --porcelain`, `userConfigDir()/manifest.json` appears, `doctor --scope user` healthy.
 8. Two projects sharing one machine-scope marketplace.

--- a/cli/scripts/smoke-real.sh
+++ b/cli/scripts/smoke-real.sh
@@ -615,6 +615,46 @@ else
   skip "opencode bridge check (opencode not installed)"
 fi
 
+section "opencode: a real session under aidd-telemetry writes a journal line"
+# The bridge check above installs the smoke fixture, which journals nothing, so it passed while
+# every OpenCode session recorded nothing (#812). This installs the repository's own
+# aidd-telemetry on the layout a user gets, and asks the journal itself.
+if [[ -n "${PRESENT[opencode]:-}" ]]; then
+  PROJ_T=$(mktemp -d "$TMPROOT/proj-telemetry.XXXXXX"); (cd "$PROJ_T" && git init -q)
+  PROJECTS+=("$PROJ_T")
+  MKT_T="$MKT-telemetry"
+  run "setup (opencode, files only)" 0 "" "$PROJ_T" -- \
+    node "$CLI" setup --source local --path "$FRAMEWORK_FIXTURE" --ai opencode \
+    --no-default-marketplace --plugins none --yes
+  run "marketplace add $MKT_T (this repository)" 0 "" "$PROJ_T" -- \
+    node "$CLI" marketplace add "$MKT_T" "$ROOT/.." --scope project --yes
+  run "plugin install aidd-telemetry -> opencode" 0 "" "$PROJ_T" -- \
+    node "$CLI" plugin install aidd-telemetry --tool opencode --from "$MKT_T" --yes
+  run "telemetry on" 0 "" "$PROJ_T" -- node "$CLI" telemetry on --yes
+
+  tel_out=$(mktemp)
+  ( cd "$PROJ_T" && exec perl -e 'alarm shift; exec @ARGV' 90 opencode run "say ok" ) </dev/null >"$tel_out" 2>&1
+  tel_rc=$?
+  cat "$tel_out" >> "$LOGFILE"
+  # The session opens on its first call, so only a turn that completed can prove an empty
+  # journal: exit 0 with no line is #812 itself, a model that never answered proves nothing.
+  if grep -qsE '"type":"session_start".*"tool":"opencode"' "$PROJ_T"/aidd_docs/runs/*.jsonl; then
+    ok "opencode: the run journal holds a session_start line from opencode"
+  elif [[ "$tel_rc" -eq 0 ]]; then
+    bad "opencode: the turn completed and the run journal holds no session_start line" \
+      "$(ls -la "$PROJ_T/aidd_docs/runs" 2>&1; cat "$tel_out")"
+  elif [[ "$tel_rc" -eq 142 ]]; then
+    skip "opencode journal: the model never answered within 90s, so the journal proves nothing"
+  elif grep -qiE "auth|api key|provider|not logged in|credential" "$tel_out"; then
+    skip "opencode journal: needs provider auth on this machine — exit $tel_rc"
+  else
+    bad "opencode: exit $tel_rc and the run journal holds no session_start line" "$(cat "$tel_out")"
+  fi
+  rm -f "$tel_out"
+else
+  skip "opencode journal check (opencode not installed)"
+fi
+
 # --- Phase C1: the guard refuses a genuinely different catalog under the same name ---
 # Identity is a catalog's declared name plus its plugin set, never a path and never a version
 # (`marketplace-source-conflict.ts`), so this fixture keeps the name `$MKT` and drops its one


### PR DESCRIPTION
## 🎯 What & why

v5.10.0 shipped an OpenCode telemetry plugin that spawned a `journal.cjs` the build no longer puts beside it. Every OpenCode session journalled nothing (#812). `smoke:real` ran a real `opencode run` on a machine with OpenCode and still passed. It installs the smoke fixture, which journals nothing, and it only checks that the bridge loads. This PR makes a real OpenCode session prove that it writes a journal line.

## 🛠️ How it works

A new `smoke:real` section, for OpenCode only:

1. Installs this repository's own `aidd-telemetry` into a throwaway project: `setup` with files only, then `marketplace add` under a unique name, `plugin install --tool opencode` and `telemetry on`.
2. Runs `opencode run "say ok"` and reads the project's run journal.
3. Classifies the result:

| Outcome | Verdict |
|---|---|
| a `session_start` line from `opencode` | OK |
| exit 0 and no line | FAIL: the turn completed and nothing was journalled, which is #812 |
| timeout and no line | SKIP: the session only opens on its first call, so a model that never answered proves nothing |
| an auth error | SKIP |

`cli/aidd_docs/memory/internal/smoke-real.md` describes the new phase.

## 🧪 How to verify

```sh
cd cli && pnpm build && pnpm smoke:real
```

What I observed on this branch on 2026-09-10. OpenCode was logged in with an OpenAI account. Its default model refuses the request, but the session still opens and exits 0.

| Run | Result |
|---|---|
| Full `smoke:real` with `opencode-plugin.js` reverted to `./journal.cjs`, the #812 bug | `✗ opencode: the turn completed and the run journal holds no session_start line`. FAIL 1, SKIP 3, no other failure. |
| Full `smoke:real` as shipped | `✓ opencode: the run journal holds a session_start line from opencode`. No failure up to cleanup. |
| The same install in a throwaway project | exit 0 with 1 `session_start` line, then 0 with the bug, then 1 with the path restored |
| The free `opencode/*` models, before the OpenAI login | they never answered in 12 tries over about 72 minutes, so the section reported SKIP, as designed |

## ⚠️ Heads-up

- The section's verdict does not depend on the model answering. The session opens on its first call, so an OpenCode that exits 0 has had its chance to write `session_start`. A run that times out with no line is a SKIP that says why.
- The shipped run was killed by macOS for low memory during its final cleanup. That cleanup was replayed by hand, and no registration from either run is left in the Claude, Codex, Copilot or Cursor registries.
- Out of scope: the same live journal proof for Claude Code, Codex, Copilot and Cursor. Each costs a real model call.

## 🔗 Linked issue

Closes #814

## ✅ I certify

- [x] I have read the contributing guide and followed the PR template.
- [x] The check was red with the #812 bug reverted and green as shipped, in full `smoke:real` runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011x4ms5qcGuZgYhCxfdHMUb
