### PR TITLE
fix(cli): record only the marketplaces a project actually registered

### DIFF
--- a/cli/src/contexts/framework/application/flows/marketplace-sync-settings-use-case.ts
+++ b/cli/src/contexts/framework/application/flows/marketplace-sync-settings-use-case.ts
@@ -444,6 +444,8 @@ export class MarketplaceSyncSettingsUseCase implements MarketplaceSyncSettings {
     // Each step is independently best-effort: one failing plugin or marketplace must warn and
     // let the others through, never abort the whole activation.
     const registeredMarketplaces: NativeMarketplaceRegistration[] = [];
+    const ownMarketplaces: NativeMarketplaceRegistration[] = [];
+    const recorded = manifest.getNativeRegistrations(toolId)?.marketplaces;
     let buildFailed = false;
     for (const marketplace of marketplaces) {
       const registration = await this.registerMarketplace(
@@ -453,11 +455,15 @@ export class MarketplaceSyncSettingsUseCase implements MarketplaceSyncSettings {
         projectRoot,
         warnings
       );
-      if (!registration.registered) buildFailed = true;
-      registeredMarketplaces.push({ alias: marketplace.name, hostName: registration.hostName });
+      if (registration.outcome === "build-failed") buildFailed = true;
+      const entry = { alias: marketplace.name, hostName: registration.hostName };
+      registeredMarketplaces.push(entry);
+      const earlier = recorded?.find((m) => m.alias === marketplace.name);
+      if (registration.outcome === "registered") ownMarketplaces.push(entry);
+      else if (earlier !== undefined) ownMarketplaces.push(earlier);
     }
     if (!activator.enablesPlugins())
-      return { marketplaces: registeredMarketplaces, pluginRefs: [], buildFailed };
+      return { marketplaces: ownMarketplaces, pluginRefs: [], buildFailed };
     this.bestEffort(() => activator.upgradeMarketplaces(), "upgrade marketplaces", warnings);
     const hostNameByAlias = new Map(registeredMarketplaces.map((m) => [m.alias, m.hostName]));
     const refs = await this.refsThisProjectEnables(
@@ -469,7 +475,7 @@ export class MarketplaceSyncSettingsUseCase implements MarketplaceSyncSettings {
     for (const ref of refs) {
       this.bestEffort(() => activator.enablePlugin(ref, scope), `enable plugin '${ref}'`, warnings);
     }
-    return { marketplaces: registeredMarketplaces, pluginRefs: refs, buildFailed };
+    return { marketplaces: ownMarketplaces, pluginRefs: refs, buildFailed };
   }
 
   private async refsThisProjectEnables(
@@ -491,14 +497,16 @@ export class MarketplaceSyncSettingsUseCase implements MarketplaceSyncSettings {
     });
   }
 
-  private bestEffort(action: () => void, label: string, warnings: string[]): void {
+  private bestEffort(action: () => void, label: string, warnings: string[]): boolean {
     try {
       action();
+      return true;
     } catch (error) {
       if (!(error instanceof NativePluginCliError)) throw error;
       const message = `Native plugin activation — ${label} skipped: ${error.message}`;
       this.logger.warn(message);
       warnings.push(message);
+      return false;
     }
   }
 
@@ -532,9 +540,9 @@ export class MarketplaceSyncSettingsUseCase implements MarketplaceSyncSettings {
     marketplace: Marketplace,
     projectRoot: string,
     warnings: string[]
-  ): Promise<{ hostName: string; registered: boolean }> {
+  ): Promise<{ hostName: string; outcome: "registered" | "refused" | "build-failed" }> {
     const builtDir = await this.buildForTool(toolId, marketplace, projectRoot);
-    if (builtDir === null) return { hostName: marketplace.name, registered: false };
+    if (builtDir === null) return { hostName: marketplace.name, outcome: "build-failed" };
     const requestedIdentity = await readMarketplaceCatalogIdentity(this.fs, toolId, builtDir);
     if (requestedIdentity === undefined) {
       throw new UnreadableBuiltCatalogError(
@@ -552,14 +560,23 @@ export class MarketplaceSyncSettingsUseCase implements MarketplaceSyncSettings {
     );
     // A "skip" is a host already following a newer shared build, never this project's own
     // pre-migration cache, so it counts as registered.
-    if (decision === "skip") return { hostName, registered: true };
+    if (decision === "skip") return { hostName, outcome: "registered" };
     try {
       activator.addMarketplace(builtDir, marketplace.scope);
     } catch (error) {
       if (!(error instanceof NativePluginCliError)) throw error;
-      this.reclaimOrReport(toolId, activator, marketplace, hostName, builtDir, error, warnings);
+      const reclaimed = this.reclaimOrReport(
+        toolId,
+        activator,
+        marketplace,
+        hostName,
+        builtDir,
+        error,
+        warnings
+      );
+      return { hostName, outcome: reclaimed ? "registered" : "refused" };
     }
-    return { hostName, registered: true };
+    return { hostName, outcome: "registered" };
   }
 
   /**
@@ -653,7 +670,7 @@ export class MarketplaceSyncSettingsUseCase implements MarketplaceSyncSettings {
     builtDir: string,
     addError: NativePluginCliError,
     warnings: string[]
-  ): void {
+  ): boolean {
     const state = activator.registrationState(hostName);
     const isUnguardedFrameworkMarketplace =
       marketplace.name === FRAMEWORK_MARKETPLACE_NAME &&
@@ -663,7 +680,7 @@ export class MarketplaceSyncSettingsUseCase implements MarketplaceSyncSettings {
       const message = `Native plugin activation — register marketplace '${hostName}' skipped: ${addError.message}`;
       this.logger.warn(message);
       warnings.push(message);
-      return;
+      return false;
     }
     const reclaimMessage =
       state === "dead"
@@ -676,7 +693,7 @@ export class MarketplaceSyncSettingsUseCase implements MarketplaceSyncSettings {
       `unregister stale marketplace '${hostName}'`,
       warnings
     );
-    this.bestEffort(
+    return this.bestEffort(
       () => activator.addMarketplace(builtDir, marketplace.scope),
       `register marketplace '${hostName}'`,
       warnings

--- a/cli/tests/contexts/framework/application/flows/marketplace-sync-settings-use-case-manifest-writes.unit.test.ts
+++ b/cli/tests/contexts/framework/application/flows/marketplace-sync-settings-use-case-manifest-writes.unit.test.ts
@@ -336,21 +336,99 @@ describe("when a recorded registration is replaced", () => {
     });
   });
 
-  it("records a marketplace whose build failed under its own alias", async () => {
+  it("records no marketplace whose build failed, this run having registered nothing for it", async () => {
     const { useCase, manifest } = await build({
       marketplaceNames: [MARKETPLACE, "broken"],
       failingBuilds: ["broken"],
+      existingRegistrations: {
+        binary: "claude",
+        marketplaces: [{ alias: "retired", hostName: "retired-catalog" }],
+        pluginRefs: [],
+      },
     });
 
     await useCase.execute({ projectRoot: PROJECT_ROOT });
 
-    expect(recorded(manifest)).toStrictEqual({
-      binary: "claude",
-      marketplaces: [
-        { alias: MARKETPLACE, hostName: MARKETPLACE },
-        { alias: "broken", hostName: "broken" },
-      ],
-      pluginRefs: [],
+    expect(recorded(manifest)?.marketplaces).toStrictEqual([
+      { alias: MARKETPLACE, hostName: MARKETPLACE },
+    ]);
+  });
+
+  it("keeps a marketplace an earlier run registered when its build now fails", async () => {
+    const { useCase, manifest } = await build({
+      marketplaceNames: [MARKETPLACE, "broken"],
+      failingBuilds: ["broken"],
+      existingRegistrations: {
+        binary: "claude",
+        marketplaces: [{ alias: "broken", hostName: "broken-catalog" }],
+        pluginRefs: [],
+      },
     });
+
+    await useCase.execute({ projectRoot: PROJECT_ROOT });
+
+    expect(recorded(manifest)?.marketplaces).toStrictEqual([
+      { alias: MARKETPLACE, hostName: MARKETPLACE },
+      { alias: "broken", hostName: "broken-catalog" },
+    ]);
+  });
+});
+
+describe("a marketplace the host refused is not this project's to remove", () => {
+  function refusingHost(registrationState: "live" | "dead"): FakeNativePluginActivator {
+    return new FakeNativePluginActivator({
+      available: true,
+      conflictOnAdd: true,
+      registrationState,
+    });
+  }
+
+  it("records no marketplace the host kept under another registration", async () => {
+    const { useCase, manifest } = await build({ activator: refusingHost("live") });
+
+    await useCase.execute({ projectRoot: PROJECT_ROOT });
+
+    expect(recorded(manifest)?.marketplaces).toStrictEqual([]);
+  });
+
+  it("keeps a marketplace an earlier run registered when the host now refuses it", async () => {
+    const { useCase, manifest } = await build({
+      activator: refusingHost("live"),
+      existingRegistrations: {
+        binary: "claude",
+        marketplaces: [{ alias: MARKETPLACE, hostName: MARKETPLACE }],
+        pluginRefs: [],
+      },
+    });
+
+    await useCase.execute({ projectRoot: PROJECT_ROOT });
+
+    expect(recorded(manifest)?.marketplaces).toStrictEqual([
+      { alias: MARKETPLACE, hostName: MARKETPLACE },
+    ]);
+  });
+
+  it("records no marketplace it failed to take back from a dead registration", async () => {
+    const activator = new FakeNativePluginActivator({
+      available: true,
+      conflictOnAdd: true,
+      registrationState: "dead",
+      throwOnRemove: true,
+    });
+    const { useCase, manifest } = await build({ activator });
+
+    await useCase.execute({ projectRoot: PROJECT_ROOT });
+
+    expect(recorded(manifest)?.marketplaces).toStrictEqual([]);
+  });
+
+  it("records a marketplace this run took back from a dead registration", async () => {
+    const { useCase, manifest } = await build({ activator: refusingHost("dead") });
+
+    await useCase.execute({ projectRoot: PROJECT_ROOT });
+
+    expect(recorded(manifest)?.marketplaces).toStrictEqual([
+      { alias: MARKETPLACE, hostName: MARKETPLACE },
+    ]);
   });
 });

--- a/cli/tests/e2e/refused-marketplace-clean.e2e.test.ts
+++ b/cli/tests/e2e/refused-marketplace-clean.e2e.test.ts
@@ -1,0 +1,68 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { delimiter, join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { createTestEnv, pathWithoutAidd, runCli } from "./helpers.js";
+
+const FRAMEWORK_REAL_PATH = resolve(process.cwd(), "tests/fixtures/framework-real");
+const SHELL_FAKE_BINARY = process.platform !== "win32";
+
+async function writeCopilotThatRefusesMarketplaceAdd(binDir: string, logFile: string) {
+  await mkdir(binDir, { recursive: true });
+  await writeFile(
+    join(binDir, "copilot"),
+    [
+      "#!/bin/sh",
+      `echo "$@" >> "${logFile}"`,
+      'case "$*" in *"marketplace add"*) echo "marketplace is already registered" >&2; exit 1;; esac',
+      "exit 0",
+      "",
+    ].join("\n"),
+    { mode: 0o755 }
+  );
+}
+
+describe("E2E: clean leaves a marketplace the host refused to register for this project", () => {
+  it.runIf(SHELL_FAKE_BINARY)("never asks copilot to remove it", async () => {
+    const test = await createTestEnv("refused-marketplace-clean");
+    try {
+      const logFile = join(test.tempDir, "copilot-invocations.log");
+      const binDir = join(test.tempDir, "bin");
+      await writeCopilotThatRefusesMarketplaceAdd(binDir, logFile);
+      const env = { PATH: `${binDir}${delimiter}${pathWithoutAidd()}` };
+      const run = (args: string[]) => runCli(args, test.projectDir, test.fakeHome, { env });
+
+      const setup = await run([
+        "setup",
+        "--source",
+        "local",
+        "--path",
+        FRAMEWORK_REAL_PATH,
+        "--ai",
+        "copilot",
+        "--plugins",
+        "none",
+        "--yes",
+      ]);
+      expect(setup.exitCode).toBe(0);
+      const add = await run([
+        "marketplace",
+        "add",
+        "probe",
+        FRAMEWORK_REAL_PATH,
+        "--scope",
+        "project",
+        "--yes",
+      ]);
+      expect(add.exitCode).toBe(0);
+      expect(await readFile(logFile, "utf-8")).toContain("marketplace add");
+
+      await writeFile(logFile, "");
+      const clean = await run(["clean", "--force"]);
+      expect(clean.exitCode).toBe(0);
+
+      expect(await readFile(logFile, "utf-8")).not.toContain("marketplace remove");
+    } finally {
+      await test.cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## 🎯 What & why

`aidd clean` removes every project-scope marketplace listed in a tool's native registrations. Sync listed every marketplace it tried to register, including ones the host never accepted (#833):

- the host refused `marketplace add` because it already held that name under a registration that still resolves (someone else's, or another project's);
- the marketplace's build failed, so nothing was sent to the host at all.

The entry was recorded anyway. `clean` then ran the host's `marketplace remove <name>` against a registration this project never made. This is the same class of bug as #829: a project undoing what it did not do.

## 🛠️ How it works

`registerMarketplace` now reports what happened: `registered`, `refused` or `build-failed`. Before, it answered `registered: true` after a refusal. `reclaimOrReport` returns whether this project ended up holding the registration: `true` when it took back a dead one, `false` when it only warned.

`activateTool` records a marketplace in `nativeRegistrations.marketplaces` when:

- this run registered it, or took it back from a dead registration; or
- an earlier run of this project had already recorded it. This keeps ownership sticky: a later refusal or build failure never makes the project forget a registration it made, which `clean` would then leave behind.

Plugin refs are enabled exactly as before. Only what is recorded as this project's changes.

## 🧪 How to verify

Every test below was written first. The red ones were watched failing for the reason they name:

| Test | Red before the fix |
| --- | --- |
| e2e `refused-marketplace-clean`: a fake `copilot` refuses `marketplace add`; `setup`, `marketplace add probe --scope project`, then `clean --force` | clean ran `plugin marketplace remove aidd-framework` |
| sync: the host refuses and keeps its own live registration | `expected [ { alias: 'aidd-framework', … } ] to strictly equal []` |
| sync: a marketplace whose build failed, never recorded before | recorded under its alias |
| sync: a marketplace an earlier run recorded, whose build now fails | the earlier `hostName` replaced by the alias |

Guards that pass on both sides and keep a wrong fix from passing:

- a marketplace an earlier run recorded stays recorded when the host now refuses it;
- a marketplace taken back from a dead registration is recorded;
- one whose take-back fails too is not recorded;
- an earlier record under another alias is never attributed to a failed build.

The existing test "records a marketplace whose build failed under its own alias" encoded the old behaviour. It is replaced by the two build-failure tests above.

Local results:

| Check | Result |
| --- | --- |
| typecheck, lint, knip, type honesty | pass |
| architecture | 128 passed |
| unit + integration | 5788 passed (before the two mutation tests below, which pass in their file) |
| e2e | 299 passed |
| smoke | 0 failed |
| mutation, restricted to the changed lines (throwaway `HOME`) | 92.86, 3 survivors |

Two of the three survivors got a test: an earlier record under another alias is never taken as this marketplace's (line 461), and a dead registration whose re-add also fails is not recorded (the `return false` of `bestEffort`). Each test was checked by applying its mutant by hand: only that test went red. The third survivor is equivalent: `"refused"` → `""`, and only `"registered"` and `"build-failed"` are ever compared.

## ⚠️ Heads-up

- Behaviour change for a failed build: a marketplace whose build failed is no longer recorded unless an earlier run recorded it. Recording it only let `clean` remove whatever the host holds under that alias.
- The e2e uses a shell fake binary, so it runs on POSIX only (`it.runIf`), with no new comment line.
- Comment budget unchanged: `src/` 4471, `tests/` 2987.

## 🔗 Linked issue

Fixes #833

## ✅ I certify

- [ ] **I DO CERTIFY I READ EACH LINE OF THE PULL REQUEST BECAUSE I AM A SOFTWARE ENGINEER, NOT A AI PUPPY.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011x4ms5qcGuZgYhCxfdHMUb
