### PR TITLE
chore(cli): check a file with Biome the moment an agent writes it

### DIFF
--- a/.claude/hooks/check-written-file.js
+++ b/.claude/hooks/check-written-file.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+// PostToolUse hook — checks a file an agent just wrote under `cli/` with the same Biome check
+// pre-commit runs, so a broken rule comes back in the same turn instead of at the next gate.
+//
+// Docs: https://code.claude.com/docs/en/hooks#posttooluse
+//   stdin : JSON { tool_input: { file_path } }
+//   exit 2: the Biome report on stderr, which Claude Code hands back to the agent
+//   exit 0: silence — a clean file, one outside `cli/`, or no Biome installed to ask
+
+const { spawnSync } = require("node:child_process");
+const { existsSync, lstatSync, readFileSync } = require("node:fs");
+const path = require("node:path");
+
+const CLI = path.resolve(__dirname, "..", "..", "cli");
+const WINDOWS = process.platform === "win32";
+const BIOME = path.join(CLI, "node_modules", ".bin", WINDOWS ? "biome.cmd" : "biome");
+const CHECKED = /\.(ts|mts|cts|js|mjs|cjs|json|jsonc)$/;
+
+function writtenFile() {
+  try {
+    return JSON.parse(readFileSync(0, "utf8")).tool_input?.file_path ?? "";
+  } catch {
+    return "";
+  }
+}
+
+function main() {
+  const file = writtenFile();
+  if (file === "" || !CHECKED.test(file) || !existsSync(file) || lstatSync(file).isSymbolicLink()) {
+    return 0;
+  }
+  const relative = path.relative(CLI, path.resolve(file));
+  if (relative.startsWith("..") || path.isAbsolute(relative)) return 0;
+  if (relative.split(path.sep).includes("node_modules") || !existsSync(BIOME)) return 0;
+  const result = spawnSync(BIOME, ["check", "--write", "--no-errors-on-unmatched", "--diagnostic-level=error", relative], {
+    cwd: CLI,
+    encoding: "utf8",
+    shell: WINDOWS,
+  });
+  if (result.status === 0) return 0;
+  process.stderr.write(`${result.stdout}${result.stderr}`);
+  return 2;
+}
+
+process.exitCode = main();

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,18 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/check-written-file.js\"",
+            "timeout": 60
+          }
+        ]
+      }
     ]
   },
   "enabledPlugins": {

--- a/scripts/__tests__/check-written-file-hook.test.js
+++ b/scripts/__tests__/check-written-file-hook.test.js
@@ -1,0 +1,55 @@
+const assert = require("node:assert/strict");
+const { spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const root = path.resolve(__dirname, "../..");
+const hook = path.join(root, ".claude/hooks/check-written-file.js");
+const biome = path.join(root, "cli/node_modules/.bin", process.platform === "win32" ? "biome.cmd" : "biome");
+const noBiome = !fs.existsSync(biome);
+
+function runHook(payload) {
+  return spawnSync(process.execPath, [hook], { input: payload, encoding: "utf8" });
+}
+
+function probe(name, content) {
+  const file = path.join(root, "cli/src", `.hook-probe-${process.pid}-${name}.ts`);
+  fs.writeFileSync(file, content);
+  return file;
+}
+
+test("hands a broken Biome rule back to the agent, naming it", { skip: noBiome }, () => {
+  const file = probe("broken", "export function one(x: number) {\n  return x == 1;\n}\n");
+  try {
+    const result = runHook(JSON.stringify({ tool_input: { file_path: file } }));
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /noDoubleEquals/);
+  } finally {
+    fs.rmSync(file, { force: true });
+  }
+});
+
+test("formats a file in place and stays silent on what would not block a commit", { skip: noBiome }, () => {
+  const file = probe("clean", "export function echo(value: any) {\n  return   value;\n}\n");
+  try {
+    const result = runHook(JSON.stringify({ tool_input: { file_path: file } }));
+    assert.equal(result.status, 0);
+    assert.equal(result.stdout + result.stderr, "");
+    assert.equal(fs.readFileSync(file, "utf8"), "export function echo(value: any) {\n  return value;\n}\n");
+  } finally {
+    fs.rmSync(file, { force: true });
+  }
+});
+
+test("leaves a file outside cli/ alone", () => {
+  const result = runHook(JSON.stringify({ tool_input: { file_path: path.join(root, "README.md") } }));
+  assert.equal(result.status, 0);
+  assert.equal(result.stdout + result.stderr, "");
+});
+
+test("answers an unreadable payload with silence, never a failure", () => {
+  const result = runHook("not json");
+  assert.equal(result.status, 0);
+  assert.equal(result.stdout + result.stderr, "");
+});


### PR DESCRIPTION
## 🎯 What & why

A Biome error an agent writes surfaces at the next gate (pre-commit, or a manual `pnpm lint`), after other edits have piled on top of it (#841). Gouvernail solved the same problem with a `PostToolUse` hook (PR 66, `check-written-file.sh`).

## 🛠️ How it works

- `.claude/settings.json` adds a `PostToolUse` hook on `Edit|Write|MultiEdit` that runs `node .claude/hooks/check-written-file.js`.
- The hook reads `tool_input.file_path`. For a file under `cli/` that Biome handles (`.ts`, `.mts`, `.cts`, `.js`, `.mjs`, `.cjs`, `.json`, `.jsonc`), it runs `biome check --write --no-errors-on-unmatched --diagnostic-level=error` from `cli/`:
  - it formats the file in place;
  - when a rule the commit gate would refuse is broken, it exits 2 with Biome's report on stderr, which Claude Code hands back to the agent in the same turn.
- It stays silent and exits 0 for:
  - a clean file;
  - a file outside `cli/`, or under `node_modules`;
  - a symlink;
  - a payload it cannot read;
  - a checkout without `cli/node_modules`.
- It reports errors only, like the gate. `noExplicitAny` is a warning in this config, so reporting it would push the agent toward something the gate never asks for.

## 🧪 How to verify

`scripts/__tests__/check-written-file-hook.test.js`:

| Test | Result |
| --- | --- |
| a file with `x == 1` → exit 2, stderr names `noDoubleEquals` | pass |
| a file with bad spacing and an `any` → reformatted, exit 0, silent | pass |
| a file outside `cli/` → exit 0, silent | pass |
| a payload that is not JSON → exit 0, silent | pass |

Red first: all four failed before the hook existed. The first version of the "broken rule" test used `noExplicitAny` and stayed red against the hook, because that rule is only a warning here. The test now uses a rule this configuration raises as an error, and whose fix `--write` does not apply.

The two Biome cases skip when `cli/node_modules` is absent, as they would on a checkout without dependencies. Probe files are removed in `finally`.

## ⚠️ Heads-up

- Project-level settings, so every Claude Code session in this repository gets the hook once this merges.
- Formatting in place changes the file right after the agent wrote it, as the pre-commit formatter would at commit time.

## 🔗 Linked issue

Fixes #841

## ✅ I certify

- [ ] **I DO CERTIFY I READ EACH LINE OF THE PULL REQUEST BECAUSE I AM A SOFTWARE ENGINEER, NOT A AI PUPPY.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011x4ms5qcGuZgYhCxfdHMUb
