### PR TITLE
test(cli): a canary mutation scope that fails if Stryker stops counting a load failure as a kill

### DIFF
--- a/cli/mutation-scopes.json
+++ b/cli/mutation-scopes.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "The one declaration of what mutation testing covers and the floor each scope must hold. scripts/run-mutation.mjs runs a scope by name and fails below its break; tests/architecture/mutation-covers-source.arch.test.ts checks no source file falls outside both maps, that every scope declares a floor, and that package.json has a script per scope. Globs, never file lists: a list goes stale the day a file is added, and the score does not drop, because the mutants that would have died were never generated. A floor is raised to the measured score after a run, never lowered without the reason here. A scope's mutate is one glob or a list where a leading ! excludes; tools is split one scope per tool profile: a profile is a static declaration whose every mutant reruns each test that loads it, and the five together outlasted every other scope on a two-core runner; vscode's single file stays with the rest.",
+  "$comment": "The one declaration of what mutation testing covers and the floor each scope must hold. scripts/run-mutation.mjs runs a scope by name and fails below its break; tests/architecture/mutation-covers-source.arch.test.ts checks no source file falls outside both maps, that every scope declares a floor, and that package.json has a script per scope. Globs, never file lists: a list goes stale the day a file is added, and the score does not drop, because the mutants that would have died were never generated. A floor is raised to the measured score after a run, never lowered without the reason here. A scope's mutate is one glob or a list where a leading ! excludes; tools is split one scope per tool profile: a profile is a static declaration whose every mutant reruns each test that loads it, and the five together outlasted every other scope on a two-core runner; vscode's single file stays with the rest. canary mutates a fixture, not the product: its one mutant stops a module from loading, which Stryker's vitest runner scores as survived on its own; at 100 the scope fails the day that happens again, so a Stryker or vitest upgrade cannot quietly bypass tests/helpers/unloadable-file-as-failed-test.ts.",
   "scopes": {
     "kernel": {
       "mutate": "src/kernel/**/*.ts",
@@ -59,6 +59,13 @@
     "tools-opencode": {
       "mutate": "src/contexts/tools/domain/profiles/opencode/**/*.ts",
       "break": 94
+    },
+    "canary": {
+      "mutate": [
+        "tests/fixtures/stryker-canary/**/*.ts",
+        "!tests/fixtures/stryker-canary/**/*.test.ts"
+      ],
+      "break": 100
     }
   },
   "excluded": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -73,6 +73,7 @@
     "test:mutation:framework": "node scripts/run-mutation.mjs framework",
     "test:mutation:presentation": "node scripts/run-mutation.mjs presentation",
     "test:mutation:runtime": "node scripts/run-mutation.mjs runtime",
+    "test:mutation:canary": "node scripts/run-mutation.mjs canary",
     "prepare": "lefthook install",
     "knip": "knip"
   },

--- a/cli/tests/architecture/mutation-covers-source.arch.test.ts
+++ b/cli/tests/architecture/mutation-covers-source.arch.test.ts
@@ -3,7 +3,7 @@
  * have died were never generated. `mutation-scopes.json` declares the globs, the floor each
  * scope must hold, and what is left out, so a directory belonging to neither fails by name.
  */
-import { existsSync } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { HARNESS, scopesToRun } from "../../scripts/mutation-scopes-to-run.mjs";
@@ -47,6 +47,12 @@ function isCovered(path: string, { scopes, excluded }: ScopeDeclaration): boolea
   );
 }
 
