### PR TITLE
fix(cli): install git hooks from the repository root only

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -74,7 +74,6 @@
     "test:mutation:presentation": "node scripts/run-mutation.mjs presentation",
     "test:mutation:runtime": "node scripts/run-mutation.mjs runtime",
     "test:mutation:canary": "node scripts/run-mutation.mjs canary",
-    "prepare": "lefthook install",
     "knip": "knip"
   },
   "dependencies": {
@@ -96,7 +95,6 @@
     "fast-check": "^4.7.0",
     "jscpd": "^5.0.0",
     "knip": "^6.0.0",
-    "lefthook": "^2.1.10",
     "tsup": "^8.0.0",
     "typescript": "^7.0.2",
     "vitest": "^3.2.6"

--- a/cli/pnpm-lock.yaml
+++ b/cli/pnpm-lock.yaml
@@ -164,9 +164,6 @@ importers:
       knip:
         specifier: ^6.0.0
         version: 6.33.0
-      lefthook:
-        specifier: ^2.1.10
-        version: 2.1.12
       tsup:
         specifier: ^8.0.0
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(typescript@7.0.2)(yaml@2.9.0)
@@ -2061,60 +2058,6 @@ packages:
   knip@6.33.0:
     resolution: {integrity: sha512-gMXWV2bqgJcdZKsaRgl1oH5V2J0VumhJ2ujfP4M6b9ftpca2BNpvlX3Dq++vVtEey7sU67EXCvZGNkQfG2w1RQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-
-  lefthook-darwin-arm64@2.1.12:
-    resolution: {integrity: sha512-GSUjqaCuxAYlPOovbjXEWE3HAIa/xOQkTTmZ937zieQldjPLTaC7+s5FHoxKywn+D9riBlofkDqG7Z4f5zzmPA==}
-    cpu: [arm64]
-    os: [darwin]
-
-  lefthook-darwin-x64@2.1.12:
-    resolution: {integrity: sha512-qAUHSSw/7Afi5wxkoLkxORxSicCeTBXyVLnRgD6YZra6udviozpK3Aok9Z6FIWeKc5FBijRMSNDxGPTREhsjcQ==}
-    cpu: [x64]
-    os: [darwin]
-
-  lefthook-freebsd-arm64@2.1.12:
-    resolution: {integrity: sha512-FHZRfKliFNbyz54zsoGdVe9muq67cNjBTZ6jrPPUjI7xUuyCwSpzA+1OpiwJT00L9pP5ZGONBqnGZKnrpC+7Uw==}
-    cpu: [arm64]
-    os: [freebsd]
-
-  lefthook-freebsd-x64@2.1.12:
-    resolution: {integrity: sha512-HYQZPGy2DDEx7dbuotusJpujY5q9igOLgx36qeeQcNQuvvdGHPj2ZGSIsGKhoJ0dw5Qa4knKJoPAHEZQWdV/og==}
-    cpu: [x64]
-    os: [freebsd]
-
-  lefthook-linux-arm64@2.1.12:
-    resolution: {integrity: sha512-ipjOri2PB/sk4noPrHQuM5fcpNBjmlKo4qMtXyLnxeOxGYHWZzf0Xi0OtrXHQ//tOprcv40ADvhUuSdcGqigLw==}
-    cpu: [arm64]
-    os: [linux]
-
-  lefthook-linux-x64@2.1.12:
-    resolution: {integrity: sha512-DmU6xfvqVoFdW+STyc70YI4Ry8vkHGKHx+IJ1Js/Gacq5dv+fiwNzwle3bi28EkL6P8xY67B/CfQfRj4SRU4tg==}
-    cpu: [x64]
-    os: [linux]
-
-  lefthook-openbsd-arm64@2.1.12:
-    resolution: {integrity: sha512-vb0J7bElLvoaCWQmna3HntsvoNqMsGAhfjjC99ss1OdCteufZKM3RxCVoMBEbD50Itv2c1Ua2AFVToltVFTy1Q==}
-    cpu: [arm64]
-    os: [openbsd]
-
-  lefthook-openbsd-x64@2.1.12:
-    resolution: {integrity: sha512-QOmhDWqPPK4+99scanfEmbJjUR+JYC93qhr/0bp5Dj3LaR3kVFNWc6zOQUsOTPy/LC6PG759Lej/mr/BtjUL2Q==}
-    cpu: [x64]
-    os: [openbsd]
-
-  lefthook-windows-arm64@2.1.12:
-    resolution: {integrity: sha512-eErEyr9AHkRFj6TxpCQeKGd0s6IrtL/VEIZ/ssg8dNfG+ycR4jAW/IAlrJSw6/ZQXb3WtWLaQ6QA5c+TLh7vmg==}
-    cpu: [arm64]
-    os: [win32]
-
-  lefthook-windows-x64@2.1.12:
-    resolution: {integrity: sha512-0h+WmDVdDriTjloD/UbjPq/ZtqaaJlPAdGcVwMCEdAxfbF0FTgDbKX3igui9g2U/qG2y6QpVhtz1jeiRe7ctaw==}
-    cpu: [x64]
-    os: [win32]
-
-  lefthook@2.1.12:
-    resolution: {integrity: sha512-2uOexfsrrRhCiTUWdGyDySxVHHhOFJ8MQejs27dM3hugrQB48/z1ZVlaNoxpZ1SnzQ1GaDIbO5rAvicwyiknYQ==}
     hasBin: true
 
   lilconfig@3.1.3:
@@ -4349,49 +4292,6 @@ snapshots:
       unbash: 4.0.10
       yaml: 2.9.0
       zod: 4.5.4
-
-  lefthook-darwin-arm64@2.1.12:
-    optional: true
-
-  lefthook-darwin-x64@2.1.12:
-    optional: true
-
-  lefthook-freebsd-arm64@2.1.12:
-    optional: true
-
-  lefthook-freebsd-x64@2.1.12:
-    optional: true
-
-  lefthook-linux-arm64@2.1.12:
-    optional: true
-
-  lefthook-linux-x64@2.1.12:
-    optional: true
-
-  lefthook-openbsd-arm64@2.1.12:
-    optional: true
-
-  lefthook-openbsd-x64@2.1.12:
-    optional: true
-
-  lefthook-windows-arm64@2.1.12:
-    optional: true
-
-  lefthook-windows-x64@2.1.12:
-    optional: true
-
-  lefthook@2.1.12:
-    optionalDependencies:
-      lefthook-darwin-arm64: 2.1.12
-      lefthook-darwin-x64: 2.1.12
-      lefthook-freebsd-arm64: 2.1.12
-      lefthook-freebsd-x64: 2.1.12
-      lefthook-linux-arm64: 2.1.12
-      lefthook-linux-x64: 2.1.12
-      lefthook-openbsd-arm64: 2.1.12
-      lefthook-openbsd-x64: 2.1.12
-      lefthook-windows-arm64: 2.1.12
-      lefthook-windows-x64: 2.1.12
 
   lilconfig@3.1.3: {}
 

--- a/cli/tests/architecture/hooks-install-from-the-root.arch.test.ts
+++ b/cli/tests/architecture/hooks-install-from-the-root.arch.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { CLI_ROOT } from "./helpers.js";
+
+describe("git hooks are installed from the repository root only", () => {
+  it("no script of this package calls lefthook: a hook in a worktree runs it with GIT_DIR set, and it takes cli/ for the root", () => {
+    const { scripts } = JSON.parse(readFileSync(join(CLI_ROOT, "package.json"), "utf8")) as {
+      scripts: Record<string, string>;
+    };
+    expect(Object.entries(scripts).filter(([, command]) => /\blefthook\b/.test(command))).toEqual(
+      []
+    );
+  });
+});


### PR DESCRIPTION
## 🎯 What & why

A stray `cli/lefthook.yml` holding lefthook's example config kept appearing untracked in linked worktrees (#860). Worse, whatever wrote it also reinstalled the git hooks that every worktree shares.

## 🛠️ How it works

The chain, reproduced in throwaway repos with lefthook 2.1.12 and pnpm 12.3.4:

1. In a linked worktree, git exports `GIT_DIR` into every hook; the main checkout gets only `GIT_INDEX_FILE`.
2. A pre-commit or pre-push job runs pnpm inside `cli/` (`cd cli && pnpm lint`, `pnpm test:arch`, `pnpm typecheck`, `pnpm --dir cli knip`, `pnpm --dir cli test`). When `cli/node_modules` is missing or stale, pnpm 12 installs first and runs `cli/package.json`'s `"prepare": "lefthook install"`.
3. With `GIT_DIR` set and no `GIT_WORK_TREE`, git takes `cli/` for the work tree root. lefthook finds no config there, writes its example, and installs hooks into the shared hooks directory.

The fix:

- `cli/package.json` drops `prepare` and its `lefthook` devDependency. The root package's `prepare` already installs the hooks, and the `Makefile` does too, from the root. Nothing else in `cli` used lefthook: knip flagged the dependency once the script was gone. The lockfile loses the lefthook entries.
- `cli/tests/architecture/hooks-install-from-the-root.arch.test.ts` asserts that no script of this package calls lefthook. It lives in `architecture` because that project runs in pre-commit on any `cli/**` change, so it catches the exact edit that would bring the bug back.

## 🧪 How to verify

- Red first: the test failed on the old `package.json` (`prepare: lefthook install`); green after.
- In the repro: `cd cli && GIT_DIR=<root>/.git lefthook install` gives `Added config: .../cli/lefthook.yml`. Without `GIT_DIR` there is no file. The pre-commit job `cd cli && pnpm lint` in a linked worktree creates it. With cli's `prepare` removed, it does not.
- Architecture 25 files, 131 tests; typecheck, lint and knip green. This commit and push, made from a linked worktree, left no `cli/lefthook.yml`.

## ⚠️ Heads-up

- Someone who runs `pnpm install` only inside `cli/` no longer gets hooks installed; `scripts/doctor.sh` already warns when they are missing. Installing from the root is the supported path.
- `|| true` would not have helped: the file still appears with it. A `.gitignore` entry would only hide it while the shared hooks keep being reinstalled.
- `cli/package.json` is a harness file, so CI runs every mutation scope.

## 🔗 Linked issue

Closes #860

## ✅ I certify

- [ ] **I DO CERTIFY I READ EACH LINE OF THE PULL REQUEST BECAUSE I AM A SOFTWARE ENGINEER, NOT A AI PUPPY.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011x4ms5qcGuZgYhCxfdHMUb
