### PR TITLE
fix(cli): run unit and integration tests, and every mutant, in a throwaway home

### DIFF
--- a/cli/tests/architecture/throwaway-profile-wiring.arch.test.ts
+++ b/cli/tests/architecture/throwaway-profile-wiring.arch.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import mutation from "../../vitest.mutation.config.js";
+import workspace from "../../vitest.workspace.js";
+
+const SETUP = "./tests/helpers/throwaway-profile.ts";
+const RUNS_SOURCE = ["unit", "integration"];
+
+function projectsRunningSource(
+  projects: readonly unknown[]
+): { name: string; globalSetup: unknown }[] {
+  return projects.flatMap((project) => {
+    const test = (project as { test?: { name?: string; globalSetup?: unknown } }).test;
+    return test?.name && RUNS_SOURCE.includes(test.name)
+      ? [{ name: test.name, globalSetup: test.globalSetup }]
+      : [];
+  });
+}
+
+describe("every project that runs the source sees a throwaway profile", () => {
+  it.each([
+    ["the suite", projectsRunningSource(workspace)],
+    ["a mutation run", projectsRunningSource(mutation.test?.projects ?? [])],
+  ])(
+    "%s declares the throwaway-profile setup on its unit and integration projects",
+    (_run, projects) => {
+      expect(projects.map((p) => p.name).sort()).toStrictEqual(["integration", "unit"]);
+      for (const project of projects) expect(project.globalSetup, project.name).toContain(SETUP);
+    }
+  );
+});

--- a/cli/tests/helpers/throwaway-profile.ts
+++ b/cli/tests/helpers/throwaway-profile.ts
@@ -1,0 +1,14 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/** Set in the main process before any worker exists: a worker thread's own env never reaches `os.homedir()`, so only this leaves a mutant no real profile to write. */
+export function setup(): () => void {
+  const home = mkdtempSync(join(tmpdir(), "aidd-test-profile-"));
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  process.env.APPDATA = join(home, "AppData", "Roaming");
+  for (const key of ["AIDD_USER_CONFIG_DIR", "AIDD_TELEMETRY_DIR", "XDG_CONFIG_HOME"])
+    delete process.env[key];
+  return () => rmSync(home, { recursive: true, force: true });
+}

--- a/cli/tests/helpers/throwaway-profile.unit.test.ts
+++ b/cli/tests/helpers/throwaway-profile.unit.test.ts
@@ -1,0 +1,18 @@
+import { homedir, tmpdir } from "node:os";
+import { describe, expect, it } from "vitest";
+import { resolveAiddConfigDir, resolveHomeDir } from "../../src/kernel/reading/home-dir.js";
+import { userConfigDir } from "../../src/runtime/user-config-dir.js";
+
+describe("the profile a test run sees", () => {
+  it("is a home under the temp directory, whichever route resolves it", () => {
+    for (const resolved of [homedir(), resolveHomeDir(), resolveAiddConfigDir(), userConfigDir()]) {
+      expect(resolved.startsWith(tmpdir()), resolved).toBe(true);
+    }
+  });
+
+  it("carries no override that points outside that home", () => {
+    for (const key of ["AIDD_USER_CONFIG_DIR", "AIDD_TELEMETRY_DIR", "XDG_CONFIG_HOME"]) {
+      expect(process.env[key], key).toBeUndefined();
+    }
+  });
+});

--- a/cli/vitest.mutation.config.ts
+++ b/cli/vitest.mutation.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
           include: ["tests/**/*.unit.test.ts"],
           globals: false,
           environment: "node",
