### PR TITLE
fix(cli): leave what a project did not install to whoever installed it

### DIFF
--- a/cli/src/contexts/framework/application/flows/marketplace-sync-settings-use-case.ts
+++ b/cli/src/contexts/framework/application/flows/marketplace-sync-settings-use-case.ts
@@ -25,6 +25,7 @@ import {
   pluginSetDifference,
 } from "../../../tools/domain/marketplace-source-conflict.js";
 import type { HostMarketplaceRegistryReader } from "../../../tools/domain/ports/host-marketplace-registry-reader.js";
+import type { HostPluginRegistryReader } from "../../../tools/domain/ports/host-plugin-registry-reader.js";
 import type { NativePluginActivator } from "../../../tools/domain/ports/native-plugin-activator.js";
 import { nativeActivationOf, resolvePluginsCapability } from "../../../tools/domain/registry.js";
 import type { FrameworkBuildTarget } from "../../../translate/domain/build-target.js";
@@ -143,7 +144,11 @@ export class MarketplaceSyncSettingsUseCase implements MarketplaceSyncSettings {
      * Absent keeps the silent no-op instead of guessing what to register. */
     private readonly marketplaceRegisterFrameworkUseCase?: MarketplaceRegisterFramework,
     private readonly userSourceReferences?: UserSourceReferences,
-    private readonly currentVersionProvider?: VersionReader
+    private readonly currentVersionProvider?: VersionReader,
+    private readonly hostPluginRegistries: ReadonlyMap<
+      AiToolId,
+      HostPluginRegistryReader
+    > = new Map()
   ) {}
 
   async execute(options: MarketplaceSyncSettingsOptions): Promise<MarketplaceSyncSettingsResult> {
@@ -455,11 +460,35 @@ export class MarketplaceSyncSettingsUseCase implements MarketplaceSyncSettings {
       return { marketplaces: registeredMarketplaces, pluginRefs: [], buildFailed };
     this.bestEffort(() => activator.upgradeMarketplaces(), "upgrade marketplaces", warnings);
     const hostNameByAlias = new Map(registeredMarketplaces.map((m) => [m.alias, m.hostName]));
-    const refs = this.pluginRefsToEnable(toolId, manifest, marketplaces, hostNameByAlias);
+    const refs = await this.refsThisProjectEnables(
+      toolId,
+      this.pluginRefsToEnable(toolId, manifest, marketplaces, hostNameByAlias),
+      manifest,
+      projectRoot
+    );
     for (const ref of refs) {
       this.bestEffort(() => activator.enablePlugin(ref, scope), `enable plugin '${ref}'`, warnings);
     }
     return { marketplaces: registeredMarketplaces, pluginRefs: refs, buildFailed };
+  }
+
+  private async refsThisProjectEnables(
+    toolId: ToolId,
+    refs: string[],
+    manifest: Manifest,
+    projectRoot: string
+  ): Promise<string[]> {
+    const hostRegistry = isAiToolId(toolId) ? this.hostPluginRegistries.get(toolId) : undefined;
+    if (hostRegistry === undefined) return refs;
+    const ownRefs = manifest.getNativeRegistrations(toolId)?.pluginRefs;
+    const onHost = (await hostRegistry.read(projectRoot)).refs;
+    return refs.filter((ref) => {
+      if (ownRefs?.includes(ref) === true || onHost?.get(ref)?.enabled !== true) return true;
+      this.logger.info(
+        `${toolId}: '${ref}' was already enabled before this project asked for it — left as it is, and this project's clean will leave it enabled.`
+      );
+      return false;
+    });
   }
 
   private bestEffort(action: () => void, label: string, warnings: string[]): void {

--- a/cli/src/contexts/framework/application/framework/translator/built-tree-materialization-translator.ts
+++ b/cli/src/contexts/framework/application/framework/translator/built-tree-materialization-translator.ts
@@ -51,7 +51,8 @@ export class BuiltTreeMaterializationTranslator implements PluginTranslator {
     projectRoot: string,
     manifest: Manifest,
     marketplace: string | undefined,
-    previousMcpEntries: ReadonlyMap<string, string> = new Map()
+    previousMcpEntries: ReadonlyMap<string, string> = new Map(),
+    userScopeDirTaken = false
   ): Promise<{ skipped: ReadonlySkipList; written?: number }> {
     const resolved =
       marketplace === undefined ? null : await this.findMarketplace(marketplace, projectRoot);
@@ -63,7 +64,8 @@ export class BuiltTreeMaterializationTranslator implements PluginTranslator {
         projectRoot,
         manifest,
         marketplace,
-        previousMcpEntries
+        previousMcpEntries,
+        userScopeDirTaken
       );
     }
     const mode = frameworkBuildModeFor(toolId);
@@ -95,10 +97,11 @@ export class BuiltTreeMaterializationTranslator implements PluginTranslator {
       mode === "flat"
         ? projectRoot
         : resolveBaseDirFromRecord(scope, toolId, projectRoot, this.homedir);
-    const written = await this.writeChangedFiles(files, baseDir);
+    const owned = userScopeDirTaken ? [] : files;
+    const written = await this.writeChangedFiles(owned, baseDir);
     manifest.addPlugin(
       toolId,
-      InstalledPlugin.fromDistribution(dist, source, files, scope, new Map(), marketplace)
+      InstalledPlugin.fromDistribution(dist, source, owned, scope, new Map(), marketplace)
     );
     return { skipped: hooksSkips, written };
   }

--- a/cli/src/contexts/framework/application/framework/translator/mode-b-flat-materialization-translator.ts
+++ b/cli/src/contexts/framework/application/framework/translator/mode-b-flat-materialization-translator.ts
@@ -51,7 +51,8 @@ export class ModeBFlatMaterializationTranslator implements PluginTranslator {
     projectRoot: string,
     manifest: Manifest,
     marketplace: string | undefined,
-    previousMcpEntries: ReadonlyMap<string, string> = new Map()
+    previousMcpEntries: ReadonlyMap<string, string> = new Map(),
+    userScopeDirTaken = false
   ): Promise<{ skipped: ReadonlySkipList }> {
     const ctx = this.resolveFlatToolContext(toolId, dist, projectRoot);
     if (ctx === null) return { skipped: [] };
@@ -63,7 +64,7 @@ export class ModeBFlatMaterializationTranslator implements PluginTranslator {
       dist,
       toolId,
       source,
-      ctx.files,
+      userScopeDirTaken ? [] : ctx.files,
       mcp.mcpEntries,
       ctx.componentPaths,
       marketplace,

--- a/cli/src/contexts/framework/application/framework/translator/plugin-translator.ts
+++ b/cli/src/contexts/framework/application/framework/translator/plugin-translator.ts
@@ -23,6 +23,7 @@ export interface PluginTranslator {
     projectRoot: string,
     manifest: Manifest,
     marketplace: string | undefined,
-    previousMcpEntries?: ReadonlyMap<string, string>
+    previousMcpEntries?: ReadonlyMap<string, string>,
+    userScopeDirTaken?: boolean
   ): Promise<{ skipped: ReadonlySkipList; written?: number }>;
 }

--- a/cli/src/contexts/framework/application/plugin/plugin-add-use-case.ts
+++ b/cli/src/contexts/framework/application/plugin/plugin-add-use-case.ts
@@ -28,7 +28,11 @@ import type { PluginTranslator } from "../framework/translator/plugin-translator
 import { resolvePluginTranslator } from "../framework/translator/resolve-plugin-translator.js";
 import type { EnsureBuiltMarketplace } from "../shared/ensure-built-marketplace-use-case.js";
 import { loadPluginManifest, writePluginFiles } from "./plugin-helpers.js";
-import { resolvePluginToolIds, resolveScopeForInstall } from "./plugin-target-resolution.js";
+import {
+  resolveBaseDirFromRecord,
+  resolvePluginToolIds,
+  resolveScopeForInstall,
+} from "./plugin-target-resolution.js";
 
 export interface PluginAddOptions {
   source: PluginSource;
@@ -62,10 +66,18 @@ export class PluginAddUseCase implements PluginAdd {
     const { source, toolIds, projectRoot, marketplace } = options;
     const manifest = await loadPluginManifest(this.manifestRepo);
     const resolvedToolIds = resolvePluginToolIds(toolIds, manifest);
+    const installedBefore = pluginsInstalledBefore(manifest, resolvedToolIds);
     if (marketplace !== undefined && (await this.isGithubMarketplace(marketplace, projectRoot))) {
-      await this.addGithubMarketplacePlugin(options, resolvedToolIds, manifest);
+      await this.addGithubMarketplacePlugin(options, resolvedToolIds, manifest, installedBefore);
     } else {
-      await this.addLocalPlugin(options, resolvedToolIds, manifest, source, projectRoot);
+      await this.addLocalPlugin(
+        options,
+        resolvedToolIds,
+        manifest,
+        source,
+        projectRoot,
+        installedBefore
+      );
     }
     await this.manifestRepo.save(manifest);
   }
@@ -79,7 +91,8 @@ export class PluginAddUseCase implements PluginAdd {
   private async addGithubMarketplacePlugin(
     options: PluginAddOptions,
     toolIds: AiToolId[],
-    manifest: Manifest
+    manifest: Manifest,
+    installedBefore: PluginsInstalledBefore
   ): Promise<void> {
     const { pluginMetadata } = options;
     if (pluginMetadata === undefined) throw new MissingPluginMetadataError();
@@ -94,7 +107,8 @@ export class PluginAddUseCase implements PluginAdd {
         flatToolIds,
         manifest,
         options.source,
-        options.projectRoot
+        options.projectRoot,
+        installedBefore
       );
     }
     await this.registerNativeGithubPlugins(options, nativeToolIds, manifest);
@@ -156,7 +170,8 @@ export class PluginAddUseCase implements PluginAdd {
     resolvedToolIds: AiToolId[],
     manifest: Manifest,
     source: PluginSource,
-    projectRoot: string
+    projectRoot: string,
+    installedBefore: PluginsInstalledBefore
   ): Promise<void> {
     const { marketplace, requiredVersion, replace, pluginMetadata } = options;
     const read = await this.readDistribution(source, projectRoot);
@@ -171,7 +186,8 @@ export class PluginAddUseCase implements PluginAdd {
       projectRoot,
       manifest,
       marketplace,
-      prevMcpMap
+      prevMcpMap,
+      installedBefore
     );
   }
 
@@ -197,11 +213,24 @@ export class PluginAddUseCase implements PluginAdd {
     projectRoot: string,
     manifest: Manifest,
     marketplace: string | undefined,
-    prevMcpMap: Map<AiToolId, ReadonlyMap<string, string>>
+    prevMcpMap: Map<AiToolId, ReadonlyMap<string, string>>,
+    installedBefore: PluginsInstalledBefore
   ): Promise<void> {
     const allSkipped: ReadonlySkipList[] = [];
     const allNotices: ReadonlyNoticeList[] = [];
     for (const toolId of toolIds) {
+      const foreignDir = await this.userScopeDirNotInstalledHere(
+        dist.manifest.name,
+        toolId,
+        projectRoot,
+        installedBefore
+      );
+      if (foreignDir !== undefined) {
+        this.logger.warn(
+          `${toolId}: ${foreignDir} was already there and this project did not install it — left as found and not tracked, so this project's clean will not delete it.`
+        );
+        continue;
+      }
       const prev = prevMcpMap.get(toolId) ?? new Map();
       const { skipped, notices } = await this.addPluginForTool(
         dist,
@@ -217,6 +246,22 @@ export class PluginAddUseCase implements PluginAdd {
     }
     this.emitSkipWarnings(allSkipped.flat());
     this.emitInstallNotices(allNotices.flat());
+  }
+
+  private async userScopeDirNotInstalledHere(
+    pluginName: string,
+    toolId: AiToolId,
+    projectRoot: string,
+    installedBefore: PluginsInstalledBefore
+  ): Promise<string | undefined> {
+    if (resolveScopeForInstall(toolId) !== "user") return undefined;
+    if (installedBefore.has(installedKey(toolId, pluginName))) return undefined;
+    const dir = join(
+      resolveBaseDirFromRecord("user", toolId, projectRoot, nodeHomedir),
+      pluginName
+    );
+    const present = await this.fs.listFilesRecursive(dir);
+    return present.length > 0 ? dir : undefined;
   }
 
   private collectPreviousMcpEntries(
@@ -367,4 +412,21 @@ export class PluginAddUseCase implements PluginAdd {
       marketplaceRegistry: this.marketplaceRegistry,
     });
   }
+}
+
+type PluginsInstalledBefore = ReadonlySet<string>;
+
+function pluginsInstalledBefore(
+  manifest: Manifest,
+  toolIds: readonly AiToolId[]
+): PluginsInstalledBefore {
+  return new Set(
+    toolIds.flatMap((toolId) =>
+      manifest.getPlugins(toolId).map((p) => installedKey(toolId, p.name))
+    )
+  );
+}
+
+function installedKey(toolId: AiToolId, pluginName: string): string {
+  return `${toolId}/${pluginName}`;
 }

--- a/cli/src/contexts/framework/application/plugin/plugin-add-use-case.ts
+++ b/cli/src/contexts/framework/application/plugin/plugin-add-use-case.ts
@@ -229,7 +229,6 @@ export class PluginAddUseCase implements PluginAdd {
         this.logger.warn(
           `${toolId}: ${foreignDir} was already there and this project did not install it — left as found and not tracked, so this project's clean will not delete it.`
         );
-        continue;
       }
       const prev = prevMcpMap.get(toolId) ?? new Map();
       const { skipped, notices } = await this.addPluginForTool(
@@ -239,7 +238,8 @@ export class PluginAddUseCase implements PluginAdd {
         projectRoot,
         manifest,
         marketplace,
-        prev
+        prev,
+        foreignDir !== undefined
       );
       allSkipped.push(skipped);
       allNotices.push(notices);
@@ -309,7 +309,8 @@ export class PluginAddUseCase implements PluginAdd {
     projectRoot: string,
     manifest: Manifest,
     marketplace: string | undefined,
-    previousMcpEntries: ReadonlyMap<string, string> = new Map()
+    previousMcpEntries: ReadonlyMap<string, string>,
+    userScopeDirTaken: boolean
   ): Promise<{ skipped: ReadonlySkipList; notices: ReadonlyNoticeList }> {
     const toolConfig = getToolConfig(toolId);
     if (!isAiTool(toolConfig)) return { skipped: [], notices: [] };
@@ -322,7 +323,8 @@ export class PluginAddUseCase implements PluginAdd {
         projectRoot,
         manifest,
         marketplace,
-        previousMcpEntries
+        previousMcpEntries,
+        userScopeDirTaken
       );
       return { ...result, notices: [] };
     }

--- a/cli/src/contexts/framework/application/plugin/plugin-remove-use-case.ts
+++ b/cli/src/contexts/framework/application/plugin/plugin-remove-use-case.ts
@@ -133,6 +133,14 @@ export class PluginRemoveUseCase {
     }
     const hostName = registeredHostName ?? alias;
     const ref = `${plugin.name}@${hostName}`;
+    if (
+      registeredHostName !== undefined &&
+      activator.enablesPlugins() &&
+      registrations?.pluginRefs.includes(ref) !== true
+    ) {
+      this.logger.warn(`${toolId}: '${ref}' is not a ref this project enabled — left enabled.`);
+      return undefined;
+    }
     const guardMessage = await this.describeGuardedPluginRef(
       nativeActivation.binary,
       toolId,

--- a/cli/src/runtime/wiring/framework.ts
+++ b/cli/src/runtime/wiring/framework.ts
@@ -302,7 +302,8 @@ export async function createDeps(
     userConfigDir,
     marketplaceRegisterFrameworkUseCase,
     userSourceReferences,
-    currentVersionProvider
+    currentVersionProvider,
+    hostPluginRegistries
   );
   const pluginAddUseCase = new PluginAddUseCase(
     fs,

--- a/cli/tests/architecture/orchestrator-deps.arch.test.ts
+++ b/cli/tests/architecture/orchestrator-deps.arch.test.ts
@@ -25,14 +25,14 @@ const BASELINE: readonly { readonly path: string; readonly injected: number }[] 
     path: "src/contexts/framework/application/restore/generate-tool-distribution-use-case.ts",
     injected: 9,
   },
+  { path: "src/contexts/framework/application/restore/restore-use-case.ts", injected: 12 },
+  // Both carry `hostPluginRegistries`, the host's own registry per `AiToolId`: clean asks it the
+  // scope a ref was registered at, sync whether the host enabled a ref before this project did.
+  { path: "src/contexts/framework/application/clean-use-case.ts", injected: 11 },
   {
     path: "src/contexts/framework/application/flows/marketplace-sync-settings-use-case.ts",
-    injected: 12,
+    injected: 13,
   },
-  { path: "src/contexts/framework/application/restore/restore-use-case.ts", injected: 12 },
-  // Carries `hostPluginRegistries`, the host's own registry reader per `AiToolId`, so the
-  // scope asked for when uninstalling a ref is the one the host actually registered it at.
-  { path: "src/contexts/framework/application/clean-use-case.ts", injected: 11 },
   // The machine-scope counterpart of `clean-use-case.ts`, same shape and same reason.
   {
     path: "src/contexts/framework/application/clean/clean-user-scope-use-case.ts",

--- a/cli/tests/contexts/framework/application/flows/marketplace-sync-native-activation.integration.test.ts
+++ b/cli/tests/contexts/framework/application/flows/marketplace-sync-native-activation.integration.test.ts
@@ -695,3 +695,86 @@ describe("what reclaiming a dead registration says", () => {
     expect(result.errors).toStrictEqual([]);
   });
 });
+
+function hostReadingOf(refs: readonly string[], enabled = true): HostPluginRegistryReading {
+  return {
+    location: "/home/dev/.claude/plugins/installed_plugins.json",
+    refs: new Map(refs.map((ref) => [ref, { enabled }])),
+  };
+}
+
+function buildSyncReadingHost(
+  activator: FakeNativePluginActivator,
+  hostRegistry: HostPluginRegistryReader
+) {
+  const registry = new InMemoryMarketplaceRegistry();
+  const manifestRepo = manifestWithPlugin();
+  const logger = new CapturingLogger();
+  const useCase = new MarketplaceSyncSettingsUseCase(
+    seededBuiltCatalog(),
+    manifestRepo,
+    registry,
+    new DeterministicHasher(),
+    logger,
+    new Map([["claude", activator]]),
+    fakeEnsureBuiltMarketplace(),
+    new Map(),
+    () => "",
+    undefined,
+    undefined,
+    undefined,
+    new Map([["claude", hostRegistry]])
+  );
+  return { useCase, registry, manifestRepo, logger };
+}
+
+describe("a ref the host had enabled before this project asked belongs to the person", () => {
+  it("is neither enabled again nor recorded, so clean has nothing of it to undo", async () => {
+    const activator = new FakeNativePluginActivator({ available: true });
+    const { useCase, registry, manifestRepo, logger } = buildSyncReadingHost(activator, {
+      read: async () => hostReadingOf([REF]),
+    });
+    await registry.save(PROJECT_ROOT, marketplace());
+
+    await useCase.execute({ projectRoot: PROJECT_ROOT });
+
+    expect(activator.enabledPlugins).toEqual([]);
+    expect(logger.infoMessages.join("\n")).toContain(REF);
+    const recorded = (await manifestRepo.load())?.getNativeRegistrations("claude");
+    expect(recorded?.pluginRefs).toEqual([]);
+  });
+
+  it("stays this project's own on the next sync, once the host reports the enable it made", async () => {
+    const activator = new FakeNativePluginActivator({ available: true });
+    const { useCase, registry, manifestRepo } = buildSyncReadingHost(activator, {
+      read: async () => hostReadingOf(activator.enabledPlugins),
+    });
+    await registry.save(PROJECT_ROOT, marketplace());
+
+    await useCase.execute({ projectRoot: PROJECT_ROOT });
+    await useCase.execute({ projectRoot: PROJECT_ROOT });
+
+    const recorded = (await manifestRepo.load())?.getNativeRegistrations("claude");
+    expect(recorded?.pluginRefs).toEqual([REF]);
+  });
+
+  it.each([
+    [
+      "cannot be read",
+      { location: "/home/dev/.claude/plugins/installed_plugins.json", unreadable: "ENOENT" },
+    ],
+    ["lists it disabled", hostReadingOf([REF], false)],
+  ])("is this project's to enable when the host registry %s", async (_case, reading) => {
+    const activator = new FakeNativePluginActivator({ available: true });
+    const { useCase, registry, manifestRepo } = buildSyncReadingHost(activator, {
+      read: async () => reading,
+    });
+    await registry.save(PROJECT_ROOT, marketplace());
+
+    await useCase.execute({ projectRoot: PROJECT_ROOT });
+
+    expect(activator.enabledPlugins).toEqual([REF]);
+    const recorded = (await manifestRepo.load())?.getNativeRegistrations("claude");
+    expect(recorded?.pluginRefs).toEqual([REF]);
+  });
+});

--- a/cli/tests/contexts/framework/application/plugin/plugin-add-use-case.unit.test.ts
+++ b/cli/tests/contexts/framework/application/plugin/plugin-add-use-case.unit.test.ts
@@ -1,7 +1,9 @@
+import { homedir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { Marketplace } from "../../../../../src/contexts/distribution/domain/marketplace.js";
 import { PluginAddUseCase } from "../../../../../src/contexts/framework/application/plugin/plugin-add-use-case.js";
+import { InstalledPlugin } from "../../../../../src/contexts/framework/domain/plugins/installed-plugin.js";
 import type { PluginDistributionReader } from "../../../../../src/contexts/framework/domain/ports/plugin-distribution-reader.js";
 import { PluginDistributionReaderAdapter } from "../../../../../src/contexts/framework/infrastructure/plugin-distribution-reader-adapter.js";
 import { PluginDistribution } from "../../../../../src/contexts/translate/domain/plugin-distribution.js";
@@ -80,7 +82,7 @@ function localAdd(toolId: "claude" | "opencode", path = PLUGIN_FIXTURE, replace?
   };
 }
 
-function pluginNames(deps: Deps, toolId: "claude" | "opencode" | "codex"): string[] {
+function pluginNames(deps: Deps, toolId: "claude" | "opencode" | "codex" | "cursor"): string[] {
   return (deps.manifestRepo.getCurrent()?.getPlugins(toolId) ?? []).map((p) => p.name).sort();
 }
 
@@ -381,6 +383,74 @@ describe("PluginAddUseCase", () => {
         const installed = plugins.find((p) => p.name === "sample-plugin");
         expect(installed).toBeDefined();
         expect(installed?.files.size).toBeGreaterThan(0);
+      });
+
+      const CURSOR_SKILL = "sample-plugin/skills/demo/SKILL.md";
+
+      function cursorSkillAt(): string {
+        return join(homedir(), ".cursor/plugins/local", CURSOR_SKILL);
+      }
+
+      async function addForCursor(deps: Deps, logger: Logger, replace?: boolean): Promise<void> {
+        await buildAddUseCase(deps, await makeGithubRegistry(PROJECT_ROOT), logger).execute({
+          source: GIT_SUBDIR_SOURCE,
+          toolIds: ["cursor"],
+          projectRoot: PROJECT_ROOT,
+          marketplace: "aidd-framework",
+          interactive: false,
+          pluginMetadata: PLUGIN_METADATA,
+          replace,
+        });
+      }
+
+      async function cursorDeps(): Promise<Deps> {
+        const deps = await buildUnitDeps(PROJECT_ROOT);
+        await initAndInstall(deps, PROJECT_ROOT, "cursor");
+        await seedFromDirectory(deps.fs, PLUGIN_FIXTURE, { useAbsolutePaths: true });
+        deps.pluginFetcher.register(GIT_SUBDIR_SOURCE, PLUGIN_FIXTURE);
+        deps.fs.setFile(`/built/cursor/plugins/${CURSOR_SKILL}`, "# Demo skill");
+        return deps;
+      }
+
+      it("leaves a plugin dir it finds already there as it was, and tracks none of it", async () => {
+        const deps = await cursorDeps();
+        deps.fs.setFile(cursorSkillAt(), "# Their own skill");
+        const logger = new CapturingLogger();
+
+        await addForCursor(deps, logger);
+
+        expect(deps.fs.getFile(cursorSkillAt())).toBe("# Their own skill");
+        expect(pluginNames(deps, "cursor")).toEqual([]);
+        expect(logger.warnMessages.join("\n")).toContain(
+          join(homedir(), ".cursor/plugins/local", "sample-plugin")
+        );
+      });
+
+      it("leaves a found plugin dir alone even when this project installed another plugin", async () => {
+        const deps = await cursorDeps();
+        const manifest = await deps.manifestRepo.load();
+        manifest?.addPlugin(
+          "cursor",
+          InstalledPlugin.fromMetadata("other-plugin", "1.0.0", GIT_SUBDIR_SOURCE, false, "user")
+        );
+        if (manifest) await deps.manifestRepo.save(manifest);
+        deps.fs.setFile(cursorSkillAt(), "# Their own skill");
+
+        await addForCursor(deps, deps.logger);
+
+        expect(deps.fs.getFile(cursorSkillAt())).toBe("# Their own skill");
+        expect(pluginNames(deps, "cursor")).toEqual(["other-plugin"]);
+      });
+
+      it("still overwrites and tracks its own plugin dir when re-installed with replace", async () => {
+        const deps = await cursorDeps();
+        await addForCursor(deps, deps.logger);
+        deps.fs.setFile(`/built/cursor/plugins/${CURSOR_SKILL}`, "# Demo skill v2");
+
+        await addForCursor(deps, deps.logger, true);
+
+        expect(deps.fs.getFile(cursorSkillAt())).toBe("# Demo skill v2");
+        expect(pluginNames(deps, "cursor")).toEqual(["sample-plugin"]);
       });
     });
 

--- a/cli/tests/contexts/framework/application/plugin/plugin-add-use-case.unit.test.ts
+++ b/cli/tests/contexts/framework/application/plugin/plugin-add-use-case.unit.test.ts
@@ -420,7 +420,9 @@ describe("PluginAddUseCase", () => {
         await addForCursor(deps, logger);
 
         expect(deps.fs.getFile(cursorSkillAt())).toBe("# Their own skill");
-        expect(pluginNames(deps, "cursor")).toEqual([]);
+        const entry = deps.manifestRepo.getCurrent()?.getPlugins("cursor")[0];
+        expect(entry?.name).toBe("sample-plugin");
+        expect(entry?.files.size).toBe(0);
         expect(logger.warnMessages.join("\n")).toContain(
           join(homedir(), ".cursor/plugins/local", "sample-plugin")
         );
@@ -439,7 +441,33 @@ describe("PluginAddUseCase", () => {
         await addForCursor(deps, deps.logger);
 
         expect(deps.fs.getFile(cursorSkillAt())).toBe("# Their own skill");
-        expect(pluginNames(deps, "cursor")).toEqual(["other-plugin"]);
+        expect(pluginNames(deps, "cursor")).toEqual(["other-plugin", "sample-plugin"]);
+      });
+
+      it("still delivers the plugin's project hooks when its user-scope dir is someone else's", async () => {
+        const deps = await cursorDeps();
+        deps.fs.setFile(cursorSkillAt(), "# Their own skill");
+
+        await addForCursor(deps, deps.logger);
+
+        expect(deps.fs.getFile(join(PROJECT_ROOT, ".cursor/hooks.json"))).toContain(
+          "update_memory"
+        );
+      });
+
+      it("leaves a found plugin dir alone on a local install with no marketplace", async () => {
+        const deps = await cursorDeps();
+        deps.fs.setFile(cursorSkillAt(), "# Their own skill");
+
+        await buildAddUseCase(deps).execute({
+          source: { kind: "local", path: PLUGIN_FIXTURE },
+          toolIds: ["cursor"],
+          projectRoot: PROJECT_ROOT,
+          interactive: false,
+        });
+
+        expect(deps.fs.getFile(cursorSkillAt())).toBe("# Their own skill");
+        expect(deps.manifestRepo.getCurrent()?.getPlugins("cursor")[0]?.files.size).toBe(0);
       });
 
       it("still overwrites and tracks its own plugin dir when re-installed with replace", async () => {

--- a/cli/tests/contexts/framework/application/plugin/plugin-remove-cache.integration.test.ts
+++ b/cli/tests/contexts/framework/application/plugin/plugin-remove-cache.integration.test.ts
@@ -154,7 +154,7 @@ describe("PluginRemoveUseCase purges the plugin's own cache subtree", () => {
     manifest.setNativeRegistrations("claude", {
       binary: "claude",
       marketplaces: [{ alias: ALIAS, hostName: evilHostName }],
-      pluginRefs: [`${PLUGIN_NAME}@${ALIAS}`],
+      pluginRefs: [`${PLUGIN_NAME}@${evilHostName}`],
     });
     const manifestRepo = new InMemoryManifestRepository(manifest, PROJECT_ROOT);
     const activator = new FakeNativePluginActivator({ available: true });

--- a/cli/tests/contexts/framework/application/plugin/plugin-remove-native-activation.integration.test.ts
+++ b/cli/tests/contexts/framework/application/plugin/plugin-remove-native-activation.integration.test.ts
@@ -197,7 +197,7 @@ describe("PluginRemoveUseCase undoes native activation", () => {
     manifest.setNativeRegistrations("claude", {
       binary: "claude",
       marketplaces: [{ alias: "local", hostName: "upstream" }],
-      pluginRefs: [],
+      pluginRefs: [`${PLUGIN_NAME}@upstream`],
     });
     await manifestRepo.save(manifest);
 
@@ -247,7 +247,7 @@ describe("PluginRemoveUseCase undoes native activation", () => {
     manifest.setNativeRegistrations("claude", {
       binary: "claude",
       marketplaces: [{ alias: "local", hostName: "upstream" }],
-      pluginRefs: [],
+      pluginRefs: [`${PLUGIN_NAME}@upstream`],
     });
     await manifestRepo.save(manifest);
 
@@ -361,7 +361,7 @@ describe("PluginRemoveUseCase undoes native activation", () => {
     manifest.setNativeRegistrations("claude", {
       binary: "claude",
       marketplaces: [{ alias: MARKETPLACE_NAME, hostName: "upstream" }],
-      pluginRefs: [],
+      pluginRefs: [`${PLUGIN_NAME}@upstream`],
     });
     await manifestRepo.save(manifest);
 
@@ -414,5 +414,44 @@ describe("PluginRemoveUseCase undoes native activation", () => {
         projectRoot: PROJECT_ROOT,
       })
     ).rejects.toThrow("activator crashed uninstalling a plugin");
+  });
+});
+
+describe("PluginRemoveUseCase undoes only the activation this project made", () => {
+  async function removeWithRecordedRefs(pluginRefs: readonly string[]) {
+    const activator = new FakeNativePluginActivator({ available: true });
+    const logger = new CapturingLogger();
+    const { removeUseCase, manifestRepo } = buildRemoveUseCase(activator, logger);
+    const manifest = Manifest.create();
+    manifest.addTool("claude", "test", []);
+    await installViaModeA(manifest);
+    manifest.setNativeRegistrations("claude", {
+      binary: "claude",
+      marketplaces: [{ alias: MARKETPLACE_NAME, hostName: MARKETPLACE_NAME }],
+      pluginRefs,
+    });
+    await manifestRepo.save(manifest);
+
+    await removeUseCase.execute({
+      pluginName: PLUGIN_NAME,
+      toolIds: ["claude"],
+      projectRoot: PROJECT_ROOT,
+    });
+    return { activator, logger, manifestRepo };
+  }
+
+  it("leaves enabled, and names, a ref the host already had before this project", async () => {
+    const { activator, logger, manifestRepo } = await removeWithRecordedRefs([]);
+
+    expect(activator.uninstalledPlugins).toEqual([]);
+    expect(logger.warnMessages.join("\n")).toContain(REF);
+    const loaded = await manifestRepo.load();
+    expect(loaded?.getPlugins("claude").some((p) => p.name === PLUGIN_NAME)).toBe(false);
+  });
+
+  it("uninstalls a ref this project's own activation enabled", async () => {
+    const { activator } = await removeWithRecordedRefs([REF]);
+
+    expect(activator.uninstalledPlugins).toEqual([REF]);
   });
 });

--- a/cli/tests/e2e/preexisting-codex-ref.e2e.test.ts
+++ b/cli/tests/e2e/preexisting-codex-ref.e2e.test.ts
@@ -1,0 +1,46 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { delimiter, join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { createTestEnv, pathWithoutAidd, runCli, writeFakeToolBinary } from "./helpers.js";
+
+const FRAMEWORK_REAL_PATH = resolve(process.cwd(), "tests/fixtures/framework-real");
+const PLUGIN_NAME = "aidd-vcs";
+const THEIR_OWN_ENABLE = `[plugins."${PLUGIN_NAME}@aidd-framework"]\nenabled = true\n`;
+
+describe("E2E: a codex plugin enabled before setup stays with the person who enabled it", () => {
+  it("setup never enables it again, and clean never removes it", async () => {
+    const test = await createTestEnv("preexisting-codex-ref");
+    try {
+      const logFile = join(test.tempDir, "codex-invocations.log");
+      const binDir = join(test.tempDir, "bin");
+      await writeFakeToolBinary(binDir, "codex", logFile);
+      const env = { PATH: `${binDir}${delimiter}${pathWithoutAidd()}` };
+      const codexConfig = join(test.fakeHome, ".codex", "config.toml");
+      await mkdir(join(test.fakeHome, ".codex"), { recursive: true });
+      await writeFile(codexConfig, THEIR_OWN_ENABLE);
+
+      const setupArgs = [
+        "setup",
+        "--source",
+        "local",
+        "--path",
+        FRAMEWORK_REAL_PATH,
+        "--ai",
+        "codex",
+        "--plugins",
+        PLUGIN_NAME,
+        "--yes",
+      ];
+      const setup = await runCli(setupArgs, test.projectDir, test.fakeHome, { env });
+      expect(setup.exitCode).toBe(0);
+      const clean = await runCli(["clean", "--force"], test.projectDir, test.fakeHome, { env });
+      expect(clean.exitCode).toBe(0);
+
+      const log = await readFile(logFile, "utf-8");
+      expect(log).not.toContain(`${PLUGIN_NAME}@`);
+      expect(await readFile(codexConfig, "utf-8")).toContain(THEIR_OWN_ENABLE);
+    } finally {
+      await test.cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## 🎯 What & why

A project that installs a plugin the person already had under the same key took that install over. The project's `aidd clean` or `aidd plugin remove` then undid the person's own install (#829):

- a codex `[plugins."…"]` section deleted, along with its cache;
- a copilot key flipped to `false`;
- a cursor `.cursor-plugin/plugin.json` overwritten on install, then deleted on clean.

The key is `<plugin>@<catalog name>` for codex, copilot and claude. For cursor it is the plugin name alone, in `~/.cursor/plugins/local/<plugin>`.

The rule this PR puts in place: **a project only undoes what it did itself.** Anything that was already there is left as found and named in the output.

## 🛠️ How it works

- **Sync, which codex, copilot and claude activate through** (`MarketplaceSyncSettingsUseCase`):
  - Before enabling a ref, sync reads the host's own plugin registry. The readers already existed and were wired into `clean` and `plugin remove`; they are now wired into sync too.
  - A ref counts as the person's when the host reports it enabled and this project never recorded it. Sync does not enable it again and leaves it out of `pluginRefs`. `clean` only undoes `pluginRefs`, so it no longer touches that ref.
  - A ref already recorded in this project's `pluginRefs` stays this project's on every later sync. The host reporting the enable this project made does not change that.
  - An unreadable registry changes nothing: the ref is enabled and recorded, as before. The readers answer "unreadable" for a missing file too (a fresh codex, a copilot never run), so treating that as the person's would mean aidd never enables anything on a fresh machine.
- **`plugin remove`:** a ref that this project's registrations name a marketplace for, but that is absent from its `pluginRefs`, is left enabled with a warning naming it. It is never uninstalled.
- **`plugin add` at user scope (cursor):** if the plugin directory already has files and this project had no manifest entry for the plugin before the command ran, the directory is neither written to nor tracked, and a warning names it. The rest of the install still happens: the plugin's hooks merged into `.cursor/hooks.json`, its MCP entries, and a manifest entry that owns no files. So `plugin remove` and `clean` delete nothing of the directory. The decision is taken in `PluginAddUseCase`, from a snapshot taken before `replace` drops the entry (so re-installing this project's own plugin still overwrites it). It is applied in the two user-scope translators, between writing the files and recording them.

No new manifest field and no migration. `pluginRefs` already meant "what this project enabled"; it is now exactly that.

## 🧪 How to verify

Every test below was written first. The red ones were watched failing for the reason they name:

| Test | Red before the fix |
| --- | --- |
| e2e `preexisting-codex-ref`: a fake HOME whose `~/.codex/config.toml` already enables `aidd-vcs@aidd-framework`; `setup`, then `clean --force` | the fake codex log showed `plugin add aidd-vcs@aidd-framework`, then `plugin remove aidd-vcs@aidd-framework` |
| sync: the host already reports the ref enabled | `expected [ 'aidd-telemetry@aidd-framework' ] to deeply equal []` |
| plugin remove: a ref absent from `pluginRefs` | `expected [ 'aidd-telemetry@aidd-framework' ] to deeply equal []` |
| plugin add, cursor: the plugin dir already exists | `expected '# Demo skill' to be '# Their own skill'` |
| plugin add, cursor: a second project's install still delivers the plugin's project hooks and records an entry owning no files | `expected undefined to be 'sample-plugin'`; no `.cursor/hooks.json` |

Guards that pass on both sides and keep a wrong fix from passing:
- sync, two runs: the ref this project enabled is still in `pluginRefs` after a second sync, when the host reports that enable back. If ownership were re-derived from the host each run, clean would silently stop undoing anything aidd installed.
- sync with an unreadable registry, or one listing the ref disabled: the ref is enabled and recorded.
- plugin remove: a ref in `pluginRefs` is still uninstalled.
- plugin add, cursor: re-installing this project's own plugin with `replace` still overwrites and tracks it.
- plugin add, cursor: a plugin dir already there is left alone even when this project installed a different plugin for cursor. This test makes the ownership key matter.

Three existing fixtures recorded registrations whose `pluginRefs` did not hold the ref a real sync would have recorded. They now hold it: two in `plugin-remove-native-activation`, one in `plugin-remove-cache`.

Local results:

| Check | Result |
| --- | --- |
| typecheck, lint, knip, type honesty | pass |
| architecture | 126 passed |
| unit + integration | 5028 passed |
| e2e | 298 passed |
| mutation, restricted to the changed lines (throwaway `HOME`) | 92.98. 4 survivors: 2 are fixed by this PR's last test, and 2 are equivalent (below) |

The two equivalent survivors:
- `resolveBaseDirFromRecord("user", …)` in `plugin-add-use-case.ts` → `""`: the line above has already returned for any scope other than `"user"`, and `""` resolves to the same user directory.
- `registrations?.pluginRefs` in `plugin-remove-use-case.ts` → `registrations.pluginRefs`: this is reached only when `registeredHostName` is defined, and `registeredHostName` is read from `registrations`, so `registrations` is always defined there.

The `installedKey` survivors (block and string) are killed by the test "leaves a found plugin dir alone even when this project installed another plugin". Blanking the key turns that test red, and only that test.

## ⚠️ Heads-up

- A first version of this PR skipped the whole install for a taken cursor dir. CI smoke caught it: `plugin remove → cursor (exit 1, want 0)`, because a second project on the same machine had no entry, and it had no hooks either. The second commit moves the guard into the translators.

- `MarketplaceSyncSettingsUseCase` takes one more collaborator, `hostPluginRegistries`, so its baseline in `orchestrator-deps.arch.test.ts` goes from 12 to 13. The reason sits in the existing comment shared with `clean-use-case.ts`, so there is no net new comment line.
- Comment budget: `src/` stays at 4474 and `tests/` at 2983.
- Out of scope, as its own issue: sync records a marketplace in `nativeRegistrations` even when the host refused to register it, and `clean` then removes that marketplace by name. Filed as #833.
- Known limit: two aidd projects sharing a cursor plugin dir. The second one to install finds the dir already there and leaves it alone; the first one's `clean` still removes it.
- `clean --scope user` is unchanged. That command exists to tear down machine-wide state.

## 🔗 Linked issue

Fixes #829

## ✅ I certify

- [ ] **I DO CERTIFY I READ EACH LINE OF THE PULL REQUEST BECAUSE I AM A SOFTWARE ENGINEER, NOT A AI PUPPY.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011x4ms5qcGuZgYhCxfdHMUb
