### PR TITLE
chore(cli): count a test file that fails to load as a failed test in a mutation run

### DIFF
--- a/cli/tests/fixtures/unloadable-test-file/broken.fixture-test.ts
+++ b/cli/tests/fixtures/unloadable-test-file/broken.fixture-test.ts
@@ -1,0 +1,4 @@
+import { it } from "vitest";
+import "./throws-on-load.js";
+
+it("is never collected", () => {});

--- a/cli/tests/fixtures/unloadable-test-file/loads.fixture-test.ts
+++ b/cli/tests/fixtures/unloadable-test-file/loads.fixture-test.ts
@@ -1,0 +1,5 @@
+import { expect, it } from "vitest";
+
+it("passes", () => {
+  expect(true).toBe(true);
+});

--- a/cli/tests/fixtures/unloadable-test-file/throws-on-load.ts
+++ b/cli/tests/fixtures/unloadable-test-file/throws-on-load.ts
@@ -1,0 +1,5 @@
+export function refuseToLoad(): never {
+  throw new Error("the module under test failed to load");
+}
+
+refuseToLoad();

--- a/cli/tests/fixtures/unloadable-test-file/vitest.config.ts
+++ b/cli/tests/fixtures/unloadable-test-file/vitest.config.ts
@@ -1,0 +1,27 @@
+import { writeFileSync } from "node:fs";
+import type { RunnerTask, RunnerTestFile } from "vitest";
+import { defineConfig } from "vitest/config";
+import { UnloadableFileAsFailedTest } from "../../helpers/unloadable-file-as-failed-test.js";
+
+function testsOf(task: RunnerTask): RunnerTask[] {
+  return task.type === "suite" ? task.tasks.flatMap(testsOf) : [task];
+}
+
+const collectedAsStrykerDoes = {
+  onFinished(files: RunnerTestFile[]): void {
+    const tests = files.flatMap(testsOf).filter((test) => test.result);
+    const seen = tests.map((test) => ({
+      file: test.file.name,
+      state: test.result?.state,
+      error: test.result?.errors?.[0]?.message,
+    }));
+    writeFileSync(String(process.env.COLLECTED), JSON.stringify(seen));
+  },
+};
+
+export default defineConfig({
+  test: {
+    include: ["*.fixture-test.ts"],
+    reporters: [new UnloadableFileAsFailedTest(), collectedAsStrykerDoes],
+  },
+});

--- a/cli/tests/helpers/unloadable-file-as-failed-test.integration.test.ts
+++ b/cli/tests/helpers/unloadable-file-as-failed-test.integration.test.ts
@@ -1,0 +1,37 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, it } from "vitest";
+
+const FIXTURE = fileURLToPath(new URL("../fixtures/unloadable-test-file/", import.meta.url));
+const VITEST = join(
+  dirname(createRequire(import.meta.url).resolve("vitest/package.json")),
+  "vitest.mjs"
+);
+const OUTSIDE_THIS_RUN = Object.fromEntries(
+  Object.entries(process.env).filter(([key]) => !key.startsWith("VITEST"))
+);
+
+it("a real vitest run hands Stryker's collection one failed test for a file that failed to load", () => {
+  const collected = join(mkdtempSync(join(tmpdir(), "unloadable-test-file-")), "collected.json");
+  spawnSync(
+    process.execPath,
+    [VITEST, "run", "--root", FIXTURE, "--config", join(FIXTURE, "vitest.config.ts")],
+    {
+      env: { ...OUTSIDE_THIS_RUN, COLLECTED: collected },
+      encoding: "utf8",
+    }
+  );
+  const seen: { file: string }[] = JSON.parse(readFileSync(collected, "utf8"));
+  expect(seen.sort((a, b) => a.file.localeCompare(b.file))).toStrictEqual([
+    {
+      file: "broken.fixture-test.ts",
+      state: "fail",
+      error: "the module under test failed to load",
+    },
+    { file: "loads.fixture-test.ts", state: "pass" },
+  ]);
+});

