### PR TITLE
test(cli): raise the tool-profile mutation floors to the scores they reach

### DIFF
--- a/cli/mutation-scopes.json
+++ b/cli/mutation-scopes.json
@@ -42,7 +42,7 @@
     },
     "tools-claude": {
       "mutate": "src/contexts/tools/domain/profiles/claude/**/*.ts",
-      "break": 92
+      "break": 94
     },
     "tools-codex": {
       "mutate": "src/contexts/tools/domain/profiles/codex/**/*.ts",
@@ -50,11 +50,11 @@
     },
     "tools-copilot": {
       "mutate": "src/contexts/tools/domain/profiles/copilot/**/*.ts",
-      "break": 93
+      "break": 95
     },
     "tools-cursor": {
       "mutate": "src/contexts/tools/domain/profiles/cursor/**/*.ts",
-      "break": 94
+      "break": 97
     },
     "tools-opencode": {
       "mutate": "src/contexts/tools/domain/profiles/opencode/**/*.ts",


### PR DESCRIPTION
## 🎯 What & why

The tool-profile mutation floors sat two or three points under their scores (#853). That margin was there because scores moved with machine load: a slow run timed out and was scored as a kill. Since #837 (`timeoutMS: 20000`) and #851 (a test file that fails to load counts as a failed test), the score is a property of the tests, so the margin only let a loss of detection pass unnoticed.

## 🛠️ How it works

`cli/mutation-scopes.json`, each floor at the integer part of the score #852's CI measured:

| Scope | Score | Floor |
| --- | --- | --- |
| tools-claude | 94.5 | 92 → 94 |
| tools-cursor | 97.3 | 94 → 97 |
| tools-copilot | 95.8 | 93 → 95 |

## 🧪 How to verify

- Locally, `node scripts/run-mutation.mjs tools-cursor --force` under a throwaway HOME scores 97.3. At a floor of 98 the gate fails with `mutation score 97.3 is below the 98 declared in mutation-scopes.json`; at 97 it passes.
- `mutation-scopes.json` is a harness file, so CI runs every mutation scope on this PR against the new floors, tools-claude and tools-copilot included.

## ⚠️ Heads-up

- No slack left on these three scopes: a change that lets one more mutant survive on a profile fails its gate. That is the point, and it means a new profile field arrives with the test that kills its mutants.
- The other scopes keep their floors; only these three were re-measured under both fixes.

## 🔗 Linked issue

Closes #853

## ✅ I certify

- [ ] **I DO CERTIFY I READ EACH LINE OF THE PULL REQUEST BECAUSE I AM A SOFTWARE ENGINEER, NOT A AI PUPPY.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011x4ms5qcGuZgYhCxfdHMUb