+          globalSetup: ["./tests/helpers/throwaway-profile.ts"],
         },
       },
       {
@@ -36,6 +37,7 @@ export default defineConfig({
           include: ["tests/**/*.integration.test.ts"],
           globals: false,
           environment: "node",
+          globalSetup: ["./tests/helpers/throwaway-profile.ts"],
           testTimeout: 60000,
         },
       },

--- a/cli/vitest.workspace.ts
+++ b/cli/vitest.workspace.ts
@@ -11,7 +11,10 @@ export default defineWorkspace([
       include: ["tests/**/*.unit.test.ts"],
       globals: false,
       environment: "node",
-      globalSetup: ["./tests/helpers/sweep-stale-temp-dirs.ts"],
+      globalSetup: [
+        "./tests/helpers/sweep-stale-temp-dirs.ts",
+        "./tests/helpers/throwaway-profile.ts",
+      ],
     },
   },
   {
@@ -31,7 +34,10 @@ export default defineWorkspace([
       globals: false,
       environment: "node",
       testTimeout: 60000,
-      globalSetup: ["./tests/helpers/sweep-stale-temp-dirs.ts"],
+      globalSetup: [
+        "./tests/helpers/sweep-stale-temp-dirs.ts",
+        "./tests/helpers/throwaway-profile.ts",
+      ],
     },
   },
   {


### PR DESCRIPTION
## 🎯 What & why

A unit or integration test that relocated only `AIDD_USER_CONFIG_DIR` was one mutant away from the real profile. A Stryker mutant that drops that override sends the test to `~/.config/aidd` of whoever runs the mutation. The mutant is killed, because the test fails, but the file is already written. On one machine this left a test marketplace entry (`/src/framework`) in the real registry, and replaced the real `auth.json` with a test token (#831).

## 🛠️ How it works

- `tests/helpers/throwaway-profile.ts` is a **global setup**. It points `HOME`, `USERPROFILE` and `APPDATA` at a temp home, and unsets `AIDD_USER_CONFIG_DIR`, `AIDD_TELEMETRY_DIR` and `XDG_CONFIG_HOME`. Every route to a profile then ends in that temp home, which is removed on teardown.
- It is declared on the `unit` and `integration` projects of both `vitest.workspace.ts` and `vitest.mutation.config.ts`.
- It runs in the main process on purpose. Stryker runs vitest in worker threads, and a thread's own `process.env` never reaches `os.homedir()`. A first version with `setupFiles` passed in forks and still left `os.homedir()` on the real home under threads. The guard test caught it with `--pool threads`.

## 🧪 How to verify

- `tests/helpers/throwaway-profile.unit.test.ts`: every resolver (`os.homedir()`, `resolveHomeDir()`, `resolveAiddConfigDir()`, `userConfigDir()`) lands under the temp directory, and no override is set.
  - Red before the fix: `/Users/<me>: expected false to be true`.
  - Red with a per-file setup under `--pool threads`.
  - Green now in threads and in forks.
- `tests/architecture/throwaway-profile-wiring.arch.test.ts`: all four projects declare the setup. It was red before the wiring.
- Mutant reproduction: rewrite `if (process.env.AIDD_USER_CONFIG_DIR) return` to `if (false) return` in `src/runtime/user-config-dir.ts`, then run `marketplace-register-framework-use-case.integration.test.ts` with `HOME` set to a stand-in developer home.
  - Before: the stand-in home receives `.config/aidd/marketplaces.json`.
  - After, in threads: the mutant is killed and the stand-in home stays empty.
- A real `node scripts/run-mutation.mjs tools-copilot --force` passes its initial run. The real `~/.config/aidd` is unchanged before and after it.

Local results on this branch:

| Check | Result |
| --- | --- |
| typecheck, lint, knip, type honesty | pass |
| architecture | 128 passed |
| unit + integration | 5021 passed |
| e2e | 297 passed |
| mutation, `tools-copilot` | score 82.2, floor 80. Real `~/.config/aidd` unchanged |
| leftover temp homes after the run | 0 |

## ⚠️ Heads-up

- The e2e project is out of scope. It spawns the built binary, which no mutant reaches, and it is not part of a mutation run.
- Comment budget: this adds one comment line under `tests/`. With #815 and #819 the count reaches 2987, exactly the baseline.

## 🔗 Linked issue

Fixes #831

## ✅ I certify

- [ ] **I DO CERTIFY I READ EACH LINE OF THE PULL REQUEST BECAUSE I AM A SOFTWARE ENGINEER, NOT A AI PUPPY.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011x4ms5qcGuZgYhCxfdHMUb
