### PR TITLE
test(cli): count a mutant as killed only when a test failed

### DIFF
--- a/cli/scripts/run-mutation.mjs
+++ b/cli/scripts/run-mutation.mjs
@@ -56,9 +56,7 @@ export function pruneIncremental(report) {
   for (const [name, file] of Object.entries(report.files ?? {})) {
     files[name] = {
       ...file,
-      mutants: file.mutants.filter(
-        (mutant) => !mutant.static && (mutant.status === "Killed" || mutant.status === "Timeout")
-      ),
+      mutants: file.mutants.filter((mutant) => !mutant.static && mutant.status === "Killed"),
     };
   }
   return { ...report, files };

--- a/cli/stryker.conf.json
+++ b/cli/stryker.conf.json
@@ -5,6 +5,7 @@
   "plugins": ["@stryker-mutator/vitest-runner"],
   "ignorePatterns": ["reports"],
   "coverageAnalysis": "perTest",
+  "timeoutMS": 20000,
   "thresholds": {
     "high": 80,
     "low": 60,

--- a/cli/tests/architecture/mutation-covers-source.arch.test.ts
+++ b/cli/tests/architecture/mutation-covers-source.arch.test.ts
@@ -220,7 +220,7 @@ describe("the guard itself", () => {
         },
       },
     });
