### PR TITLE
fix(telemetry): a sink record's day comes from the moment it parses to

### DIFF
--- a/cli/src/contexts/telemetry/domain/telemetry-sink-record.ts
+++ b/cli/src/contexts/telemetry/domain/telemetry-sink-record.ts
@@ -102,12 +102,8 @@ export function telemetrySinkRecordDayKey(record: TelemetrySinkRecord): string |
   // casts the rest, so a number here would parse as epoch milliseconds, land outside every
   // real period and go missing from the read without being counted as undated.
   if (typeof at !== "string") return undefined;
-  // The parse is checked first, always: the slice below is a faster way to read a moment
-  // already known to parse, never a substitute for checking it does. Slicing first lets a
-  // string merely shaped like a moment ("not-a-momentZ") answer a calendar fragment.
   const parsed = new Date(at);
   if (Number.isNaN(parsed.getTime())) return undefined;
-  if (at.length >= DAY_KEY_LENGTH && at.endsWith("Z")) return at.slice(0, DAY_KEY_LENGTH);
   return parsed.toISOString().slice(0, DAY_KEY_LENGTH);
 }
 

--- a/cli/tests/architecture/comments.arch.test.ts
+++ b/cli/tests/architecture/comments.arch.test.ts
@@ -21,7 +21,7 @@ const EXTERNAL_REFERENCE: readonly { readonly name: string; readonly pattern: Re
 ];
 
 /** Comment lines under `src/` and `tests/` may only decrease; a raise needs its reason here: tests/ 2960 to 2984, four guard files and their probes; 2984 to 2987, the reason the display folder is baselined over the size limit. */
-const MAX_COMMENT_LINES = { src: 4474, tests: 2987 };
+const MAX_COMMENT_LINES = { src: 4471, tests: 2987 };
 
 function testFiles(): string[] {
   const out: string[] = [];

--- a/cli/tests/contexts/telemetry/domain/telemetry-sink-record.unit.test.ts
+++ b/cli/tests/contexts/telemetry/domain/telemetry-sink-record.unit.test.ts
@@ -93,14 +93,28 @@ describe("telemetrySinkRecordDayKey()", () => {
     step_attribution: "unattributed",
   };
 
-  it("answers the UTC day for a real moment, the fast path and the parsed one alike", () => {
+  it("answers the UTC day for a real moment, whatever its offset", () => {
     expect(telemetrySinkRecordDayKey({ ...BASE, event_timestamp: "2026-08-18T01:00:00Z" })).toBe(
       "2026-08-18"
     );
-    // No `Z` offset - the parsed path, not the sliced one.
     expect(
       telemetrySinkRecordDayKey({ ...BASE, event_timestamp: "2026-08-18T01:00:00+05:00" })
     ).toBe("2026-08-17");
+  });
+
+  it("rolls 24:00 over to the next day, as the moment it names does", () => {
+    expect(telemetrySinkRecordDayKey({ ...BASE, event_timestamp: "2026-09-10T24:00:00Z" })).toBe(
+      "2026-09-11"
+    );
+  });
+
+  it("answers a calendar day for a parseable moment not written in ISO form", () => {
+    expect(
+      telemetrySinkRecordDayKey({ ...BASE, event_timestamp: "Thu, 10 Sep 2026 23:00:00 Z" })
+    ).toBe("2026-09-10");
+    expect(telemetrySinkRecordDayKey({ ...BASE, event_timestamp: "+002026-09-10T10:00:00Z" })).toBe(
+      "2026-09-10"
+    );
   });
 
   it("answers undefined for no moment at all", () => {


### PR DESCRIPTION
## 🎯 What & why

`telemetrySinkRecordDayKey` decides which UTC day a stored telemetry record belongs to. That day chooses the periods a report counts it in. Once the timestamp parsed, it took a shortcut: any string ending in `Z` was sliced to its first ten characters. A moment that parses but is not in canonical ISO form got the wrong day, or a key that is no day at all. That key sits outside every period, so the record silently left a report without being counted as undated.

| `event_timestamp` | Before | After |
|---|---|---|
| `2026-09-10T24:00:00Z` | `2026-09-10` | `2026-09-11` |
| `Thu, 10 Sep 2026 23:00:00 Z` | `Thu, 10 Se` | `2026-09-10` |
| `+002026-09-10T10:00:00Z` | `+002026-09` | `2026-09-10` |

## 🛠️ How it works

- The shortcut and the three comment lines that justified it are deleted. The day is always `parsed.toISOString().slice(0, 10)`.
- The `src` comment ceiling in `comments.arch.test.ts` drops by the same three lines, 4474 → 4471.

## 🧪 How to verify

```sh
cd cli && pnpm vitest run --project unit tests/contexts/telemetry/domain/telemetry-sink-record.unit.test.ts
```

| Run | Result |
|---|---|
| Before the change | red: "expected '2026-09-10' to be '2026-09-11'" and "expected 'Thu, 10 Se' to be '2026-09-10'" |
| After | 13 of 13 pass |
| Telemetry suite | 56 files, 852 tests passed |
| test:arch | 126 passed |

Typecheck, lint, knip and type honesty are clean.

## ⚠️ Heads-up

- Latent: this CLI writes canonical `toISOString()` timestamps itself. A sink shared through `AIDD_TELEMETRY_DIR` can still hold lines another writer produced.
- The in-memory sink double calls the same function, so tests and the adapter still agree.

## 🔗 Linked issue

Fixes #825

## ✅ I certify

- [x] I have read the contributing guide and followed the PR template.
- [x] The tests were red before the fix and every gate listed above passed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011x4ms5qcGuZgYhCxfdHMUb