+function fixtureFiles(): string[] {
+  return readdirSync(join(REPO_ROOT, "cli/tests/fixtures"), { recursive: true, encoding: "utf8" })
+    .filter((entry) => entry.endsWith(".ts"))
+    .map((entry) => `tests/fixtures/${entry.replaceAll("\\", "/")}`);
+}
+
 describe("mutation covers every source file", () => {
   it("no file under src/ falls outside both the scopes and the exclusions", () => {
     const declared = declaration();
@@ -71,7 +77,7 @@ describe("mutation covers every source file", () => {
     }
     for (const [name, { mutate }] of Object.entries(scopes)) {
       expect(
-        files.some((file) => scopeMatches(mutate, file)),
+        [...files, ...fixtureFiles()].some((file) => scopeMatches(mutate, file)),
         `scope "${name}" (${mutate}) matches no file — it would score an empty set`
       ).toBe(true);
     }

--- a/cli/tests/fixtures/stryker-canary/settings.ts
+++ b/cli/tests/fixtures/stryker-canary/settings.ts
@@ -1,0 +1,1 @@
+export const SETTINGS: { directory: string } = JSON.parse('{"directory":".cursor/"}');

--- a/cli/tests/fixtures/stryker-canary/settings.unit.test.ts
+++ b/cli/tests/fixtures/stryker-canary/settings.unit.test.ts
@@ -1,0 +1,6 @@
+import { expect, it } from "vitest";
+import { SETTINGS } from "./settings.js";
+
+it("reads the directory the settings declare", () => {
+  expect(SETTINGS).toStrictEqual({ directory: ".cursor/" });
+});


### PR DESCRIPTION
## 🎯 What & why

Stryker's vitest runner scores a mutant that stops a module from loading as *survived*, in every release up to 10.0.0. Upstream tracks it as stryker-js#6150, where the 10.0.0 repro is now posted. No Stryker option or runner option changes it. #851 fixed it here with a vitest reporter, and the suite proves what a real vitest run hands Stryker's collection. Nothing proved the last step: Stryker itself scoring that mutant Killed (#856). So a Stryker or vitest upgrade that bypassed the reporter would bring the false survivors back silently.

## 🛠️ How it works

- `cli/tests/fixtures/stryker-canary/settings.ts` holds exactly one mutant: a static `StringLiteral` whose replacement makes `JSON.parse` throw on import. Its unit test checks the unmutated value and runs in every ordinary suite.
- `mutation-scopes.json` declares a `canary` scope over it, with a floor of 100 and the reason in `$comment`; `package.json` gets `test:mutation:canary`.
- `mutation-scopes-to-run.mjs` runs it on a change to the harness (`package.json`, the lockfile, the Stryker config), to `tests/helpers/` or to the fixture, and not otherwise.
- `mutation-covers-source.arch.test.ts`: "every scope matches a file" now also looks under `tests/fixtures`, the one place a scope may mutate something that is not product.

## 🧪 How to verify

- Inventory: `stryker run --mutate tests/fixtures/stryker-canary/settings.ts` gives one mutant, `Killed`, `Unexpected end of JSON input`.
- Reporter neutralized: `Survived` with `testsCompleted` 0. Through the gate, `node scripts/run-mutation.mjs canary --force` exits 1 with `mutation score 0.0 is below the 100 declared in mutation-scopes.json`.
- Restored: `Report: reports/mutation/canary/ (score 100.0, floor 100)`.
- Arch red first: with the scope added and the check unchanged, `scope "canary" ... matches no file`. Green after.
- `CHANGED=cli/package.json` and `CHANGED=cli/tests/helpers/unloadable-file-as-failed-test.ts` select `canary`; `CHANGED=cli/src/kernel/paths.ts` gives `["kernel"]`.
- Architecture + fixture test 25 files, 131 tests; typecheck, lint, knip green; scripts suite green.

## ⚠️ Heads-up

- One more mutation job, on harness changes only. The scope's single static mutant only reruns the fixture's own test.
- When stryker-js#6150 is fixed upstream, the canary stays green without the reporter. That is the signal to delete `tests/helpers/unloadable-file-as-failed-test.ts` and keep the canary.

## 🔗 Linked issue

Closes #856

## ✅ I certify

- [ ] **I DO CERTIFY I READ EACH LINE OF THE PULL REQUEST BECAUSE I AM A SOFTWARE ENGINEER, NOT A AI PUPPY.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011x4ms5qcGuZgYhCxfdHMUb