-    expect(pruned.files?.["a.ts"]?.mutants).toEqual([{ status: "Killed" }, { status: "Timeout" }]);
+    expect(pruned.files?.["a.ts"]?.mutants).toEqual([{ status: "Killed" }]);
   });
 
   it("fails a score under the floor and passes one on it", () => {

--- a/cli/tests/contexts/tools/domain/profiles/claude.unit.test.ts
+++ b/cli/tests/contexts/tools/domain/profiles/claude.unit.test.ts
@@ -3,9 +3,24 @@ import { describe, expect, it } from "vitest";
 import { claude } from "../../../../../src/contexts/tools/domain/profiles/claude/profile.js";
 
 describe("claude", () => {
+  it("has .claude/ directory", () => {
+    expect(claude.directory).toBe(".claude/");
+  });
+
+  it("writes agents as markdown", () => {
+    expect(claude.capabilities.agents.params.format).toBe("markdown");
+  });
+
   describe("capabilities.mcp", () => {
     it("outputs to .mcp.json", () => {
       expect(claude.capabilities.mcp.params.outputPath).toBe(".mcp.json");
+    });
+
+    it("writes its servers as JSON under `mcpServers`", () => {
+      expect(claude.capabilities.mcp.params).toMatchObject({
+        format: "json",
+        entrySection: "mcpServers",
+      });
     });
 
     it("consumes the mcp config name", () => {

--- a/cli/tests/contexts/tools/domain/profiles/copilot.unit.test.ts
+++ b/cli/tests/contexts/tools/domain/profiles/copilot.unit.test.ts
@@ -1,6 +1,8 @@
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { CONFIG_MCP } from "../../../../../src/contexts/tools/domain/capabilities/config-refs.js";
 import { copilot } from "../../../../../src/contexts/tools/domain/profiles/copilot/profile.js";
+import { nativeActivationOf } from "../../../../../src/contexts/tools/domain/registry.js";
 
 describe("copilot", () => {
   describe("capabilities.rules.convertFrontmatter()", () => {
@@ -487,6 +489,43 @@ describe("a reference to another framework file, installed for Copilot", () => {
       expect(activation?.userSettingsPath?.("/home/tester", () => undefined)).toBe(
         join("/home/tester", ".copilot", "settings.json")
       );
+    });
+  });
+});
+
+describe("copilot declarations the rest of the CLI reads", () => {
+  it("probes a plugin manifest in the three places Copilot reads one, in its order", () => {
+    expect(copilot.distributionProbes?.manifest).toStrictEqual([
+      ".plugin/plugin.json",
+      ".github/plugin/plugin.json",
+      "plugin.json",
+    ]);
+  });
+
+  it("writes agents as markdown", () => {
+    expect(copilot.capabilities.agents.params.format).toBe("markdown");
+  });
+
+  it("writes its MCP servers as JSON under `servers`", () => {
+    expect(copilot.capabilities.mcp.params).toMatchObject({
+      format: "json",
+      entrySection: "servers",
+    });
+    expect(copilot.capabilities.mcp.consumes).toStrictEqual([CONFIG_MCP]);
+  });
+
+  it("translates plugins for its own marketplace", () => {
+    expect(copilot.capabilities.plugins.translationMode).toBe("marketplace");
+  });
+
+  it("drives its own CLI with the verbs it answers to", () => {
+    expect(nativeActivationOf("copilot")).toMatchObject({
+      binary: "copilot",
+      upgradeVerb: "update",
+      enableVerb: "install",
+      disableVerb: "uninstall",
+      sourceCheckVerb: "update",
+      forceRemoveArgs: ["--force"],
     });
   });
 });

--- a/cli/tests/contexts/tools/domain/profiles/cursor.unit.test.ts
+++ b/cli/tests/contexts/tools/domain/profiles/cursor.unit.test.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { CONFIG_MCP } from "../../../../../src/contexts/tools/domain/capabilities/config-refs.js";
 import { cursor } from "../../../../../src/contexts/tools/domain/profiles/cursor/profile.js";
 
 describe("cursor", () => {
@@ -168,5 +169,30 @@ describe("cursor", () => {
       const result = cursor.capabilities.plugins.resolvePluginsBaseDir("/proj", "/home/user");
       expect(result).toBe(join("/home/user", ".cursor", "plugins", "local"));
     });
+  });
+});
+
+describe("cursor declarations the rest of the CLI reads", () => {
+  it("has .cursor/ directory", () => {
+    expect(cursor.directory).toBe(".cursor/");
+  });
+
+  it("probes a marketplace catalog at .cursor-plugin/marketplace.json", () => {
+    expect(cursor.distributionProbes?.marketplace).toStrictEqual([
+      ".cursor-plugin/marketplace.json",
+    ]);
+  });
+
+  it("writes agents as markdown", () => {
+    expect(cursor.capabilities.agents.params.format).toBe("markdown");
+  });
+
+  it("writes its MCP servers as JSON under `mcpServers`, in .cursor/mcp.json", () => {
+    expect(cursor.capabilities.mcp.params).toMatchObject({
+      outputPath: ".cursor/mcp.json",
+      format: "json",
+      entrySection: "mcpServers",
+    });
+    expect(cursor.capabilities.mcp.consumes).toStrictEqual([CONFIG_MCP]);
   });
 });


### PR DESCRIPTION
## 🎯 What & why

Mutation gates scored a slow test run as a killed mutant (#837). Stryker counts a `Timeout` as detected. `cli/stryker.conf.json` set no `timeoutMS`, so Stryker's default limit applied, and a run that was merely slow crossed it. The mutants concerned were static ones: a string or object literal in a tool profile, which cannot loop. How many timed out depended on how busy the machine was: 47 for tools-claude on a loaded run on Sep 9, 8 on a quiet one, 7 in CI. A gate's verdict depended on load, not on the tests.

## 🛠️ How it works

- **`timeoutMS: 20000`** in `stryker.conf.json`. A test run no longer crosses the limit by being slow; a mutant that really loops still does. Gouvernail measured the same thing: 110 of its 111 timeouts at 5 s were false (`ffb6db86`).
- **`pruneIncremental` carries only kills forward.** It used to carry a `Timeout` forward like a kill, so an incremental run, which is what CI does, would never have re-tested one under the new limit. Its own doc comment already said "only a kill is carried forward"; the code now does what it says.
- **Tests for the declarations the timeouts were hiding.** Each profile test now asserts:
  - claude: its directory, its agent format, and its MCP file's format and entry section;
  - copilot: its manifest probes, its agent format, its MCP format, entry section and consumed config, its translation mode, and the verbs of its own CLI;
  - cursor: its directory, its marketplace probe, its agent format, and its MCP file path, format, entry section and consumed config.

## 🧪 How to verify

Same scope, full run (`--force`), throwaway `HOME`, nothing else running on the machine:

| Scope | Floor | Before: timeouts, score | `timeoutMS` 20000 only | With the new tests |
| --- | --- | --- | --- | --- |
| tools-claude | 92 | 8, 93.8 | 0, 92.7 | 0, **93.8** |
| tools-cursor | 94 | 7, 96.4 | 0, 93.3 (red) | 0, **96.4** |
| tools-copilot | 93 | 17, 95.5 | 0, 92.7 (red) | 0, **95.5** |

With the higher limit alone, 7 of cursor's timeouts and 12 of copilot's turned out to be survivors. That put both scopes below their floor, which is the state the gate had been hiding. The new tests kill those survivors with real test failures.

- Red first: `mutation-covers-source.arch.test.ts` "carries only a kill forward…" now expects `[{ status: "Killed" }]`, and failed on the old filter with `expected [ { status: 'Killed' }, …(1) ] to deeply equal [ { status: 'Killed' } ]`.
- Every new profile assertion kills a mutant that survived the 20 s run. Checked directly: cursor's `entrySection: "mcpServers"` → `""` went from survived to killed by the new cursor test.

Local gates: typecheck, lint, knip and type honesty pass; architecture 128 passed; unit + integration 5801 passed.

## ⚠️ Heads-up

- **Stryker's vitest runner has a blind spot, and it goes the safe way.** A static mutant that makes a module throw on import, such as `DIRECTORY` → `""` or `new SkillsCapability({})`, is reported as *survived*. The runner keeps only the tests it collected, and a test file that fails to import collects none. The same mutant applied by hand fails `cursor.unit.test.ts` outright, with `SkillsCapability requires either prefix or directory`. Five such survivors remain across the three scopes. They lower a score and never inflate one, so they are left in and named here.
- `stryker.conf.json` is a harness file, so CI runs every mutation scope on this PR. Static mutants always re-run, and timeouts are no longer carried forward, so CI measures every scope under the new limit.
- Comment budget unchanged: `src/` 4471, `tests/` 2987.

## 🔗 Linked issue

Fixes #837

## ✅ I certify

- [ ] **I DO CERTIFY I READ EACH LINE OF THE PULL REQUEST BECAUSE I AM A SOFTWARE ENGINEER, NOT A AI PUPPY.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011x4ms5qcGuZgYhCxfdHMUb
