### PR TITLE
fix(telemetry): an empty worktree id in the journal reads as not stated

### DIFF
--- a/cli/src/contexts/telemetry/infrastructure/run-journal-reader-adapter.ts
+++ b/cli/src/contexts/telemetry/infrastructure/run-journal-reader-adapter.ts
@@ -95,13 +95,13 @@ function parseBoundary(parsed: RawJournalLine): RunJournalBoundary | null {
   return { type: "step_start", at, skill, ...(turnId === undefined ? {} : { turn_id: turnId }) };
 }
 
-/** A plain checkout writes neither key; `asString` rejects `""`, so a torn or empty value
- * reads as "not stated" rather than as a worktree named nothing. */
+/** A plain checkout writes neither key, and an empty value is dropped with them, so a torn
+ * or empty value reads as "not stated" rather than as a worktree named nothing. */
 function parseWorktree(
   parsed: RawJournalLine
 ): Pick<RunJournalSessionStart, "worktree_id" | "worktree_repo_id"> {
-  const worktreeId = asString(parsed.worktree_id);
-  const worktreeRepoId = asString(parsed.worktree_repo_id);
+  const worktreeId = asString(parsed.worktree_id) || undefined;
+  const worktreeRepoId = asString(parsed.worktree_repo_id) || undefined;
   return {
     ...(worktreeId === undefined ? {} : { worktree_id: worktreeId }),
     ...(worktreeRepoId === undefined ? {} : { worktree_repo_id: worktreeRepoId }),

--- a/cli/tests/contexts/telemetry/infrastructure/run-journal-reader-adapter.integration.test.ts
+++ b/cli/tests/contexts/telemetry/infrastructure/run-journal-reader-adapter.integration.test.ts
@@ -53,6 +53,58 @@ describe("RunJournalReaderAdapter", () => {
     ]);
   });
 
+  it("reads an empty worktree id and repo id as not stated, never as a worktree named nothing", async () => {
+    await writeFile(
+      join(runsDir, `${RUN_ID}__${SESSION_ID}.jsonl`),
+      runFileLines({
+        type: "session_start",
+        at: "2026-08-20T09:59:00Z",
+        run_id: RUN_ID,
+        tool: "claude-code",
+        vendor_id: SESSION_ID,
+        worktree_id: "",
+        worktree_repo_id: "",
+      })
+    );
+
+    const journal = await new RunJournalReaderAdapter(projectRoot).read(SESSION_ID);
+
+    expect(journal?.session).toStrictEqual({
+      type: "session_start",
+      at: "2026-08-20T09:59:00Z",
+      run_id: RUN_ID,
+      tool: "claude-code",
+      vendor_id: SESSION_ID,
+    });
+  });
+
+  it("keeps a stated worktree id and repo id as written", async () => {
+    await writeFile(
+      join(runsDir, `${RUN_ID}__${SESSION_ID}.jsonl`),
+      runFileLines({
+        type: "session_start",
+        at: "2026-08-20T09:59:00Z",
+        run_id: RUN_ID,
+        tool: "claude-code",
+        vendor_id: SESSION_ID,
+        worktree_id: "feature-x",
+        worktree_repo_id: "framework",
+      })
+    );
+
+    const journal = await new RunJournalReaderAdapter(projectRoot).read(SESSION_ID);
+
+    expect(journal?.session).toStrictEqual({
+      type: "session_start",
+      at: "2026-08-20T09:59:00Z",
+      run_id: RUN_ID,
+      tool: "claude-code",
+      vendor_id: SESSION_ID,
+      worktree_id: "feature-x",
+      worktree_repo_id: "framework",
+    });
+  });
+
   it("answers null for a session no run file names, rather than the wrong file", async () => {
     await writeFile(
       join(runsDir, `${RUN_ID}__other-session.jsonl`),


### PR DESCRIPTION
## 🎯 What & why

`parseWorktree` in the run-journal reader promised, in its comment, that a torn or empty `worktree_id` reads as "not stated", because `asString` rejects `""`. The adapter's `asString` returns any string, so a `session_start` carrying `"worktree_id": ""` was read as a worktree named nothing. The worktree fields had no test at all.

## 🛠️ How it works

- An empty `worktree_id` or `worktree_repo_id` is now dropped like an absent one: `asString(...) || undefined`.
- The comment is reworded to say what the code does, with no added comment line.

## 🧪 How to verify

```sh
cd cli && pnpm vitest run --project integration tests/contexts/telemetry/infrastructure/run-journal-reader-adapter.integration.test.ts
```

| Run | Result |
|---|---|
| Before the change | "reads an empty worktree id and repo id as not stated…" is red |
| After | 38 of 38 pass |
| Both fields dropped unconditionally | "keeps a stated worktree id and repo id as written" is red |

Telemetry suite: 56 files, 852 tests passed. Typecheck, lint, test:arch, knip and type honesty are clean.

## ⚠️ Heads-up

Not reached in practice today, because the journal hook never writes an empty worktree id. The fix makes the reader keep the promise its comment already made, which was the recommended option in #826.

## 🔗 Linked issue

Fixes #826

## ✅ I certify

- [x] I have read the contributing guide and followed the PR template.
- [x] The test was red before the fix and every gate listed above passed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011x4ms5qcGuZgYhCxfdHMUb
