### PR TITLE
chore(cli): skip the pre-push suite on a tree that already passed it

### DIFF
--- a/aidd_docs/memory/coding-assertions.md
+++ b/aidd_docs/memory/coding-assertions.md
@@ -43,6 +43,8 @@ Every `cli` job is globbed on `cli/**`. A change under `kanban/` alone fires no 
 | ----- | ------- | ------ |
 | 1 | `pnpm exec lefthook run pre-push` | `cli knip`, then the full `cli` suite, when `cli/` changed |
 
+Each runs through `scripts/gate-witness.js`, which skips a gate this exact tree already passed: same index, same unstaged edits, same untracked files. A tree that changed while the gate ran is never stamped.
+
 `--no-verify` buys nothing: `validate.yml` re-runs the whole pre-commit over the whole tree on every push and pull request.
 
 ## Behavior

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -175,10 +175,10 @@ pre-push:
   commands:
     cli-knip:
       glob: "cli/**"
-      run: cd cli && pnpm knip
+      run: node scripts/gate-witness.js cli-knip -- pnpm --dir cli knip
     cli-test:
       glob: "cli/**"
-      run: cd cli && pnpm test
+      run: node scripts/gate-witness.js cli-test -- pnpm --dir cli test
 
 commit-msg:
   commands:

--- a/scripts/__tests__/gate-witness.test.js
+++ b/scripts/__tests__/gate-witness.test.js
@@ -1,0 +1,90 @@
+const assert = require("node:assert/strict");
+const { execFileSync, spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const WITNESS = path.resolve(__dirname, "../gate-witness.js");
+const CLEAN_ENV = Object.fromEntries(Object.entries(process.env).filter(([k]) => !k.startsWith("GIT_")));
+
+function repo() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "gate-witness-"));
+  const git = (...args) => execFileSync("git", args, { cwd: dir, env: CLEAN_ENV, stdio: "pipe" });
+  git("init", "-q");
+  git("config", "user.email", "test@example.com");
+  git("config", "user.name", "Test");
+  fs.writeFileSync(path.join(dir, "a.txt"), "a\n");
+  fs.writeFileSync(path.join(dir, "b.txt"), "b\n");
+  git("add", "-A");
+  git("commit", "-q", "-m", "init");
+  const runs = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "gate-witness-runs-")), "count");
+  fs.writeFileSync(runs, "");
+  return { dir, git, runs };
+}
+
+function gate(r, script, name = "suite") {
+  return spawnSync(process.execPath, [WITNESS, name, "--", process.execPath, "-e", script, r.runs], {
+    cwd: r.dir,
+    env: CLEAN_ENV,
+    encoding: "utf8",
+  });
+}
+
+const COUNT = "require('fs').appendFileSync(process.argv[1], 'x')";
+const runsOf = (r) => fs.readFileSync(r.runs, "utf8").length;
+
+test("skips a gate on a tree that already passed it, and says so", () => {
+  const r = repo();
+  assert.equal(gate(r, COUNT).status, 0);
+  const second = gate(r, COUNT);
+  assert.equal(second.status, 0);
+  assert.equal(runsOf(r), 1);
+  assert.match(second.stdout + second.stderr, /already passed/);
+});
+
+test("runs again after a tracked file changes, staged or not", () => {
+  const r = repo();
+  gate(r, COUNT);
+  fs.writeFileSync(path.join(r.dir, "a.txt"), "a changed\n");
+  gate(r, COUNT);
+  r.git("add", "a.txt");
+  fs.writeFileSync(path.join(r.dir, "a.txt"), "a changed\n");
+  gate(r, COUNT);
+  assert.equal(runsOf(r), 3);
+});
+
+test("runs again after a file is added, left untracked, or removed", () => {
+  const r = repo();
+  gate(r, COUNT);
+  fs.writeFileSync(path.join(r.dir, "new.txt"), "new\n");
+  gate(r, COUNT);
+  r.git("add", "new.txt");
+  gate(r, COUNT);
+  r.git("rm", "-q", "b.txt");
+  gate(r, COUNT);
+  assert.equal(runsOf(r), 4);
+});
+
+test("stamps nothing when the tree changed while the gate ran, even once it changes back", () => {
+  const r = repo();
+  const editsOnItsFirstRun = `${COUNT}; if (require('fs').readFileSync(process.argv[1], 'utf8') === 'x') require('fs').writeFileSync('a.txt', 'edited during the run')`;
+  assert.equal(gate(r, editsOnItsFirstRun).status, 0);
+  fs.writeFileSync(path.join(r.dir, "a.txt"), "a\n");
+  gate(r, editsOnItsFirstRun);
+  assert.equal(runsOf(r), 2);
+});
+
+test("passes a failure through and stamps nothing", () => {
+  const r = repo();
+  assert.equal(gate(r, `${COUNT}; process.exit(3)`).status, 3);
+  gate(r, COUNT);
+  assert.equal(runsOf(r), 2);
+});
+
+test("keeps one stamp per gate, so another gate still runs", () => {
+  const r = repo();
+  gate(r, COUNT, "knip");
+  gate(r, COUNT, "suite");
+  assert.equal(runsOf(r), 2);
+});