--- a/cli/tests/helpers/unloadable-file-as-failed-test.ts
+++ b/cli/tests/helpers/unloadable-file-as-failed-test.ts
@@ -1,0 +1,23 @@
+import type { RunnerTestCase, RunnerTestFile } from "vitest";
+import type { Reporter } from "vitest/reporters";
+
+export class UnloadableFileAsFailedTest implements Reporter {
+  onFinished(files: RunnerTestFile[]): void {
+    for (const file of files) {
+      if (file.result?.state !== "fail" || file.tasks.length > 0) continue;
+      const loadFailure: Omit<RunnerTestCase, "context"> = {
+        type: "test",
+        id: `${file.id}_load`,
+        name: "the file loads",
+        mode: "run",
+        meta: {},
+        file,
+        suite: file,
+        timeout: 0,
+        annotations: [],
+        result: { state: "fail", errors: file.result.errors ?? [] },
+      };
+      file.tasks.push(loadFailure as RunnerTestCase);
+    }
+  }
+}

--- a/cli/tests/helpers/unloadable-file-as-failed-test.unit.test.ts
+++ b/cli/tests/helpers/unloadable-file-as-failed-test.unit.test.ts
@@ -15,7 +15,7 @@ function testFile(state: "pass" | "fail", tasks: RunnerTestFile["tasks"] = []): 
     mode: "run",
     meta: {},
     type: "suite",
-    filepath: "/cli/tests/cursor.unit.test.ts",
+    filepath: "/repo/cli/tests/contexts/tools/domain/profiles/cursor.unit.test.ts",
     projectName: "unit",
     tasks,
     result: { state, errors: state === "fail" ? [LOAD_ERROR] : [] },

--- a/cli/tests/helpers/unloadable-file-as-failed-test.unit.test.ts
+++ b/cli/tests/helpers/unloadable-file-as-failed-test.unit.test.ts
@@ -1,0 +1,54 @@
+import type { RunnerTestFile } from "vitest";
+import { describe, expect, it } from "vitest";
+import mutation from "../../vitest.mutation.config.js";
+import { UnloadableFileAsFailedTest } from "./unloadable-file-as-failed-test.js";
+
+const LOAD_ERROR = {
+  name: "Error",
+  message: "SkillsCapability requires either prefix or directory",
+};
+
+function testFile(state: "pass" | "fail", tasks: RunnerTestFile["tasks"] = []): RunnerTestFile {
+  const file: RunnerTestFile = {
+    id: "cursor",
+    name: "cursor.unit.test.ts",
+    mode: "run",
+    meta: {},
+    type: "suite",
+    filepath: "/cli/tests/cursor.unit.test.ts",
+    projectName: "unit",
+    tasks,
+    result: { state, errors: state === "fail" ? [LOAD_ERROR] : [] },
+    get file() {
+      return file;
+    },
+  };
+  return file;
+}
+
+describe("a test file that fails to load, in a mutation run", () => {
+  it("counts as one failed test carrying the load error", () => {
+    const unloaded = testFile("fail");
+    new UnloadableFileAsFailedTest().onFinished([unloaded]);
+    expect(unloaded.tasks).toHaveLength(1);
+    expect(unloaded.tasks[0]).toMatchObject({
+      type: "test",
+      mode: "run",
+      file: unloaded,
+      suite: unloaded,
+      result: { state: "fail", errors: [LOAD_ERROR] },
+    });
+  });
+
+  it("leaves a file that loaded as it is, whether its tests passed or failed", () => {
+    const passed = testFile("pass");
+    const failed = testFile("fail", [{ ...testFile("fail"), id: "inner" }]);
+    new UnloadableFileAsFailedTest().onFinished([passed, failed]);
+    expect(passed.tasks).toHaveLength(0);
+    expect(failed.tasks.map((task) => task.id)).toStrictEqual(["inner"]);
+  });
+
+  it("is a reporter of every mutation run", () => {
+    expect(mutation.test?.reporters).toContainEqual(expect.any(UnloadableFileAsFailedTest));
+  });
+});

--- a/cli/vitest.mutation.config.ts
+++ b/cli/vitest.mutation.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "vitest/config";
+import { UnloadableFileAsFailedTest } from "./tests/helpers/unloadable-file-as-failed-test.js";
 import { textLoader } from "./tests/helpers/vitest-text-loader.js";
 
 const TEXT_EXTENSIONS = [".md", ".toml"] as const;
@@ -16,9 +17,16 @@ const TEXT_EXTENSIONS = [".md", ".toml"] as const;
  *
  * A plain `test.exclude` does not do this. The workspace file defines the projects, and
  * it wins over a config passed with `--config`; only another workspace replaces it.
