### PR TITLE
refactor(cli): drop the copilot command handler's frontmatter method nothing calls

### DIFF
--- a/cli/src/contexts/tools/domain/profiles/copilot/profile.ts
+++ b/cli/src/contexts/tools/domain/profiles/copilot/profile.ts
@@ -109,12 +109,6 @@ const commandsHandler = {
     const flat = flattenFileName(fileName, EXT_PROMPT);
     return `${DIRECTORY}prompts/${flat}`;
   },
-  convertFrontmatter(
-    fm: Record<string, unknown>,
-    relativeFileName: string
-  ): Record<string, unknown> {
-    return convertCommandFrontmatter(fm, relativeFileName);
-  },
 };
 
 const rulesHandler = {


### PR DESCRIPTION
## 🎯 What & why

`commandsHandler.convertFrontmatter` in the copilot profile is never called. The commands capability gets `convertCommandFrontmatter` directly, and the handler only serves `buildFilePath`. The #799 mutation pass found it, because its mutants could only survive. knip does not see unused methods on an object literal.

## 🛠️ How it works

Six lines deleted from `cli/src/contexts/tools/domain/profiles/copilot/profile.ts`. Nothing else changes.

## 🧪 How to verify

```sh
git grep -n "commandsHandler.convertFrontmatter" -- cli/src   # nothing
cd cli && pnpm vitest run --project unit --project integration tests/contexts/tools && pnpm vitest run --project e2e tests/golden
```

The tools suite and the golden snapshots pass unchanged. Typecheck, lint, test:arch, knip and type honesty are clean.

## ⚠️ Heads-up

CI runs the `tools-copilot` mutation gate. Removing lines whose mutants could only survive can only raise that score.

## 🔗 Linked issue

Fixes #822

## ✅ I certify

- [x] I have read the contributing guide and followed the PR template.
- [x] Every gate listed above passed locally. There is no behaviour to write a failing test for, and the unchanged golden snapshots prove the output is the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011x4ms5qcGuZgYhCxfdHMUb
