### PR TITLE
docs(vcs): merging a stacked pull request without closing it

### DIFF
--- a/aidd_docs/memory/vcs.md
+++ b/aidd_docs/memory/vcs.md
@@ -32,6 +32,11 @@ The version-control conventions this project follows: branches, commits, and the
 - The board does not advance on its own; it is moved by hand, by a human or an agent through `gh`. Board conventions are in `backlog.md`.
 - Automation owns `promote/*` and `back-merge/*`, which follow neither the format nor the table.
 
+## Pull requests
+
+- A pull request stacked on another targets that branch, not `next`. Before merging the base, retarget the dependent one: `gh pr edit <n> --base next`. GitHub closes a pull request whose base branch is deleted, unless the deletion is the merge's own, so never delete a branch another open pull request targets.
+- A squash merge of the base leaves the dependent branch carrying the base's original commits, and it conflicts with `next`. Replay only its own commits: `git rebase --onto origin/next <base's last commit>`, then push with `--force-with-lease`.
+
 ## Commits
 
 - Convention: [Conventional Commits](https://www.conventionalcommits.org/), enforced by `commitlint.config.cjs`. **Read that file before composing a message; if this page and the config disagree, the config wins.**


### PR DESCRIPTION
## 🎯 What & why

Merging a stack of pull requests closed one by accident (#843). After #818 merged, its branch was deleted through the API. #819 targeted that branch, and GitHub closed it instead of retargeting it: GitHub only retargets when the merge itself deletes the branch. Recovering took recreating the branch at its old SHA, reopening and retargeting #819, then rebasing it, because #818 had been squashed.

## 🛠️ How it works

A new "Pull requests" section in `aidd_docs/memory/vcs.md`:

- retarget a dependent pull request to `next` before merging its base, and never delete a branch another open pull request targets;
- after a squash merge of the base, replay only the dependent branch's own commits with `git rebase --onto origin/next <base's last commit>`, then push with `--force-with-lease`.

## 🧪 How to verify

- Read the section in `aidd_docs/memory/vcs.md`.
- `pre-commit` runs `check-doc-duplication.js`, so no other page restates the rule.

## ⚠️ Heads-up

- Documentation only.

## 🔗 Linked issue

Fixes #843

## ✅ I certify

- [ ] **I DO CERTIFY I READ EACH LINE OF THE PULL REQUEST BECAUSE I AM A SOFTWARE ENGINEER, NOT A AI PUPPY.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011x4ms5qcGuZgYhCxfdHMUb