--- a/scripts/__tests__/gate-witness.test.js
+++ b/scripts/__tests__/gate-witness.test.js
@@ -1,5 +1,6 @@
 const assert = require("node:assert/strict");
 const { execFileSync, spawnSync } = require("node:child_process");
+const { createHash } = require("node:crypto");
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
@@ -23,15 +24,19 @@ function repo() {
   return { dir, git, runs };
 }
 
-function gate(r, script, name = "suite") {
-  return spawnSync(process.execPath, [WITNESS, name, "--", process.execPath, "-e", script, r.runs], {
-    cwd: r.dir,
-    env: CLEAN_ENV,
-    encoding: "utf8",
-  });
+function witness(r, commandLine, name = "suite") {
+  return spawnSync(process.execPath, [WITNESS, name, "--", commandLine], { cwd: r.dir, env: CLEAN_ENV, encoding: "utf8" });
 }
 
-const COUNT = "require('fs').appendFileSync(process.argv[1], 'x')";
+function commandLine(r, script) {
+  const file = path.join(path.dirname(r.runs), `${createHash("sha256").update(script).digest("hex")}.js`);
+  fs.writeFileSync(file, script);
+  return [process.execPath, file, r.runs].map((part) => `"${part}"`).join(" ");
+}
+
+const gate = (r, script, name) => witness(r, commandLine(r, script), name);
+
+const COUNT = "require('fs').appendFileSync(process.argv[2], 'x')";
 const runsOf = (r) => fs.readFileSync(r.runs, "utf8").length;
 
 test("skips a gate on a tree that already passed it, and says so", () => {
@@ -68,7 +73,7 @@ test("runs again after a file is added, left untracked, or removed", () => {
 
 test("stamps nothing when the tree changed while the gate ran, even once it changes back", () => {
   const r = repo();
-  const editsOnItsFirstRun = `${COUNT}; if (require('fs').readFileSync(process.argv[1], 'utf8') === 'x') require('fs').writeFileSync('a.txt', 'edited during the run')`;
+  const editsOnItsFirstRun = `${COUNT}; if (require('fs').readFileSync(process.argv[2], 'utf8') === 'x') require('fs').writeFileSync('a.txt', 'edited during the run')`;
   assert.equal(gate(r, editsOnItsFirstRun).status, 0);
   fs.writeFileSync(path.join(r.dir, "a.txt"), "a\n");
   gate(r, editsOnItsFirstRun);
@@ -86,5 +91,12 @@ test("keeps one stamp per gate, so another gate still runs", () => {
   const r = repo();
   gate(r, COUNT, "knip");
   gate(r, COUNT, "suite");
+  assert.equal(runsOf(r), 2);
+});
+
+test("runs what follows -- as one shell command line, on every platform", () => {
+  const r = repo();
+  const count = commandLine(r, COUNT);
+  assert.equal(witness(r, `${count} && ${count}`).status, 0);
   assert.equal(runsOf(r), 2);
 });

--- a/scripts/gate-witness.js
+++ b/scripts/gate-witness.js
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+/**
+ * Runs a gate unless this exact tree already passed it. The witness is keyed on everything a
+ * gate reads from the checkout: the index, so `git add` and `git rm` count; unstaged edits to
+ * tracked files; and untracked files git does not ignore. It is taken before the run and saved
+ * only when the run is green and the tree is still the one it was taken on, so an edit made
+ * while the gate ran is never signed off. The command's own exit code passes through.
+ *
+ * Usage:
+ *   node scripts/gate-witness.js <name> -- <command...>
+ */
+const { execFileSync, spawnSync } = require("node:child_process");
+const { createHash } = require("node:crypto");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const USAGE_EXIT = 2;
+
+function git(root, args, input) {
+  return execFileSync("git", args, {
+    cwd: root,
+    input,
+    maxBuffer: 1 << 30,
+    stdio: ["pipe", "pipe", "ignore"],
+  });
+}
+
+function treeKey(root, command) {
+  const hash = createHash("sha256");
+  hash.update(JSON.stringify(command));
+  hash.update(git(root, ["ls-files", "-s", "-z"]));
+  hash.update(git(root, ["diff", "-z", "--no-ext-diff", "--binary"]));
+  const untracked = git(root, ["ls-files", "-o", "--exclude-standard", "-z"])
+    .toString("utf8")
+    .split("\0")
+    .filter(Boolean);
+  if (untracked.length > 0) {
+    hash.update(untracked.join("\0"));
+    hash.update(git(root, ["hash-object", "--stdin-paths"], untracked.join("\n")));
+  }
+  return hash.digest("hex");
+}
+
+function readStamp(file) {
+  try {
+    return fs.readFileSync(file, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+function main() {
+  const [name, separator, ...command] = process.argv.slice(2);
+  if (!/^[\w-]+$/.test(name ?? "") || separator !== "--" || command.length === 0) {
+    console.error("Usage: node scripts/gate-witness.js <name> -- <command...>");
+    return USAGE_EXIT;
+  }
+  const root = git(process.cwd(), ["rev-parse", "--show-toplevel"]).toString("utf8").trim();
+  const gitPath = git(root, ["rev-parse", "--git-path", `aidd-gate-witness/${name}`]);
+  const stamp = path.resolve(root, gitPath.toString("utf8").trim());
+  const before = treeKey(root, command);
+  if (readStamp(stamp) === before) {
+    console.log(`✓ ${name}: skipped, this exact tree already passed it.`);
+    return 0;
+  }
+  const result = spawnSync(command[0], command.slice(1), {
+    stdio: "inherit",
+    shell: process.platform === "win32",
+  });
+  if (result.status !== 0) return result.status ?? 1;
+  if (treeKey(root, command) !== before) {
+    console.log(`${name}: passed, but the tree changed while it ran, so it is not stamped.`);
+    return 0;
+  }
+  fs.mkdirSync(path.dirname(stamp), { recursive: true });
+  fs.writeFileSync(stamp, before);
+  return 0;
+}
+
+process.exitCode = main();

--- a/scripts/gate-witness.js
+++ b/scripts/gate-witness.js
@@ -6,6 +6,10 @@
  * only when the run is green and the tree is still the one it was taken on, so an edit made
  * while the gate ran is never signed off. The command's own exit code passes through.
  *
+ * What follows `--` is one shell command line, run by the platform's shell everywhere: on
+ * Windows only a shell can start `pnpm`, and a shell given separate arguments would re-split
+ * them unquoted, so the caller quotes once and every platform reads the same line.
+ *
  * Usage:
  *   node scripts/gate-witness.js <name> -- <command...>
  */
@@ -63,10 +67,7 @@ function main() {
     console.log(`✓ ${name}: skipped, this exact tree already passed it.`);
     return 0;
   }
-  const result = spawnSync(command[0], command.slice(1), {
-    stdio: "inherit",
-    shell: process.platform === "win32",
-  });
+  const result = spawnSync(command.join(" "), { stdio: "inherit", shell: true });
   if (result.status !== 0) return result.status ?? 1;
   if (treeKey(root, command) !== before) {
     console.log(`${name}: passed, but the tree changed while it ran, so it is not stamped.`);


### PR DESCRIPTION
## 🎯 What & why

The pre-push hook ran `knip` and the whole CLI suite on every push, 40 seconds or more, even when the same tree had passed them moments before (#840). That is the normal case when an agent runs the gates and then pushes, or when a push has to be retried. Gouvernail's "gate witness" (`5fbc9368`, `1fa95495`) solves this.

## 🛠️ How it works

`node scripts/gate-witness.js <name> -- <command...>` runs a gate unless this exact tree already passed it.

- **The witness** is a SHA-256 over:
  - the command;
  - the index (`git ls-files -s`), so `git add` and `git rm` count;
  - unstaged edits to tracked files (`git diff --binary`);
  - every untracked file git does not ignore, path and content.
- **When it is taken:** before the run. It is saved under `.git/aidd-gate-witness/<name>` only when the command exits 0 and the tree hashes the same afterwards. Gouvernail's first version signed off trees it had never checked; taking the key before and re-checking it after is what prevents that.
- **On failure:** the command's exit code passes through and nothing is stamped.
- **The command:** what follows `--` is one shell command line, run by the platform's shell everywhere. The first push passed separate arguments and let only Windows use a shell; cmd.exe re-split them unquoted and the Windows CI job failed every probe.
- **Where it applies:** `lefthook.yml`'s `cli-knip` and `cli-test` pre-push jobs now run through it. `aidd_docs/memory/coding-assertions.md` says so in its "Before push" section.

## 🧪 How to verify

`scripts/__tests__/gate-witness.test.js` runs six probes in a throwaway git repository:

| Probe | Result |
| --- | --- |
| an unchanged tree is skipped the second time, and says so | pass |
| a tracked file edited, unstaged then staged, runs again each time | pass |
| a file added, left untracked, or `git rm`'d runs again each time | pass |
| a tree edited while the gate ran is not stamped, even once it is edited back | pass |
| a failing gate passes its exit code through and stamps nothing | pass |
| one stamp per gate name | pass |

Red first: all six failed before the script existed. Each part of the key was then broken by hand, and exactly the probe named for it went red:

- dropping unstaged edits from the key broke "a tracked file edited";
- dropping untracked files broke "a file added, left untracked, or removed";
- skipping the after-run check broke "edited while the gate ran". The first version of that probe did not catch this mutant: its second run used a different command, and the command is part of the key. The probe now runs the same command twice, editing the tree only on the first run, and restores the file before the second.

Real pre-push on this branch: `lefthook run pre-push` took 38 s the first time (knip, then 6216 tests) and 1 s the second, with `✓ cli-knip: skipped, this exact tree already passed it.` and the same for `cli-test`.

## ⚠️ Heads-up

- The key covers the checkout, not what lives outside it. A `node_modules` changed without a lockfile change would not invalidate a stamp. The lockfile itself is tracked, so a dependency change made through it does.
- CI is unaffected: it has no stamps, and `validate.yml` re-runs the gates regardless.

## 🔗 Linked issue

Fixes #840

## ✅ I certify

- [ ] **I DO CERTIFY I READ EACH LINE OF THE PULL REQUEST BECAUSE I AM A SOFTWARE ENGINEER, NOT A AI PUPPY.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011x4ms5qcGuZgYhCxfdHMUb