+ *
+ * A test file that fails to load still counts. Stryker's vitest runner reads only the tests it
+ * collected, and a file whose import throws collects none, so a static mutant that stops a
+ * module from loading was reported as survived. `UnloadableFileAsFailedTest` gives such a file
+ * one failed test carrying its load error. Vitest types a test with a context only it can build;
+ * that test has none, and nothing reads one once the run has finished.
  */
 export default defineConfig({
   test: {
+    reporters: ["default", new UnloadableFileAsFailedTest()],
     projects: [
       {
         plugins: [textLoader(TEXT_EXTENSIONS)],


### PR DESCRIPTION
## 🎯 What & why

Stryker reported a static mutant that stops a module from loading as *survived* (#851). Its vitest runner builds each mutant's result from the tests it collected, and a test file whose import throws collects none. So a mutant the suite does catch, since the test file cannot even load, counted against the score and sent a reader after a test gap that does not exist.

## 🛠️ How it works

- `cli/tests/helpers/unloadable-file-as-failed-test.ts`: a vitest reporter. When the run finishes, each test file whose result is `fail` and that holds no task gets one failed test carrying the file's load error. A file that loaded is left as it is, whether its tests passed or failed.
- `cli/vitest.mutation.config.ts` declares it next to the `default` reporter, so only a mutation run sees it; the everyday suite is unchanged. Its docblock says why, including the one cast: vitest types a test with a context only it can build, and nothing reads one once the run has finished.
- Mechanism, read in `@stryker-mutator/vitest-runner` 9.6.1 (same logic in 10.0.0): `vitest-test-runner.js:142-144` keeps `collectTestsFromSuite(file)` only, `vitest-helpers.js:73-85` walks `suite.tasks` only, and `api/run-result-helpers.js:18-32` gives Survived when no test failed.

## 🧪 How to verify

- Unit test first, red for the reason it names against a no-op reporter: `expected [] to have a length of 1`, and the mutation config declaring no such reporter. Green after.
- On a real vitest run, automated: `unloadable-file-as-failed-test.integration.test.ts` runs vitest over `tests/fixtures/unloadable-test-file/` (a test file whose import throws, and one that passes) with the reporter and a second reporter that collects tests the way Stryker's runner does (`vitest-test-runner.js:142-144`). Red with the reporter neutralized: it sees only the passing test. Green: one failed test carrying the load error, plus the passing one.
- Guard mutations by hand: dropping `|| file.tasks.length > 0` or `file.result?.state !== "fail" ||` each fails `leaves a file that loaded as it is`.
- End to end through Stryker itself, measured by hand: `stryker run --mutate src/contexts/tools/domain/profiles/cursor/profile.ts:27-27` (`DIRECTORY` → `""`) under a throwaway HOME.
  - on `next`: `Survived`, with 212 tests completed. The other files loaded, so this is not a zero-test run.
  - on this branch: `Killed`, reason `SkillsCapability requires either prefix or directory`, killed by the load failure of `cursor.unit.test.ts` and of every other file that imports the profile.
- `vitest --project unit --project integration --project architecture`: 452 files, 5933 tests green; scripts suite 453/453; comment ratchet unchanged. Typecheck, lint, knip and type honesty green.
- `vitest.mutation.config.ts` is a harness file, so CI runs every mutation scope on this PR.

## ⚠️ Heads-up

- The suite proves the transform, the wiring, and what a real vitest run hands a Stryker-style collection. It mirrors Stryker's three collection lines rather than importing them: the runner exports only its package root. The last step, Stryker turning that failed test into Killed, is proven by the manual run above and by the mutation scopes CI runs on this PR.
- The reporter reads vitest's task tree, which is internal. Recheck it when moving to vitest 4.
- A test file that fails to load now fails a mutation run's initial run instead of passing silently. That is correct, and it is a new way for that run to go red.
- Scores can only go up: mutants that were false survivors become kills. No floor changes here.
- Upstream, `run()` could turn a failed file with no task into a failed result. No issue exists for it on stryker-js yet.

## 🔗 Linked issue

Closes #851

## ✅ I certify

- [ ] **I DO CERTIFY I READ EACH LINE OF THE PULL REQUEST BECAUSE I AM A SOFTWARE ENGINEER, NOT A AI PUPPY.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011x4ms5qcGuZgYhCxfdHMUb
