### PR TITLE
test(cli): two projects on one HOME installing the same cursor plugin

### DIFF
--- a/cli/tests/e2e/two-projects-one-home-cursor.e2e.test.ts
+++ b/cli/tests/e2e/two-projects-one-home-cursor.e2e.test.ts
@@ -1,0 +1,61 @@
+import { existsSync } from "node:fs";
+import { mkdir, readdir, readFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { createTestEnv, runCli } from "./helpers.js";
+
+const FRAMEWORK_REAL_PATH = resolve(process.cwd(), "tests/fixtures/framework-real");
+const PLUGIN = "aidd-context";
+
+describe("E2E: two projects on one HOME install the same cursor plugin", () => {
+  it("gives each project its hooks, and lets the second remove and clean without taking the first's", async () => {
+    const test = await createTestEnv("two-projects-one-home");
+    try {
+      const second = join(test.tempDir, "second");
+      await mkdir(second, { recursive: true });
+      const userDir = join(test.fakeHome, ".cursor", "plugins", "local", PLUGIN);
+      const setup = (cwd: string) =>
+        runCli(
+          [
+            "setup",
+            "--source",
+            "local",
+            "--path",
+            FRAMEWORK_REAL_PATH,
+            "--ai",
+            "cursor",
+            "--plugins",
+            PLUGIN,
+            "--yes",
+          ],
+          cwd,
+          test.fakeHome
+        );
+      const hooksOf = (cwd: string) => readFile(join(cwd, ".cursor", "hooks.json"), "utf-8");
+
+      expect((await setup(test.projectDir)).exitCode).toBe(0);
+      expect(await hooksOf(test.projectDir)).toContain("update_memory");
+      const firstInstall = await readdir(userDir, { recursive: true });
+      expect(firstInstall.length).toBeGreaterThan(0);
+
+      const secondSetup = await setup(second);
+      expect(secondSetup.exitCode).toBe(0);
+      expect(secondSetup.stdout + secondSetup.stderr).toContain("was already there");
+      expect(await hooksOf(second)).toContain("update_memory");
+
+      const remove = await runCli(
+        ["plugin", "remove", PLUGIN, "--tool", "cursor"],
+        second,
+        test.fakeHome
+      );
+      expect(remove.exitCode).toBe(0);
+      expect((await runCli(["clean", "--force"], second, test.fakeHome)).exitCode).toBe(0);
+      expect(await readdir(userDir, { recursive: true })).toEqual(firstInstall);
+
+      expect((await runCli(["clean", "--force"], test.projectDir, test.fakeHome)).exitCode).toBe(0);
+      expect(existsSync(userDir)).toBe(false);
+    } finally {
+      await test.cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## 🎯 What & why

A user-scope tool (Cursor) installs a plugin into `~/.cursor/plugins/local/<plugin>`, shared by every project on the machine. No e2e ran two projects against one HOME. The first version of #829's cursor fix passed every unit, integration and e2e test, and only `smoke-tools.sh`, which does share a HOME, caught it (#839).

## 🛠️ How it works

`tests/e2e/two-projects-one-home-cursor.e2e.test.ts`: two projects, one fake HOME, both running `setup --ai cursor --plugins aidd-context`. That plugin ships a `SessionStart` hook. The test asserts:

- the first project gets `.cursor/hooks.json` with the plugin's hook, and the user-scope directory is populated;
- the second project also gets its hooks, and is told the directory "was already there";
- in the second project, `plugin remove aidd-context --tool cursor` exits 0, and `clean --force` exits 0;
- the user-scope directory is unchanged after both, file for file;
- the first project's `clean --force` then removes it. This pins today's behaviour for the directory's owner.

## 🧪 How to verify

- Green on `next`.
- Red on the first version of the #829 cursor fix, restored by hand for the check (the whole install skipped with `continue`): `ENOENT … second/.cursor/hooks.json`, at the second project's hooks assertion.

Local results:

| Check | Result |
| --- | --- |
| typecheck, lint, knip, type honesty | pass |
| architecture | 128 passed |
| e2e | 300 passed, 53 files (one more than `next`) |
| comment lines | `src/` 4471, `tests/` 2987, unchanged |

## ⚠️ Heads-up

- Test only, no production change.
- The last assertion encodes a known limit, noted on #829: the owning project's `clean` removes a directory another project also uses.

## 🔗 Linked issue

Fixes #839

## ✅ I certify

- [ ] **I DO CERTIFY I READ EACH LINE OF THE PULL REQUEST BECAUSE I AM A SOFTWARE ENGINEER, NOT A AI PUPPY.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011x4ms5qcGuZgYhCxfdHMUb
